### PR TITLE
perf+sec: DROP 9 service_role_full_* redundantes (fecha leak de 280 rows financeiras a anon)

### DIFF
--- a/database/_advisor_snapshots/2026-04-24-multiple-permissive-preflight.md
+++ b/database/_advisor_snapshots/2026-04-24-multiple-permissive-preflight.md
@@ -1,0 +1,280 @@
+# Preflight — perf/03-multiple-permissive-policies
+
+Findings raw: **66**, parse failures: **0**
+Tabelas distintas afetadas: **11**
+
+## Sumario por bucket
+
+| Bucket | Tabelas | Significado |
+|---|---:|---|
+| A — DROP service_role redundante | 9 | service_role tem BYPASSRLS=true; policy USING(auth.role()='service_role') OR USING(true) eh no-op. DROP eh seguro. |
+| B — Roles distintos | 0 | Policies com roles diferentes; pode ser intencional. |
+| C — Read/write split / complexo | 2 | Cmds diferentes; merge nao trivial. Precisa decisao. |
+| **Total** | **11** | |
+
+## Premissa critica (verificada via pg_roles)
+
+```
+rolname            rolbypassrls
+anon               false
+authenticated      false
+authenticator      false
+dashboard_user     false
+postgres           true
+service_role       true   <-- bypassa RLS
+supabase_admin     true
+```
+
+Conclusao: policies do tipo `service_role_full_*` com `USING (auth.role()='service_role')`
+ou `USING (true)` sao redundantes — `service_role` ja bypassa qualquer RLS por default.
+DROP dessas policies NAO altera comportamento de service_role.
+
+Bonus: 2 das policies a dropar (contaazul_*) tem `roles={public}` + `USING (true)`,
+o que vazava SELECT pra TODOS os roles (incluindo `anon`). DROP fortalece seguranca.
+
+## Bucket A — DROP service_role policy redundante
+
+Pattern: DROP POLICY <service_role_*> + manter <usuarios_leem_*> intacta.
+
+**SEM ALTER POLICY** na que fica — ela ja esta correta.
+**COM DROP POLICY** na redundante (bypass RLS torna inutil).
+
+### `crm.crm_segmentacao` (6 findings)
+
+**Atual:**
+```sql
+-- DROP candidate (redundante por BYPASSRLS):
+--   service_role_full_crm_segmentacao                  cmd=ALL    permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  (( SELECT auth.role() AS role) = 'service_role'::text)
+
+-- KEEP (policy real do usuario):
+--   usuarios_leem_crm_segmentacao                      cmd=SELECT permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  ((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))
+```
+
+**SQL proposto:**
+```sql
+DROP POLICY "service_role_full_crm_segmentacao" ON "crm"."crm_segmentacao";
+```
+
+### `crm.nps_falae_diario_legacy_backup` (6 findings)
+
+**Atual:**
+```sql
+-- DROP candidate (redundante por BYPASSRLS):
+--   service_role_full_nps_falae_diario                 cmd=ALL    permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  (( SELECT auth.role() AS role) = 'service_role'::text)
+
+-- KEEP (policy real do usuario):
+--   usuarios_leem_nps_falae_diario                     cmd=SELECT permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  ((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))
+```
+
+**SQL proposto:**
+```sql
+DROP POLICY "service_role_full_nps_falae_diario" ON "crm"."nps_falae_diario_legacy_backup";
+```
+
+### `crm.nps_falae_diario_pesquisa` (6 findings)
+
+**Atual:**
+```sql
+-- DROP candidate (redundante por BYPASSRLS):
+--   service_role_full_nps_falae_diario_pesquisa        cmd=ALL    permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  (( SELECT auth.role() AS role) = 'service_role'::text)
+
+-- KEEP (policy real do usuario):
+--   usuarios_leem_nps_falae_diario_pesquisa            cmd=SELECT permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  ((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))
+```
+
+**SQL proposto:**
+```sql
+DROP POLICY "service_role_full_nps_falae_diario_pesquisa" ON "crm"."nps_falae_diario_pesquisa";
+```
+
+### `financial.cmv_mensal` (6 findings)
+
+**Atual:**
+```sql
+-- DROP candidate (redundante por BYPASSRLS):
+--   service_role_full_cmv_mensal                       cmd=ALL    permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  (( SELECT auth.role() AS role) = 'service_role'::text)
+
+-- KEEP (policy real do usuario):
+--   usuarios_leem_cmv_mensal                           cmd=SELECT permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  ((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))
+```
+
+**SQL proposto:**
+```sql
+DROP POLICY "service_role_full_cmv_mensal" ON "financial"."cmv_mensal";
+```
+
+### `integrations.contaazul_categorias` (6 findings)
+
+**Atual:**
+```sql
+-- DROP candidate (redundante por BYPASSRLS):
+--   service_role_full_access                           cmd=ALL    permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  true
+--     with_check: true
+
+-- KEEP (policy real do usuario):
+--   authenticated_select_bar_access                    cmd=SELECT permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  ((( SELECT auth.role() AS role) = 'authenticated'::text) AND (bar_id IN ( SELECT usuarios_bares.bar_id
+   FROM usuarios_bares
+  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid)))))
+```
+
+**SQL proposto:**
+```sql
+DROP POLICY "service_role_full_access" ON "integrations"."contaazul_categorias";
+```
+
+⚠️ **Nota seguranca**: esta policy tinha `USING (true)` + `roles={public}`,
+permitindo SELECT por TODOS os roles incluindo `anon`. DROP corrige bug de seguranca
+que ja existia. service_role continua acessando via BYPASSRLS.
+
+### `integrations.contaazul_centros_custo` (6 findings)
+
+**Atual:**
+```sql
+-- DROP candidate (redundante por BYPASSRLS):
+--   service_role_full_access                           cmd=ALL    permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  true
+--     with_check: true
+
+-- KEEP (policy real do usuario):
+--   authenticated_select_bar_access                    cmd=SELECT permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  ((( SELECT auth.role() AS role) = 'authenticated'::text) AND (bar_id IN ( SELECT usuarios_bares.bar_id
+   FROM usuarios_bares
+  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid)))))
+```
+
+**SQL proposto:**
+```sql
+DROP POLICY "service_role_full_access" ON "integrations"."contaazul_centros_custo";
+```
+
+⚠️ **Nota seguranca**: esta policy tinha `USING (true)` + `roles={public}`,
+permitindo SELECT por TODOS os roles incluindo `anon`. DROP corrige bug de seguranca
+que ja existia. service_role continua acessando via BYPASSRLS.
+
+### `meta.metas_desempenho_historico` (6 findings)
+
+**Atual:**
+```sql
+-- DROP candidate (redundante por BYPASSRLS):
+--   service_role_full_metas_desempenho_historico       cmd=ALL    permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  (( SELECT auth.role() AS role) = 'service_role'::text)
+
+-- KEEP (policy real do usuario):
+--   usuarios_leem_metas_desempenho_historico           cmd=SELECT permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  ((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))
+```
+
+**SQL proposto:**
+```sql
+DROP POLICY "service_role_full_metas_desempenho_historico" ON "meta"."metas_desempenho_historico";
+```
+
+### `system.sync_contagem_historico` (6 findings)
+
+**Atual:**
+```sql
+-- DROP candidate (redundante por BYPASSRLS):
+--   service_role_full_sync_contagem_historico          cmd=ALL    permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  (( SELECT auth.role() AS role) = 'service_role'::text)
+
+-- KEEP (policy real do usuario):
+--   usuarios_leem_sync_contagem_historico              cmd=SELECT permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  ((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))
+```
+
+**SQL proposto:**
+```sql
+DROP POLICY "service_role_full_sync_contagem_historico" ON "system"."sync_contagem_historico";
+```
+
+### `system.sync_metadata` (6 findings)
+
+**Atual:**
+```sql
+-- DROP candidate (redundante por BYPASSRLS):
+--   service_role_full_sync_metadata                    cmd=ALL    permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  (( SELECT auth.role() AS role) = 'service_role'::text)
+
+-- KEEP (policy real do usuario):
+--   usuarios_leem_sync_metadata                        cmd=SELECT permissive=PERMISSIVE
+--     roles: {public}
+--     qual:  ((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))
+```
+
+**SQL proposto:**
+```sql
+DROP POLICY "service_role_full_sync_metadata" ON "system"."sync_metadata";
+```
+
+## Bucket C — Read/write split (precisa decisao)
+
+Estas tabelas tem 2 policies PERMISSIVE com cmds diferentes (uma SELECT, outra ALL).
+Overlap so existe em SELECT. NAO da pra simplesmente DROP — perde funcionalidade.
+
+Opcoes possiveis (escolher por tabela):
+1. **Adiar** — manter como esta. Overhead de 2 policies em SELECT eh pequeno.
+2. **Split cmd** — DROP a policy ALL + CREATE 3 novas (INSERT, UPDATE, DELETE).
+   Mantem semantica, satisfaz advisor. Mas viola 'no DROP+CREATE' (cria 3 novas).
+3. **Merge cmd=ALL com USING e WITH CHECK separados** — DROP read + ALTER write
+   pra `USING (read_cond OR write_cond) WITH CHECK (write_cond)`. Funciona em
+   SELECT/INSERT/UPDATE mas DELETE so checa USING (vaza permissao de delete!).
+   ⚠️ Risco de regressao de seguranca em DELETE.
+
+### `operations.config_metas_planejamento`
+
+**Policies envolvidas:**
+```sql
+-- config_metas_read_by_bar                           cmd=SELECT roles={public}
+--   qual: user_has_bar_access(bar_id)
+--
+-- config_metas_write_admin                           cmd=ALL    roles={public}
+--   qual: is_user_admin()
+--   with_check: is_user_admin()
+--
+```
+
+**Recomendacao**: opcao 1 (adiar) por default. Opcao 2 se voce quiser
+eliminar todos os warnings. Opcao 3 NAO recomendada (risco DELETE).
+
+### `ops.job_camada_mapping`
+
+**Policies envolvidas:**
+```sql
+-- job_camada_read_auth                               cmd=SELECT roles={public}
+--   qual: (( SELECT auth.role() AS role) = 'authenticated'::text)
+--
+-- job_camada_write_admin                             cmd=ALL    roles={public}
+--   qual: is_user_admin()
+--   with_check: is_user_admin()
+--
+```
+
+**Recomendacao**: opcao 1 (adiar) por default. Opcao 2 se voce quiser
+eliminar todos os warnings. Opcao 3 NAO recomendada (risco DELETE).

--- a/database/_advisor_snapshots/2026-04-24-perf-after-03.json
+++ b/database/_advisor_snapshots/2026-04-24-perf-after-03.json
@@ -1,0 +1,1771 @@
+[
+  {
+    "name": "unindexed_foreign_keys",
+    "title": "Unindexed foreign keys",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Identifies foreign key constraints without a covering index, which can impact database performance.",
+    "detail": "Table \\`crm.crm_templates\\` has a foreign key \\`crm_templates_bar_id_fkey\\` without a covering index. This can lead to suboptimal query performance.",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys",
+    "metadata": {
+      "name": "crm_templates",
+      "type": "table",
+      "schema": "crm",
+      "fkey_name": "crm_templates_bar_id_fkey",
+      "fkey_columns": [
+        2
+      ]
+    },
+    "cache_key": "unindexed_foreign_keys_crm_crm_templates_crm_templates_bar_id_fkey"
+  },
+  {
+    "name": "unindexed_foreign_keys",
+    "title": "Unindexed foreign keys",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Identifies foreign key constraints without a covering index, which can impact database performance.",
+    "detail": "Table \\`financial.dre_manual\\` has a foreign key \\`dre_manual_bar_id_fkey\\` without a covering index. This can lead to suboptimal query performance.",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys",
+    "metadata": {
+      "name": "dre_manual",
+      "type": "table",
+      "schema": "financial",
+      "fkey_name": "dre_manual_bar_id_fkey",
+      "fkey_columns": [
+        11
+      ]
+    },
+    "cache_key": "unindexed_foreign_keys_financial_dre_manual_dre_manual_bar_id_fkey"
+  },
+  {
+    "name": "unindexed_foreign_keys",
+    "title": "Unindexed foreign keys",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Identifies foreign key constraints without a covering index, which can impact database performance.",
+    "detail": "Table \\`hr.contratos_funcionario\\` has a foreign key \\`contratos_funcionario_funcionario_id_fkey\\` without a covering index. This can lead to suboptimal query performance.",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys",
+    "metadata": {
+      "name": "contratos_funcionario",
+      "type": "table",
+      "schema": "hr",
+      "fkey_name": "contratos_funcionario_funcionario_id_fkey",
+      "fkey_columns": [
+        2
+      ]
+    },
+    "cache_key": "unindexed_foreign_keys_hr_contratos_funcionario_contratos_funcionario_funcionario_id_fkey"
+  },
+  {
+    "name": "unindexed_foreign_keys",
+    "title": "Unindexed foreign keys",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Identifies foreign key constraints without a covering index, which can impact database performance.",
+    "detail": "Table \\`meta.metas_desempenho_historico\\` has a foreign key \\`metas_desempenho_historico_meta_id_fkey\\` without a covering index. This can lead to suboptimal query performance.",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys",
+    "metadata": {
+      "name": "metas_desempenho_historico",
+      "type": "table",
+      "schema": "meta",
+      "fkey_name": "metas_desempenho_historico_meta_id_fkey",
+      "fkey_columns": [
+        2
+      ]
+    },
+    "cache_key": "unindexed_foreign_keys_meta_metas_desempenho_historico_metas_desempenho_historico_meta_id_fkey"
+  },
+  {
+    "name": "unindexed_foreign_keys",
+    "title": "Unindexed foreign keys",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Identifies foreign key constraints without a covering index, which can impact database performance.",
+    "detail": "Table \\`system.dados_bloqueados\\` has a foreign key \\`dados_bloqueados_bar_id_fkey\\` without a covering index. This can lead to suboptimal query performance.",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys",
+    "metadata": {
+      "name": "dados_bloqueados",
+      "type": "table",
+      "schema": "system",
+      "fkey_name": "dados_bloqueados_bar_id_fkey",
+      "fkey_columns": [
+        4
+      ]
+    },
+    "cache_key": "unindexed_foreign_keys_system_dados_bloqueados_dados_bloqueados_bar_id_fkey"
+  },
+  {
+    "name": "unindexed_foreign_keys",
+    "title": "Unindexed foreign keys",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Identifies foreign key constraints without a covering index, which can impact database performance.",
+    "detail": "Table \\`system.sync_contagem_historico\\` has a foreign key \\`sync_contagem_historico_bar_id_fkey\\` without a covering index. This can lead to suboptimal query performance.",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys",
+    "metadata": {
+      "name": "sync_contagem_historico",
+      "type": "table",
+      "schema": "system",
+      "fkey_name": "sync_contagem_historico_bar_id_fkey",
+      "fkey_columns": [
+        2
+      ]
+    },
+    "cache_key": "unindexed_foreign_keys_system_sync_contagem_historico_sync_contagem_historico_bar_id_fkey"
+  },
+  {
+    "name": "no_primary_key",
+    "title": "No Primary Key",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if a table does not have a primary key. Tables without a primary key can be inefficient to interact with at scale.",
+    "detail": "Table \\`public.view_top_produtos_legacy_snapshot\\` does not have a primary key",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0004_no_primary_key",
+    "metadata": {
+      "name": "view_top_produtos_legacy_snapshot",
+      "type": "table",
+      "schema": "public"
+    },
+    "cache_key": "no_primary_key_public_view_top_produtos_legacy_snapshot"
+  },
+  {
+    "name": "no_primary_key",
+    "title": "No Primary Key",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if a table does not have a primary key. Tables without a primary key can be inefficient to interact with at scale.",
+    "detail": "Table \\`meta.desempenho_manual_backup_20260423\\` does not have a primary key",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0004_no_primary_key",
+    "metadata": {
+      "name": "desempenho_manual_backup_20260423",
+      "type": "table",
+      "schema": "meta"
+    },
+    "cache_key": "no_primary_key_meta_desempenho_manual_backup_20260423"
+  },
+  {
+    "name": "no_primary_key",
+    "title": "No Primary Key",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if a table does not have a primary key. Tables without a primary key can be inefficient to interact with at scale.",
+    "detail": "Table \\`meta.desempenho_manual_backup_20260422_v2\\` does not have a primary key",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0004_no_primary_key",
+    "metadata": {
+      "name": "desempenho_manual_backup_20260422_v2",
+      "type": "table",
+      "schema": "meta"
+    },
+    "cache_key": "no_primary_key_meta_desempenho_manual_backup_20260422_v2"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_cancel_prd\\` on table \\`bronze.bronze_contahub_avendas_cancelamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_contahub_avendas_cancelamentos",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_contahub_avendas_cancelamentos_idx_bronze_cancel_prd"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_stockout_raw_prd_venda\\` on table \\`bronze.bronze_contahub_operacional_stockout_raw\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_contahub_operacional_stockout_raw",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_contahub_operacional_stockout_raw_idx_stockout_raw_prd_venda"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_stockout_proc_motivo\\` on table \\`silver.silver_contahub_operacional_stockout_processado\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "silver_contahub_operacional_stockout_processado",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_silver_contahub_operacional_stockout_processado_idx_stockout_proc_motivo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_cmv_manual_bar_periodo\\` on table \\`public.cmv_manual\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "cmv_manual",
+      "type": "table",
+      "schema": "public"
+    },
+    "cache_key": "unused_index_public_cmv_manual_idx_cmv_manual_bar_periodo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bar_local_mapeamento_bar_id\\` on table \\`operations.bar_local_mapeamento\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bar_local_mapeamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_bar_local_mapeamento_idx_bar_local_mapeamento_bar_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bar_local_mapeamento_categoria\\` on table \\`operations.bar_local_mapeamento\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bar_local_mapeamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_bar_local_mapeamento_idx_bar_local_mapeamento_categoria"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_automation_logs_execution_id\\` on table \\`operations.checklist_automation_logs\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_automation_logs",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_automation_logs_idx_checklist_automation_logs_execution_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_provisoes_trabalhistas_funcionario_id_new\\` on table \\`hr.provisoes_trabalhistas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "provisoes_trabalhistas",
+      "type": "table",
+      "schema": "hr"
+    },
+    "cache_key": "unused_index_hr_provisoes_trabalhistas_idx_provisoes_trabalhistas_funcionario_id_new"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_sympla_pedidos_email\\` on table \\`bronze.bronze_sympla_pedidos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_sympla_pedidos",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_sympla_pedidos_idx_bronze_sympla_pedidos_email"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_cliente_visitas_cli_id\\` on table \\`silver.cliente_visitas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "cliente_visitas",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_cliente_visitas_idx_cliente_visitas_cli_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_sympla_pedidos_data\\` on table \\`bronze.bronze_sympla_pedidos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_sympla_pedidos",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_sympla_pedidos_idx_bronze_sympla_pedidos_data"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_sympla_part_order\\` on table \\`bronze.bronze_sympla_participantes\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_sympla_participantes",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_sympla_participantes_idx_bronze_sympla_part_order"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`ix_byfh_data_hora\\` on table \\`bronze.bronze_yuzer_fatporhora\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_yuzer_fatporhora",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_yuzer_fatporhora_ix_byfh_data_hora"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_sistema_alertas_bar_id\\` on table \\`system.sistema_alertas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "sistema_alertas",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_sistema_alertas_idx_sistema_alertas_bar_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_cliente_estatisticas_cli_id\\` on table \\`silver.cliente_estatisticas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "cliente_estatisticas",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_cliente_estatisticas_idx_cliente_estatisticas_cli_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`ix_byslog_executed\\` on table \\`bronze.bronze_yuzer_sync_log\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_yuzer_sync_log",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_yuzer_sync_log_ix_byslog_executed"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_produtos_top_categoria\\` on table \\`silver.produtos_top\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "produtos_top",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_produtos_top_idx_produtos_top_categoria"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_sympla_part_email\\` on table \\`bronze.bronze_sympla_participantes\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_sympla_participantes",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_sympla_participantes_idx_bronze_sympla_part_email"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_eventos_base_cancelamentos\\` on table \\`operations.eventos_base\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "eventos_base",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_eventos_base_idx_eventos_base_cancelamentos"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_eventos_base_conta_assinada\\` on table \\`operations.eventos_base\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "eventos_base",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_eventos_base_idx_eventos_base_conta_assinada"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_insight_events_type\\` on table \\`system.insight_events\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "insight_events",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_insight_events_idx_insight_events_type"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_insight_events_processed\\` on table \\`system.insight_events\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "insight_events",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_insight_events_idx_insight_events_processed"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agent_insights_v2_visualizado\\` on table \\`agent_ai.agent_insights_v2\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agent_insights_v2",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agent_insights_v2_idx_agent_insights_v2_visualizado"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agent_insights_v2_arquivado\\` on table \\`agent_ai.agent_insights_v2\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agent_insights_v2",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agent_insights_v2_idx_agent_insights_v2_arquivado"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_sympla_bilheteria_event_id\\` on table \\`silver.sympla_bilheteria_diaria\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "sympla_bilheteria_diaria",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_sympla_bilheteria_diaria_idx_sympla_bilheteria_event_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agent_insights_v2_tipo\\` on table \\`agent_ai.agent_insights_v2\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agent_insights_v2",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agent_insights_v2_idx_agent_insights_v2_tipo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agent_insights_v2_severidade\\` on table \\`agent_ai.agent_insights_v2\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agent_insights_v2",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agent_insights_v2_idx_agent_insights_v2_severidade"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_sync_metadata_active\\` on table \\`system.sync_metadata\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "sync_metadata",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_sync_metadata_idx_sync_metadata_active"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_google_reviews_date\\` on table \\`bronze.bronze_google_reviews\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_google_reviews",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_google_reviews_idx_bronze_google_reviews_date"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_google_reviews_place\\` on table \\`bronze.bronze_google_reviews\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_google_reviews",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_google_reviews_idx_bronze_google_reviews_place"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_automation_logs_tipo\\` on table \\`operations.checklist_automation_logs\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_automation_logs",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_automation_logs_idx_checklist_automation_logs_tipo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_automation_logs_schedule\\` on table \\`operations.checklist_automation_logs\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_automation_logs",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_automation_logs_idx_checklist_automation_logs_schedule"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_audit_trail_user_operation\\` on table \\`system.audit_trail\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "audit_trail",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_audit_trail_idx_audit_trail_user_operation"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_audit_trail_table_record\\` on table \\`system.audit_trail\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "audit_trail",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_audit_trail_idx_audit_trail_table_record"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contaazul_lancamentos_valor_nao_pago\\` on table \\`integrations.contaazul_lancamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contaazul_lancamentos",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_contaazul_lancamentos_idx_contaazul_lancamentos_valor_nao_pago"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_agendamentos_bar_data\\` on table \\`operations.checklist_agendamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_agendamentos",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_agendamentos_idx_checklist_agendamentos_bar_data"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_agendamentos_status\\` on table \\`operations.checklist_agendamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_agendamentos",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_agendamentos_idx_checklist_agendamentos_status"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_agendamentos_deadline\\` on table \\`operations.checklist_agendamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_agendamentos",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_agendamentos_idx_checklist_agendamentos_deadline"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_agendamentos_responsavel\\` on table \\`operations.checklist_agendamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_agendamentos",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_agendamentos_idx_checklist_agendamentos_responsavel"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_yuzer_produtos_evento_produto\\` on table \\`silver.yuzer_produtos_evento\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "yuzer_produtos_evento",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_yuzer_produtos_evento_idx_yuzer_produtos_evento_produto"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_ca_cat_pai\\` on table \\`bronze.bronze_contaazul_categorias\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_contaazul_categorias",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_contaazul_categorias_idx_bronze_ca_cat_pai"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_ca_log_bar\\` on table \\`bronze.bronze_contaazul_sync_log\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_contaazul_sync_log",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_contaazul_sync_log_idx_bronze_ca_log_bar"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_planejamento_comercial_diario_recalculo\\` on table \\`gold.planejamento\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "planejamento",
+      "type": "table",
+      "schema": "gold"
+    },
+    "cache_key": "unused_index_gold_planejamento_idx_planejamento_comercial_diario_recalculo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_ca_lanc_cat\\` on table \\`bronze.bronze_contaazul_lancamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_contaazul_lancamentos",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_contaazul_lancamentos_idx_bronze_ca_lanc_cat"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_ca_lanc_cc\\` on table \\`bronze.bronze_contaazul_lancamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_contaazul_lancamentos",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_contaazul_lancamentos_idx_bronze_ca_lanc_cc"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contaazul_categorias_tipo\\` on table \\`integrations.contaazul_categorias\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contaazul_categorias",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_contaazul_categorias_idx_contaazul_categorias_tipo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_umbler_conv_telefone\\` on table \\`bronze.bronze_umbler_conversas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_umbler_conversas",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_umbler_conversas_idx_bronze_umbler_conv_telefone"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contaazul_categorias_ativo\\` on table \\`integrations.contaazul_categorias\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contaazul_categorias",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_contaazul_categorias_idx_contaazul_categorias_ativo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_umbler_conv_ult_msg\\` on table \\`bronze.bronze_umbler_conversas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_umbler_conversas",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_umbler_conversas_idx_bronze_umbler_conv_ult_msg"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contaazul_centros_custo_ativo\\` on table \\`integrations.contaazul_centros_custo\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contaazul_centros_custo",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_contaazul_centros_custo_idx_contaazul_centros_custo_ativo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_nps_falae_diario_pesquisa_search\\` on table \\`crm.nps_falae_diario_pesquisa\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "nps_falae_diario_pesquisa",
+      "type": "table",
+      "schema": "crm"
+    },
+    "cache_key": "unused_index_crm_nps_falae_diario_pesquisa_idx_nps_falae_diario_pesquisa_search"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_umbler_campanha_destinatarios_campanha_id_new\\` on table \\`integrations.umbler_campanha_destinatarios\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "umbler_campanha_destinatarios",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_umbler_campanha_destinatarios_idx_umbler_campanha_destinatarios_campanha_id_new"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contratos_funcionario_area_id\\` on table \\`hr.contratos_funcionario\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contratos_funcionario",
+      "type": "table",
+      "schema": "hr"
+    },
+    "cache_key": "unused_index_hr_contratos_funcionario_idx_contratos_funcionario_area_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contratos_funcionario_cargo_id\\` on table \\`hr.contratos_funcionario\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contratos_funcionario",
+      "type": "table",
+      "schema": "hr"
+    },
+    "cache_key": "unused_index_hr_contratos_funcionario_idx_contratos_funcionario_cargo_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_umbler_msg_conversa\\` on table \\`bronze.bronze_umbler_mensagens\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_umbler_mensagens",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_umbler_mensagens_idx_bronze_umbler_msg_conversa"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_umbler_msg_enviada\\` on table \\`bronze.bronze_umbler_mensagens\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_umbler_mensagens",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_umbler_mensagens_idx_bronze_umbler_msg_enviada"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_umbler_msg_telefone\\` on table \\`bronze.bronze_umbler_mensagens\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_umbler_mensagens",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_umbler_mensagens_idx_bronze_umbler_msg_telefone"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contaazul_pessoas_documento\\` on table \\`integrations.contaazul_pessoas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contaazul_pessoas",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_contaazul_pessoas_idx_contaazul_pessoas_documento"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contaazul_pessoas_perfil\\` on table \\`integrations.contaazul_pessoas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contaazul_pessoas",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_contaazul_pessoas_idx_contaazul_pessoas_perfil"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_umbler_destin_campanha\\` on table \\`bronze.bronze_umbler_campanha_destinatarios\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_umbler_campanha_destinatarios",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_umbler_campanha_destinatarios_idx_bronze_umbler_destin_campanha"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_umbler_destin_msg\\` on table \\`bronze.bronze_umbler_campanha_destinatarios\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_umbler_campanha_destinatarios",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_umbler_campanha_destinatarios_idx_bronze_umbler_destin_msg"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_reservantes_perfil_segmento\\` on table \\`silver.reservantes_perfil\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "reservantes_perfil",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_reservantes_perfil_idx_reservantes_perfil_segmento"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_reservantes_perfil_vip\\` on table \\`silver.reservantes_perfil\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "reservantes_perfil",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_reservantes_perfil_idx_reservantes_perfil_vip"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_funcionarios_area_id_new\\` on table \\`hr.funcionarios\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "funcionarios",
+      "type": "table",
+      "schema": "hr"
+    },
+    "cache_key": "unused_index_hr_funcionarios_idx_funcionarios_area_id_new"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_funcionarios_cargo_id_new\\` on table \\`hr.funcionarios\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "funcionarios",
+      "type": "table",
+      "schema": "hr"
+    },
+    "cache_key": "unused_index_hr_funcionarios_idx_funcionarios_cargo_id_new"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_usuarios_bares_bar_id\\` on table \\`public.usuarios_bares\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "usuarios_bares",
+      "type": "table",
+      "schema": "public"
+    },
+    "cache_key": "unused_index_public_usuarios_bares_idx_usuarios_bares_bar_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_config_metas_bar_ano\\` on table \\`operations.config_metas_planejamento\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_config_metas_planejamento_idx_config_metas_bar_ano"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agente_alertas_insight_id\\` on table \\`agent_ai.agente_alertas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agente_alertas",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agente_alertas_idx_agente_alertas_insight_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agente_configuracoes_bar_id\\` on table \\`agent_ai.agente_configuracoes\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agente_configuracoes",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agente_configuracoes_idx_agente_configuracoes_bar_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contahub_pagamentos_cli_fone\\` on table \\`bronze.bronze_contahub_financeiro_pagamentosrecebidos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_contahub_financeiro_pagamentosrecebidos",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_contahub_financeiro_pagamentosrecebidos_idx_contahub_pagamentos_cli_fone"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agente_insights_scan_id\\` on table \\`agent_ai.agente_insights\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agente_insights",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agente_insights_idx_agente_insights_scan_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_notificacoes_bar_id\\` on table \\`system.notificacoes\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "notificacoes",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_notificacoes_idx_notificacoes_bar_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contahub_pagamentos_cli_cpf\\` on table \\`bronze.bronze_contahub_financeiro_pagamentosrecebidos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_contahub_financeiro_pagamentosrecebidos",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_contahub_financeiro_pagamentosrecebidos_idx_contahub_pagamentos_cli_cpf"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bares_config_bar_id\\` on table \\`operations.bares_config\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bares_config",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_bares_config_idx_bares_config_bar_id"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`operations.config_metas_planejamento\\` has multiple permissive policies for role \\`anon\\` for action \\`SELECT\\`. Policies include \\`{config_metas_read_by_bar,config_metas_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "multiple_permissive_policies_operations_config_metas_planejamento_anon_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`ops.job_camada_mapping\\` has multiple permissive policies for role \\`anon\\` for action \\`SELECT\\`. Policies include \\`{job_camada_read_auth,job_camada_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "job_camada_mapping",
+      "type": "table",
+      "schema": "ops"
+    },
+    "cache_key": "multiple_permissive_policies_ops_job_camada_mapping_anon_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`operations.config_metas_planejamento\\` has multiple permissive policies for role \\`authenticated\\` for action \\`SELECT\\`. Policies include \\`{config_metas_read_by_bar,config_metas_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "multiple_permissive_policies_operations_config_metas_planejamento_authenticated_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`ops.job_camada_mapping\\` has multiple permissive policies for role \\`authenticated\\` for action \\`SELECT\\`. Policies include \\`{job_camada_read_auth,job_camada_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "job_camada_mapping",
+      "type": "table",
+      "schema": "ops"
+    },
+    "cache_key": "multiple_permissive_policies_ops_job_camada_mapping_authenticated_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`operations.config_metas_planejamento\\` has multiple permissive policies for role \\`authenticator\\` for action \\`SELECT\\`. Policies include \\`{config_metas_read_by_bar,config_metas_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "multiple_permissive_policies_operations_config_metas_planejamento_authenticator_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`ops.job_camada_mapping\\` has multiple permissive policies for role \\`authenticator\\` for action \\`SELECT\\`. Policies include \\`{job_camada_read_auth,job_camada_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "job_camada_mapping",
+      "type": "table",
+      "schema": "ops"
+    },
+    "cache_key": "multiple_permissive_policies_ops_job_camada_mapping_authenticator_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`operations.config_metas_planejamento\\` has multiple permissive policies for role \\`cli_login_postgres\\` for action \\`SELECT\\`. Policies include \\`{config_metas_read_by_bar,config_metas_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "multiple_permissive_policies_operations_config_metas_planejamento_cli_login_postgres_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`ops.job_camada_mapping\\` has multiple permissive policies for role \\`cli_login_postgres\\` for action \\`SELECT\\`. Policies include \\`{job_camada_read_auth,job_camada_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "job_camada_mapping",
+      "type": "table",
+      "schema": "ops"
+    },
+    "cache_key": "multiple_permissive_policies_ops_job_camada_mapping_cli_login_postgres_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`operations.config_metas_planejamento\\` has multiple permissive policies for role \\`dashboard_user\\` for action \\`SELECT\\`. Policies include \\`{config_metas_read_by_bar,config_metas_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "multiple_permissive_policies_operations_config_metas_planejamento_dashboard_user_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`ops.job_camada_mapping\\` has multiple permissive policies for role \\`dashboard_user\\` for action \\`SELECT\\`. Policies include \\`{job_camada_read_auth,job_camada_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "job_camada_mapping",
+      "type": "table",
+      "schema": "ops"
+    },
+    "cache_key": "multiple_permissive_policies_ops_job_camada_mapping_dashboard_user_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`operations.config_metas_planejamento\\` has multiple permissive policies for role \\`supabase_privileged_role\\` for action \\`SELECT\\`. Policies include \\`{config_metas_read_by_bar,config_metas_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "multiple_permissive_policies_operations_config_metas_planejamento_supabase_privileged_role_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`ops.job_camada_mapping\\` has multiple permissive policies for role \\`supabase_privileged_role\\` for action \\`SELECT\\`. Policies include \\`{job_camada_read_auth,job_camada_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "job_camada_mapping",
+      "type": "table",
+      "schema": "ops"
+    },
+    "cache_key": "multiple_permissive_policies_ops_job_camada_mapping_supabase_privileged_role_SELECT"
+  },
+  {
+    "name": "table_bloat",
+    "title": "Table Bloat",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if a table has excess bloat and may benefit from maintenance operations like vacuum full or cluster.",
+    "detail": "Table `operations`.`eventos_base` has excessive bloat",
+    "remediation": "Consider running vacuum full (WARNING: incurs downtime) and tweaking autovacuum settings to reduce bloat.",
+    "metadata": {
+      "name": "eventos_base",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "table_bloat_operations_eventos_base"
+  },
+  {
+    "name": "auth_db_connections_absolute",
+    "title": "Auth DB Connection Strategy is not Percentage",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Using a percentage based allocation connection strategy for Auth can help to improve the server's performance when increasing instance size.",
+    "detail": "Your project's Auth server is configured to use at most 10 connections. Increasing the instance size without manually adjusting this number will not improve the performance of the Auth server. Switch to a percentage based connection allocation strategy instead.",
+    "cache_key": "auth_db_connections_absolute",
+    "remediation": "https://supabase.com/docs/guides/deployment/going-into-prod",
+    "metadata": {
+      "type": "auth",
+      "entity": "Auth"
+    }
+  }
+]

--- a/database/_advisor_snapshots/2026-04-24-permissive-smoke-after.json
+++ b/database/_advisor_snapshots/2026-04-24-permissive-smoke-after.json
@@ -1,0 +1,17 @@
+{
+  "captured_at": "2026-04-24",
+  "method": "SET LOCAL ROLE + SELECT count(*) per table per role, transaction rolled back",
+  "uuid_authenticated": "9106ba7d-8f55-4a6c-b638-3165ecad6291",
+  "results": [
+    {"table": "crm.crm_segmentacao",                   "authenticated":   0, "service_role":   0, "anon": 0, "diff_vs_before": "all roles unchanged (tabela vazia)"},
+    {"table": "crm.nps_falae_diario_legacy_backup",    "authenticated":  37, "service_role":  37, "anon": 0, "diff_vs_before": "no change"},
+    {"table": "crm.nps_falae_diario_pesquisa",         "authenticated":  29, "service_role":  29, "anon": 0, "diff_vs_before": "no change"},
+    {"table": "financial.cmv_mensal",                  "authenticated":  19, "service_role":  19, "anon": 0, "diff_vs_before": "no change"},
+    {"table": "integrations.contaazul_categorias",     "authenticated": 122, "service_role": 122, "anon": 0, "diff_vs_before": "✅ anon: 122 -> 0 (bug fechado, conforme expectativa)"},
+    {"table": "integrations.contaazul_centros_custo",  "authenticated": 158, "service_role": 158, "anon": 0, "diff_vs_before": "✅ anon: 158 -> 0 (bug fechado, conforme expectativa)"},
+    {"table": "meta.metas_desempenho_historico",       "authenticated":  15, "service_role":  15, "anon": 0, "diff_vs_before": "no change"},
+    {"table": "system.sync_contagem_historico",        "authenticated":  51, "service_role":  51, "anon": 0, "diff_vs_before": "no change"},
+    {"table": "system.sync_metadata",                  "authenticated":   9, "service_role":   9, "anon": 0, "diff_vs_before": "no change"}
+  ],
+  "verdict": "GREEN. Authenticated e service_role identicos antes/depois. Anon bloqueado em todas — leak de 280 rows financeiras (122 + 158) fechado."
+}

--- a/database/_advisor_snapshots/2026-04-24-permissive-smoke-before.json
+++ b/database/_advisor_snapshots/2026-04-24-permissive-smoke-before.json
@@ -1,0 +1,20 @@
+{
+  "captured_at": "2026-04-24",
+  "method": "SET LOCAL ROLE + SELECT count(*) per table per role, transaction rolled back",
+  "uuid_authenticated": "9106ba7d-8f55-4a6c-b638-3165ecad6291",
+  "results": [
+    {"table": "crm.crm_segmentacao",                   "authenticated":   0, "service_role":   0, "anon":   0, "note": "tabela vazia"},
+    {"table": "crm.nps_falae_diario_legacy_backup",    "authenticated":  37, "service_role":  37, "anon":   0, "note": "anon bloqueado conforme intencao"},
+    {"table": "crm.nps_falae_diario_pesquisa",         "authenticated":  29, "service_role":  29, "anon":   0, "note": "anon bloqueado conforme intencao"},
+    {"table": "financial.cmv_mensal",                  "authenticated":  19, "service_role":  19, "anon":   0, "note": "anon bloqueado conforme intencao"},
+    {"table": "integrations.contaazul_categorias",     "authenticated": 122, "service_role": 122, "anon": 122, "note": "⚠️ BUG: anon ve TODAS 122 rows (USING true + roles=public)"},
+    {"table": "integrations.contaazul_centros_custo",  "authenticated": 158, "service_role": 158, "anon": 158, "note": "⚠️ BUG: anon ve TODAS 158 rows (USING true + roles=public)"},
+    {"table": "meta.metas_desempenho_historico",       "authenticated":  15, "service_role":  15, "anon":   0, "note": "anon bloqueado conforme intencao"},
+    {"table": "system.sync_contagem_historico",        "authenticated":  51, "service_role":  51, "anon":   0, "note": "anon bloqueado conforme intencao"},
+    {"table": "system.sync_metadata",                  "authenticated":   9, "service_role":   9, "anon":   0, "note": "anon bloqueado conforme intencao"}
+  ],
+  "expected_after_fix": {
+    "authenticated_and_service_role": "counts identicos a before (politicas usuarios_leem_*/authenticated_select_* mantidas, service_role continua via BYPASSRLS)",
+    "anon": "counts iguais a before EXCETO contaazul_categorias e contaazul_centros_custo que devem cair pra 0 (bug fechado)"
+  }
+}

--- a/database/_advisor_snapshots/2026-04-24-pg-policies-post-fase2.json
+++ b/database/_advisor_snapshots/2026-04-24-pg-policies-post-fase2.json
@@ -1,0 +1,2372 @@
+[
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agent_insights_v2",
+    "policyname": "agent_insights_v2_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": null
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agent_insights_v2",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_alertas",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_aprendizado",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_configuracoes",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_conversas",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_feedbacks",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_historico",
+    "policyname": "Service role acesso total agente_historico",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_ia_metricas",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_insights",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_memoria_vetorial",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_metricas",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_padroes_detectados",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_regras_dinamicas",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_scans",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_uso",
+    "policyname": "Service role acesso total agente_uso",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "agent_ai",
+    "tablename": "agente_uso",
+    "policyname": "authenticated_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "auth_custom",
+    "tablename": "empresa_usuarios",
+    "policyname": "empresa_usuarios_delete",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "(usuario_id = ( SELECT auth.uid() AS uid))",
+    "with_check": null
+  },
+  {
+    "schemaname": "auth_custom",
+    "tablename": "empresa_usuarios",
+    "policyname": "empresa_usuarios_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "(usuario_id = ( SELECT auth.uid() AS uid))"
+  },
+  {
+    "schemaname": "auth_custom",
+    "tablename": "empresa_usuarios",
+    "policyname": "empresa_usuarios_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "(usuario_id = ( SELECT auth.uid() AS uid))",
+    "with_check": null
+  },
+  {
+    "schemaname": "auth_custom",
+    "tablename": "empresa_usuarios",
+    "policyname": "empresa_usuarios_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "(usuario_id = ( SELECT auth.uid() AS uid))",
+    "with_check": "(usuario_id = ( SELECT auth.uid() AS uid))"
+  },
+  {
+    "schemaname": "auth_custom",
+    "tablename": "empresas",
+    "policyname": "empresas_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "((( SELECT auth.role() AS role) = 'service_role'::text) OR (EXISTS ( SELECT 1\n   FROM auth_custom.empresa_usuarios eu\n  WHERE ((eu.empresa_id = empresas.id) AND (eu.usuario_id = ( SELECT auth.uid() AS uid)) AND (eu.ativo = true)))))"
+  },
+  {
+    "schemaname": "auth_custom",
+    "tablename": "empresas",
+    "policyname": "empresas_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "(EXISTS ( SELECT 1\n   FROM auth_custom.empresa_usuarios eu\n  WHERE ((eu.empresa_id = empresas.id) AND (eu.usuario_id = ( SELECT auth.uid() AS uid)) AND (eu.ativo = true))))",
+    "with_check": null
+  },
+  {
+    "schemaname": "auth_custom",
+    "tablename": "empresas",
+    "policyname": "empresas_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "(EXISTS ( SELECT 1\n   FROM auth_custom.empresa_usuarios eu\n  WHERE ((eu.empresa_id = empresas.id) AND (eu.usuario_id = ( SELECT auth.uid() AS uid)) AND (eu.ativo = true))))",
+    "with_check": "(EXISTS ( SELECT 1\n   FROM auth_custom.empresa_usuarios eu\n  WHERE ((eu.empresa_id = empresas.id) AND (eu.usuario_id = ( SELECT auth.uid() AS uid)) AND (eu.ativo = true))))"
+  },
+  {
+    "schemaname": "auth_custom",
+    "tablename": "pessoas_responsaveis",
+    "policyname": "Acesso pessoas por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "auth_custom",
+    "tablename": "template_tags",
+    "policyname": "Only system can modify tags",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "false"
+  },
+  {
+    "schemaname": "auth_custom",
+    "tablename": "template_tags",
+    "policyname": "Users can view tags",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "true",
+    "with_check": null
+  },
+  {
+    "schemaname": "bronze",
+    "tablename": "bronze_contahub_avendas_porproduto_analitico",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "bronze",
+    "tablename": "bronze_contahub_avendas_vendasdiahoraanalitico",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "bronze",
+    "tablename": "bronze_contahub_avendas_vendasperiodo",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "bronze",
+    "tablename": "bronze_contahub_financeiro_pagamentosrecebidos",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "bronze",
+    "tablename": "bronze_contahub_produtos_temposproducao",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "bronze",
+    "tablename": "bronze_contahub_raw_data",
+    "policyname": "contahub_raw_data_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.role() AS role) = 'authenticated'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "cliente_perfil_consumo_legacy_backup",
+    "policyname": "Acesso perfil consumo por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "crm_segmentacao",
+    "policyname": "service_role_full_crm_segmentacao",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.role() AS role) = 'service_role'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "crm_segmentacao",
+    "policyname": "usuarios_leem_crm_segmentacao",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))",
+    "with_check": null
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "crm_templates",
+    "policyname": "Acesso CRM templates por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "nps",
+    "policyname": "Acesso NPS por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "nps_falae_diario_legacy_backup",
+    "policyname": "service_role_full_nps_falae_diario",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.role() AS role) = 'service_role'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "nps_falae_diario_legacy_backup",
+    "policyname": "usuarios_leem_nps_falae_diario",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))",
+    "with_check": null
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "nps_falae_diario_pesquisa",
+    "policyname": "service_role_full_nps_falae_diario_pesquisa",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.role() AS role) = 'service_role'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "nps_falae_diario_pesquisa",
+    "policyname": "usuarios_leem_nps_falae_diario_pesquisa",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))",
+    "with_check": null
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "nps_reservas",
+    "policyname": "Acesso NPS reservas por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "voz_cliente",
+    "policyname": "voz_cliente_delete",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "voz_cliente",
+    "policyname": "voz_cliente_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "voz_cliente",
+    "policyname": "voz_cliente_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "crm",
+    "tablename": "voz_cliente",
+    "policyname": "voz_cliente_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "cron",
+    "tablename": "job",
+    "policyname": "cron_job_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(username = CURRENT_USER)",
+    "with_check": null
+  },
+  {
+    "schemaname": "cron",
+    "tablename": "job_run_details",
+    "policyname": "cron_job_run_details_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(username = CURRENT_USER)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_impostos_movimentos",
+    "policyname": "caixa_impostos_delete",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_impostos_movimentos",
+    "policyname": "caixa_impostos_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_impostos_movimentos",
+    "policyname": "caixa_impostos_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_impostos_movimentos",
+    "policyname": "caixa_impostos_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_investimentos_movimentos",
+    "policyname": "caixa_invest_delete",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_investimentos_movimentos",
+    "policyname": "caixa_invest_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_investimentos_movimentos",
+    "policyname": "caixa_invest_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_investimentos_movimentos",
+    "policyname": "caixa_invest_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_recebimentos_futuros",
+    "policyname": "caixa_receb_delete",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_recebimentos_futuros",
+    "policyname": "caixa_receb_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_recebimentos_futuros",
+    "policyname": "caixa_receb_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_recebimentos_futuros",
+    "policyname": "caixa_receb_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_valores_terceiros",
+    "policyname": "caixa_terc_delete",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_valores_terceiros",
+    "policyname": "caixa_terc_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_valores_terceiros",
+    "policyname": "caixa_terc_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "caixa_valores_terceiros",
+    "policyname": "caixa_terc_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "cmv_mensal",
+    "policyname": "service_role_full_cmv_mensal",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.role() AS role) = 'service_role'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "cmv_mensal",
+    "policyname": "usuarios_leem_cmv_mensal",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "cmv_semanal",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "custos_mensais_diluidos",
+    "policyname": "Acesso custos por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "dre_manual",
+    "policyname": "dre_manual_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT ( SELECT auth.uid() AS uid) AS uid) IS NOT NULL)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "formas_pagamento",
+    "policyname": "formas_pagamento_all",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "user_has_access_to_empresa(empresa_id)",
+    "with_check": "user_has_access_to_empresa(empresa_id)"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "fp_categorias_template",
+    "policyname": "Acesso templates FP",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "(( SELECT auth.role() AS role) = 'authenticated'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "fp_contas",
+    "policyname": "Usuário pode acessar suas contas FP",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "((usuario_cpf)::text = (get_user_cpf())::text)",
+    "with_check": "((usuario_cpf)::text = (get_user_cpf())::text)"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "orcamentacao",
+    "policyname": "orcamentacao_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.role() AS role) = 'authenticated'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "pix_enviados",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "financial",
+    "tablename": "simulacoes_cmo",
+    "policyname": "Acesso simulacoes CMO por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "gold",
+    "tablename": "gold_contahub_operacional_stockout",
+    "policyname": "service_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "areas",
+    "policyname": "areas_delete_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "areas",
+    "policyname": "areas_insert_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "areas",
+    "policyname": "areas_select_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "areas",
+    "policyname": "areas_update_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "cargos",
+    "policyname": "cargos_delete_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "cargos",
+    "policyname": "cargos_insert_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "cargos",
+    "policyname": "cargos_select_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "cargos",
+    "policyname": "cargos_update_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "contratos_funcionario",
+    "policyname": "contratos_delete_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "(EXISTS ( SELECT 1\n   FROM hr.funcionarios f\n  WHERE ((f.id = contratos_funcionario.funcionario_id) AND user_has_access_to_bar(f.bar_id))))",
+    "with_check": null
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "contratos_funcionario",
+    "policyname": "contratos_insert_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "(EXISTS ( SELECT 1\n   FROM hr.funcionarios f\n  WHERE ((f.id = contratos_funcionario.funcionario_id) AND user_has_access_to_bar(f.bar_id))))"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "contratos_funcionario",
+    "policyname": "contratos_select_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "(EXISTS ( SELECT 1\n   FROM hr.funcionarios f\n  WHERE ((f.id = contratos_funcionario.funcionario_id) AND user_has_access_to_bar(f.bar_id))))",
+    "with_check": null
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "contratos_funcionario",
+    "policyname": "contratos_update_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "(EXISTS ( SELECT 1\n   FROM hr.funcionarios f\n  WHERE ((f.id = contratos_funcionario.funcionario_id) AND user_has_access_to_bar(f.bar_id))))",
+    "with_check": "(EXISTS ( SELECT 1\n   FROM hr.funcionarios f\n  WHERE ((f.id = contratos_funcionario.funcionario_id) AND user_has_access_to_bar(f.bar_id))))"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "folha_pagamento",
+    "policyname": "folha_delete_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "folha_pagamento",
+    "policyname": "folha_insert_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "folha_pagamento",
+    "policyname": "folha_select_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "folha_pagamento",
+    "policyname": "folha_update_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "funcionarios",
+    "policyname": "funcionarios_delete_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "funcionarios",
+    "policyname": "funcionarios_insert_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "funcionarios",
+    "policyname": "funcionarios_select_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "funcionarios",
+    "policyname": "funcionarios_update_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "pesquisa_felicidade",
+    "policyname": "Acesso pesquisa felicidade por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "provisoes_trabalhistas",
+    "policyname": "provisoes_delete_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "provisoes_trabalhistas",
+    "policyname": "provisoes_insert_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "provisoes_trabalhistas",
+    "policyname": "provisoes_select_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "hr",
+    "tablename": "provisoes_trabalhistas",
+    "policyname": "provisoes_update_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "bar_api_configs",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "contaazul_categorias",
+    "policyname": "authenticated_select_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND (bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid)))))",
+    "with_check": null
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "contaazul_categorias",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "contaazul_centros_custo",
+    "policyname": "authenticated_select_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND (bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid)))))",
+    "with_check": null
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "contaazul_centros_custo",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "contaazul_contas_financeiras",
+    "policyname": "authenticated_select_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))",
+    "with_check": null
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "contaazul_contas_financeiras",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "contaazul_lancamentos",
+    "policyname": "authenticated_select_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))",
+    "with_check": null
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "contaazul_lancamentos",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "contaazul_logs_sincronizacao",
+    "policyname": "authenticated_select_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))",
+    "with_check": null
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "contaazul_logs_sincronizacao",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "contaazul_pessoas",
+    "policyname": "authenticated_select_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))",
+    "with_check": null
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "contaazul_pessoas",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "falae_config",
+    "policyname": "falae_config_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "falae_respostas",
+    "policyname": "falae_respostas_delete_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "falae_respostas",
+    "policyname": "falae_respostas_insert_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "falae_respostas",
+    "policyname": "falae_respostas_select_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "falae_respostas",
+    "policyname": "falae_respostas_update_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "getin_sync_logs",
+    "policyname": "Only system can modify",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "false"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "getin_sync_logs",
+    "policyname": "Users can view sync logs",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "true",
+    "with_check": null
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "google_oauth_tokens",
+    "policyname": "google_oauth_service_only",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.role() AS role) = 'service_role'::text)",
+    "with_check": "(( SELECT auth.role() AS role) = 'service_role'::text)"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "google_reviews",
+    "policyname": "google_reviews_delete",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "google_reviews",
+    "policyname": "google_reviews_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "google_reviews",
+    "policyname": "google_reviews_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "google_reviews",
+    "policyname": "google_reviews_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "sympla_eventos",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "sympla_participantes",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "sympla_pedidos",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "umbler_campanha_destinatarios",
+    "policyname": "umbler_campanha_destinatarios_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(EXISTS ( SELECT 1\n   FROM integrations.umbler_campanhas c\n  WHERE ((c.id = umbler_campanha_destinatarios.campanha_id) AND user_has_access_to_bar(c.bar_id))))",
+    "with_check": "(EXISTS ( SELECT 1\n   FROM integrations.umbler_campanhas c\n  WHERE ((c.id = umbler_campanha_destinatarios.campanha_id) AND user_has_access_to_bar(c.bar_id))))"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "umbler_campanhas",
+    "policyname": "umbler_campanhas_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "umbler_config",
+    "policyname": "umbler_config_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "umbler_conversas",
+    "policyname": "umbler_conversas_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "umbler_mensagens",
+    "policyname": "umbler_mensagens_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "umbler_webhook_logs",
+    "policyname": "umbler_webhook_logs_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "yuzer_eventos",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "yuzer_fatporhora",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "yuzer_pagamento",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "integrations",
+    "tablename": "yuzer_produtos",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "desempenho_manual",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "marketing_mensal",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "marketing_semanal",
+    "policyname": "marketing_semanal_delete",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "marketing_semanal",
+    "policyname": "marketing_semanal_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "marketing_semanal",
+    "policyname": "marketing_semanal_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "marketing_semanal",
+    "policyname": "marketing_semanal_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "metas_anuais",
+    "policyname": "metas_anuais_delete",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "metas_anuais",
+    "policyname": "metas_anuais_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "metas_anuais",
+    "policyname": "metas_anuais_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "metas_anuais",
+    "policyname": "metas_anuais_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "user_has_access_to_bar(bar_id)",
+    "with_check": "user_has_access_to_bar(bar_id)"
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "metas_desempenho",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "metas_desempenho_historico",
+    "policyname": "service_role_full_metas_desempenho_historico",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.role() AS role) = 'service_role'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "metas_desempenho_historico",
+    "policyname": "usuarios_leem_metas_desempenho_historico",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))",
+    "with_check": null
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "organizador_okrs",
+    "policyname": "Acesso OKRs",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "(( SELECT auth.role() AS role) = 'authenticated'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "organizador_visao",
+    "policyname": "Acesso visao por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "meta",
+    "tablename": "semanas_referencia",
+    "policyname": "semanas_referencia_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.uid() AS uid) IS NOT NULL)",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bar_artistas",
+    "policyname": "authenticated_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bar_artistas",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bar_categorias_custo",
+    "policyname": "authenticated_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bar_categorias_custo",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bar_local_mapeamento",
+    "policyname": "authenticated_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bar_local_mapeamento",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bar_metas_periodo",
+    "policyname": "authenticated_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bar_metas_periodo",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bar_notification_configs",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bar_regras_negocio",
+    "policyname": "authenticated_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bar_regras_negocio",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bares",
+    "policyname": "bars_insert_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "(( SELECT ( SELECT auth.uid() AS uid) AS uid) IS NOT NULL)"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bares",
+    "policyname": "bars_select_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "true",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bares_config",
+    "policyname": "authenticated_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "bares_config",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "calendario_operacional",
+    "policyname": "Acesso calendario por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "checklist_agendamentos",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "checklist_auto_executions",
+    "policyname": "checklist_exec_delete",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "(EXISTS ( SELECT 1\n   FROM operations.checklist_agendamentos ca\n  WHERE ((ca.id = checklist_auto_executions.checklist_agendamento_id) AND user_has_access_to_bar(ca.bar_id))))",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "checklist_auto_executions",
+    "policyname": "checklist_exec_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "(EXISTS ( SELECT 1\n   FROM operations.checklist_agendamentos ca\n  WHERE ((ca.id = checklist_auto_executions.checklist_agendamento_id) AND user_has_access_to_bar(ca.bar_id))))"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "checklist_auto_executions",
+    "policyname": "checklist_exec_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "(EXISTS ( SELECT 1\n   FROM operations.checklist_agendamentos ca\n  WHERE ((ca.id = checklist_auto_executions.checklist_agendamento_id) AND user_has_access_to_bar(ca.bar_id))))",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "checklist_auto_executions",
+    "policyname": "checklist_exec_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "(EXISTS ( SELECT 1\n   FROM operations.checklist_agendamentos ca\n  WHERE ((ca.id = checklist_auto_executions.checklist_agendamento_id) AND user_has_access_to_bar(ca.bar_id))))",
+    "with_check": "(EXISTS ( SELECT 1\n   FROM operations.checklist_agendamentos ca\n  WHERE ((ca.id = checklist_auto_executions.checklist_agendamento_id) AND user_has_access_to_bar(ca.bar_id))))"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "checklist_automation_logs",
+    "policyname": "checklist_logs_delete",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "(( SELECT auth.role() AS role) = 'service_role'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "checklist_automation_logs",
+    "policyname": "checklist_logs_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "(( SELECT auth.role() AS role) = 'service_role'::text)"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "checklist_automation_logs",
+    "policyname": "checklist_logs_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "true",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "config_metas_planejamento",
+    "policyname": "config_metas_read_by_bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "config_metas_planejamento",
+    "policyname": "config_metas_write_admin",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "is_user_admin()",
+    "with_check": "is_user_admin()"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "contagem_estoque_insumos",
+    "policyname": "Acesso contagem insumos por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "eventos_base",
+    "policyname": "authenticated_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "eventos_base",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "eventos_base_auditoria",
+    "policyname": "Acesso auditoria eventos por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "eventos_base_auditoria",
+    "policyname": "Insert auditoria eventos",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "eventos_concorrencia",
+    "policyname": "eventos_concorrencia_delete",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "(( SELECT auth.role() AS role) = 'service_role'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "eventos_concorrencia",
+    "policyname": "eventos_concorrencia_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "(( SELECT auth.role() AS role) = 'service_role'::text)"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "eventos_concorrencia",
+    "policyname": "eventos_concorrencia_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "((status = 'ativo'::text) OR (( SELECT auth.role() AS role) = 'service_role'::text))",
+    "with_check": null
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "eventos_concorrencia",
+    "policyname": "eventos_concorrencia_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "(( SELECT auth.role() AS role) = 'service_role'::text)",
+    "with_check": "(( SELECT auth.role() AS role) = 'service_role'::text)"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "grupos_produto",
+    "policyname": "grupos_all",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "user_has_access_to_empresa(empresa_id)",
+    "with_check": "user_has_access_to_empresa(empresa_id)"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "insumos",
+    "policyname": "Acesso insumos por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "operations",
+    "tablename": "produtos",
+    "policyname": "produtos_all",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "user_has_access_to_empresa(empresa_id)",
+    "with_check": "user_has_access_to_empresa(empresa_id)"
+  },
+  {
+    "schemaname": "ops",
+    "tablename": "job_camada_mapping",
+    "policyname": "job_camada_read_auth",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "(( SELECT auth.role() AS role) = 'authenticated'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "ops",
+    "tablename": "job_camada_mapping",
+    "policyname": "job_camada_write_admin",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "is_user_admin()",
+    "with_check": "is_user_admin()"
+  },
+  {
+    "schemaname": "public",
+    "tablename": "api_credentials",
+    "policyname": "Users can access their bar data",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))"
+  },
+  {
+    "schemaname": "public",
+    "tablename": "usuarios",
+    "policyname": "usuarios_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "(id = ( SELECT auth.uid() AS uid))"
+  },
+  {
+    "schemaname": "public",
+    "tablename": "usuarios",
+    "policyname": "usuarios_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "(auth_id = ( SELECT auth.uid() AS uid))",
+    "with_check": null
+  },
+  {
+    "schemaname": "public",
+    "tablename": "usuarios",
+    "policyname": "usuarios_update",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "UPDATE",
+    "qual": "(auth_id = ( SELECT auth.uid() AS uid))",
+    "with_check": null
+  },
+  {
+    "schemaname": "public",
+    "tablename": "usuarios_bares",
+    "policyname": "Users can access their own associations",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(usuario_id = ( SELECT auth.uid() AS uid))",
+    "with_check": "(usuario_id = ( SELECT auth.uid() AS uid))"
+  },
+  {
+    "schemaname": "silver",
+    "tablename": "faturamento_hora",
+    "policyname": "authenticated_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "silver",
+    "tablename": "faturamento_hora",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "silver",
+    "tablename": "faturamento_pagamentos",
+    "policyname": "authenticated_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "silver",
+    "tablename": "faturamento_pagamentos",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "silver",
+    "tablename": "tempos_producao",
+    "policyname": "authenticated_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "silver",
+    "tablename": "tempos_producao",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "silver",
+    "tablename": "vendas_item",
+    "policyname": "authenticated_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "silver",
+    "tablename": "vendas_item",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "storage",
+    "tablename": "objects",
+    "policyname": "Service role can delete backups",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "DELETE",
+    "qual": "(bucket_id = 'sgb-backups'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "storage",
+    "tablename": "objects",
+    "policyname": "Service role can download backups",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "(bucket_id = 'sgb-backups'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "storage",
+    "tablename": "objects",
+    "policyname": "Service role can list backups",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "(bucket_id = 'sgb-backups'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "storage",
+    "tablename": "objects",
+    "policyname": "Service role can upload backups",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "(bucket_id = 'sgb-backups'::text)"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "alertas_enviados",
+    "policyname": "Acesso alertas por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "audit_trail",
+    "policyname": "Insert audit trail service",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "true"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "audit_trail",
+    "policyname": "Leitura audit trail",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "(( SELECT auth.role() AS role) = 'authenticated'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "system",
+    "tablename": "automation_logs",
+    "policyname": "automation_logs_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.role() AS role) = 'authenticated'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "system",
+    "tablename": "cron_heartbeats",
+    "policyname": "Service role full access on cron_heartbeats",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "dados_bloqueados",
+    "policyname": "Acesso dados bloqueados por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "discord_webhooks",
+    "policyname": "Acesso webhooks discord por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "execucoes_automaticas",
+    "policyname": "execucoes_automaticas_policy",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.uid() AS uid) IS NOT NULL)",
+    "with_check": null
+  },
+  {
+    "schemaname": "system",
+    "tablename": "insight_events",
+    "policyname": "insight_events_bar_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(bar_id IN ( SELECT usuarios_bares.bar_id\n   FROM usuarios_bares\n  WHERE (usuarios_bares.usuario_id = ( SELECT auth.uid() AS uid))))",
+    "with_check": null
+  },
+  {
+    "schemaname": "system",
+    "tablename": "insight_events",
+    "policyname": "service_role_full_access",
+    "permissive": "PERMISSIVE",
+    "roles": "{service_role}",
+    "cmd": "ALL",
+    "qual": "true",
+    "with_check": "true"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "notificacoes",
+    "policyname": "Users can access their notifications",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "(usuario_id = ( SELECT auth.uid() AS uid))",
+    "with_check": "(usuario_id = ( SELECT auth.uid() AS uid))"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "security_events",
+    "policyname": "Only system can modify",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "false"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "security_events",
+    "policyname": "Users can view security events",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "SELECT",
+    "qual": "true",
+    "with_check": null
+  },
+  {
+    "schemaname": "system",
+    "tablename": "sistema_alertas",
+    "policyname": "Acesso alertas sistema por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "sync_contagem_historico",
+    "policyname": "service_role_full_sync_contagem_historico",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.role() AS role) = 'service_role'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "system",
+    "tablename": "sync_contagem_historico",
+    "policyname": "usuarios_leem_sync_contagem_historico",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))",
+    "with_check": null
+  },
+  {
+    "schemaname": "system",
+    "tablename": "sync_metadata",
+    "policyname": "service_role_full_sync_metadata",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.role() AS role) = 'service_role'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "system",
+    "tablename": "sync_metadata",
+    "policyname": "usuarios_leem_sync_metadata",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "((( SELECT auth.role() AS role) = 'authenticated'::text) AND user_has_bar_access(bar_id))",
+    "with_check": null
+  },
+  {
+    "schemaname": "system",
+    "tablename": "system_logs",
+    "policyname": "system_logs_insert",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "INSERT",
+    "qual": null,
+    "with_check": "(( SELECT auth.role() AS role) = 'service_role'::text)"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "system_logs",
+    "policyname": "system_logs_select",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "SELECT",
+    "qual": "true",
+    "with_check": null
+  },
+  {
+    "schemaname": "system",
+    "tablename": "uploads",
+    "policyname": "Usuário gerencia uploads",
+    "permissive": "PERMISSIVE",
+    "roles": "{public}",
+    "cmd": "ALL",
+    "qual": "(( SELECT auth.role() AS role) = 'authenticated'::text)",
+    "with_check": null
+  },
+  {
+    "schemaname": "system",
+    "tablename": "validacao_dados",
+    "policyname": "Acesso validacao dados por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "validacao_dados_diaria",
+    "policyname": "Acesso validacao diaria por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  },
+  {
+    "schemaname": "system",
+    "tablename": "validacoes_cruzadas",
+    "policyname": "Acesso validacoes cruzadas por bar",
+    "permissive": "PERMISSIVE",
+    "roles": "{authenticated}",
+    "cmd": "ALL",
+    "qual": "user_has_bar_access(bar_id)",
+    "with_check": "user_has_bar_access(bar_id)"
+  }
+]

--- a/database/migrations/2026-04-24-perf-consolidate-permissive-policies.rollback.sql
+++ b/database/migrations/2026-04-24-perf-consolidate-permissive-policies.rollback.sql
@@ -1,0 +1,100 @@
+-- Rollback de 2026-04-24-perf-consolidate-permissive-policies.sql.
+-- Recria as 9 policies dropadas com qual/with_check fiel ao snapshot
+-- database/_advisor_snapshots/2026-04-24-pg-policies-post-fase2.json.
+--
+-- ATENCAO: este rollback recria policies que permitiam `anon` SELECT em
+-- integrations.contaazul_categorias e integrations.contaazul_centros_custo
+-- (USING true + roles=public, bug de seguranca pre-existente).
+-- Aplicar APENAS se a migration forward causou regressao funcional comprovada.
+
+-- ============================================
+-- crm.crm_segmentacao
+-- ============================================
+CREATE POLICY "service_role_full_crm_segmentacao"
+  ON "crm"."crm_segmentacao"
+  AS PERMISSIVE
+  FOR ALL
+  TO public
+  USING (((select auth.role()) = 'service_role'::text));
+
+-- ============================================
+-- crm.nps_falae_diario_legacy_backup
+-- ============================================
+CREATE POLICY "service_role_full_nps_falae_diario"
+  ON "crm"."nps_falae_diario_legacy_backup"
+  AS PERMISSIVE
+  FOR ALL
+  TO public
+  USING (((select auth.role()) = 'service_role'::text));
+
+-- ============================================
+-- crm.nps_falae_diario_pesquisa
+-- ============================================
+CREATE POLICY "service_role_full_nps_falae_diario_pesquisa"
+  ON "crm"."nps_falae_diario_pesquisa"
+  AS PERMISSIVE
+  FOR ALL
+  TO public
+  USING (((select auth.role()) = 'service_role'::text));
+
+-- ============================================
+-- financial.cmv_mensal
+-- ============================================
+CREATE POLICY "service_role_full_cmv_mensal"
+  ON "financial"."cmv_mensal"
+  AS PERMISSIVE
+  FOR ALL
+  TO public
+  USING (((select auth.role()) = 'service_role'::text));
+
+-- ============================================
+-- integrations.contaazul_categorias  ⚠️ RE-ABRE BUG
+-- ============================================
+CREATE POLICY "service_role_full_access"
+  ON "integrations"."contaazul_categorias"
+  AS PERMISSIVE
+  FOR ALL
+  TO public
+  USING (true)
+  WITH CHECK (true);
+
+-- ============================================
+-- integrations.contaazul_centros_custo  ⚠️ RE-ABRE BUG
+-- ============================================
+CREATE POLICY "service_role_full_access"
+  ON "integrations"."contaazul_centros_custo"
+  AS PERMISSIVE
+  FOR ALL
+  TO public
+  USING (true)
+  WITH CHECK (true);
+
+-- ============================================
+-- meta.metas_desempenho_historico
+-- ============================================
+CREATE POLICY "service_role_full_metas_desempenho_historico"
+  ON "meta"."metas_desempenho_historico"
+  AS PERMISSIVE
+  FOR ALL
+  TO public
+  USING (((select auth.role()) = 'service_role'::text));
+
+-- ============================================
+-- system.sync_contagem_historico
+-- ============================================
+CREATE POLICY "service_role_full_sync_contagem_historico"
+  ON "system"."sync_contagem_historico"
+  AS PERMISSIVE
+  FOR ALL
+  TO public
+  USING (((select auth.role()) = 'service_role'::text));
+
+-- ============================================
+-- system.sync_metadata
+-- ============================================
+CREATE POLICY "service_role_full_sync_metadata"
+  ON "system"."sync_metadata"
+  AS PERMISSIVE
+  FOR ALL
+  TO public
+  USING (((select auth.role()) = 'service_role'::text));

--- a/database/migrations/2026-04-24-perf-consolidate-permissive-policies.sql
+++ b/database/migrations/2026-04-24-perf-consolidate-permissive-policies.sql
@@ -1,0 +1,72 @@
+-- DROP de 9 policies service_role_full_* redundantes apontadas pelo
+-- Supabase Performance Advisor (multiple_permissive_policies).
+-- Baseline: database/_advisor_snapshots/2026-04-24-perf-after-02.json (66 findings)
+-- Pre-flight: database/_advisor_snapshots/2026-04-24-multiple-permissive-preflight.md
+--
+-- Premissa critica: service_role tem rolbypassrls=TRUE no Postgres deste projeto
+-- (verificado via pg_roles em 2026-04-24). As policies removidas eram no-ops:
+--   - 7 com USING (auth.role()='service_role'): no-op total para service_role
+--     (que ja bypassa RLS nativamente).
+--   - 2 com USING (true) + roles={public}: BUG DE SEGURANCA (vazava SELECT
+--     pra anon e outros roles publicos); DROP fecha o furo. service_role
+--     continua acessando via BYPASSRLS.
+--
+-- Bucket C (2 tabelas) adiado: operations.config_metas_planejamento e
+-- ops.job_camada_mapping tem read/write split com cmds diferentes — fix
+-- nao-trivial sem write-tests dedicados. Reavaliar em PR futuro.
+
+-- ============================================
+-- crm.crm_segmentacao
+-- (USING auth.role()='service_role' — redundante)
+-- ============================================
+DROP POLICY IF EXISTS "service_role_full_crm_segmentacao" ON "crm"."crm_segmentacao";
+
+-- ============================================
+-- crm.nps_falae_diario_legacy_backup
+-- (USING auth.role()='service_role' — redundante)
+-- ============================================
+DROP POLICY IF EXISTS "service_role_full_nps_falae_diario" ON "crm"."nps_falae_diario_legacy_backup";
+
+-- ============================================
+-- crm.nps_falae_diario_pesquisa
+-- (USING auth.role()='service_role' — redundante)
+-- ============================================
+DROP POLICY IF EXISTS "service_role_full_nps_falae_diario_pesquisa" ON "crm"."nps_falae_diario_pesquisa";
+
+-- ============================================
+-- financial.cmv_mensal
+-- (USING auth.role()='service_role' — redundante)
+-- ============================================
+DROP POLICY IF EXISTS "service_role_full_cmv_mensal" ON "financial"."cmv_mensal";
+
+-- ============================================
+-- integrations.contaazul_categorias
+-- ⚠️ BUG SEGURANCA: USING (true) + roles={public} — vazava SELECT pra anon.
+-- DROP fecha o furo. service_role acessa via BYPASSRLS.
+-- ============================================
+DROP POLICY IF EXISTS "service_role_full_access" ON "integrations"."contaazul_categorias";
+
+-- ============================================
+-- integrations.contaazul_centros_custo
+-- ⚠️ BUG SEGURANCA: USING (true) + roles={public} — vazava SELECT pra anon.
+-- DROP fecha o furo. service_role acessa via BYPASSRLS.
+-- ============================================
+DROP POLICY IF EXISTS "service_role_full_access" ON "integrations"."contaazul_centros_custo";
+
+-- ============================================
+-- meta.metas_desempenho_historico
+-- (USING auth.role()='service_role' — redundante)
+-- ============================================
+DROP POLICY IF EXISTS "service_role_full_metas_desempenho_historico" ON "meta"."metas_desempenho_historico";
+
+-- ============================================
+-- system.sync_contagem_historico
+-- (USING auth.role()='service_role' — redundante)
+-- ============================================
+DROP POLICY IF EXISTS "service_role_full_sync_contagem_historico" ON "system"."sync_contagem_historico";
+
+-- ============================================
+-- system.sync_metadata
+-- (USING auth.role()='service_role' — redundante)
+-- ============================================
+DROP POLICY IF EXISTS "service_role_full_sync_metadata" ON "system"."sync_metadata";

--- a/scripts/perf/analyze-permissive-policies.py
+++ b/scripts/perf/analyze-permissive-policies.py
@@ -1,0 +1,288 @@
+"""
+Analise de findings multiple_permissive_policies do Supabase Performance Advisor.
+
+Inputs:
+  database/_advisor_snapshots/2026-04-24-perf-after-02.json (apos Fase 2)
+  database/_advisor_snapshots/2026-04-24-pg-policies-post-fase2.json (estado fresco)
+
+Output:
+  database/_advisor_snapshots/2026-04-24-multiple-permissive-preflight.md
+
+Fase 3.0 = analise apenas. NAO gera migration. NAO aplica DDL.
+Migration eh gerada na Fase 3.1, apos aprovacao por bucket.
+
+Idempotente: rodar 2x produz o mesmo output.
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+ROOT = Path(__file__).resolve().parents[2]
+SNAP = ROOT / "database" / "_advisor_snapshots"
+
+PERF_FILE = SNAP / "2026-04-24-perf-after-02.json"
+PG_POLICIES_FILE = SNAP / "2026-04-24-pg-policies-post-fase2.json"
+PREFLIGHT = SNAP / "2026-04-24-multiple-permissive-preflight.md"
+
+BS = chr(92)
+
+
+def parse_detail(detail: str) -> Optional[tuple]:
+    """Extrai (schema, table, role, action, policies_tuple) do detail."""
+    parts = detail.split("`")
+    if len(parts) < 8:
+        return None
+    st = parts[1].rstrip(BS)
+    role = parts[3].rstrip(BS)
+    action = parts[5].rstrip(BS)
+    pols_raw = parts[7].rstrip(BS).strip("{}")
+    if "." not in st:
+        return None
+    s, t = st.split(".", 1)
+    pols = tuple(sorted(p.strip() for p in pols_raw.split(",")))
+    return s, t, role, action, pols
+
+
+def is_service_role_check(qual: str) -> bool:
+    """True se qual eh check 'auth.role() = service_role' (com ou sem wrap)."""
+    if not qual:
+        return False
+    q = qual.lower().replace(" ", "").replace("\n", "")
+    needles = [
+        "auth.role()='service_role'",
+        "auth.role()=cast('service_role'astext)",
+        "(selectauth.role())='service_role'",
+        "(selectauth.role()asrole)='service_role'",
+    ]
+    return any(n in q for n in needles)
+
+
+def is_always_true(qual: str) -> bool:
+    return qual is not None and qual.strip().lower() == "true"
+
+
+def is_user_writer_check(qual: str) -> bool:
+    """True se qual contem auth.role()='authenticated' E user_has_bar_access."""
+    if not qual:
+        return False
+    q = qual.lower()
+    return "'authenticated'" in q and "user_has_bar_access" in q
+
+
+def main() -> None:
+    perf = json.loads(PERF_FILE.read_text(encoding="utf-8"))
+    pol_list = json.loads(PG_POLICIES_FILE.read_text(encoding="utf-8"))
+
+    pol_by_table: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    pol_index: dict[tuple[str, str, str], dict] = {}
+    for p in pol_list:
+        key_table = (p["schemaname"], p["tablename"])
+        pol_by_table[key_table].append(p)
+        pol_index[(p["schemaname"], p["tablename"], p["policyname"])] = p
+
+    findings = [l for l in perf if l["name"] == "multiple_permissive_policies"]
+
+    # Agrupa por (schema, table)
+    table_findings: dict[tuple[str, str], list[tuple]] = defaultdict(list)
+    parse_failures = []
+    for f in findings:
+        parsed = parse_detail(f.get("detail", ""))
+        if parsed is None:
+            parse_failures.append(f.get("cache_key", "?"))
+            continue
+        s, t, role, action, pols = parsed
+        table_findings[(s, t)].append((role, action, pols))
+
+    # Para cada tabela, classificar
+    bucket_a = []  # DROP redundant service_role (BYPASSRLS makes it no-op)
+    bucket_b = []  # roles distintos (legitimo)
+    bucket_c = []  # complexo / read-write split / precisa decisao
+
+    for (s, t), entries in sorted(table_findings.items()):
+        all_pols = pol_by_table[(s, t)]
+        permissive_pols = [p for p in all_pols if p["permissive"] == "PERMISSIVE"]
+
+        # Pegar uniao de policies envolvidas em qualquer finding
+        flagged_names = set()
+        for _, _, pols in entries:
+            flagged_names.update(pols)
+
+        # Classificar
+        # Pattern A (DROP service_role): exatamente 2 policies envolvidas, uma e
+        # service_role check (ou USING true), outra e auth.role()='authenticated'
+        # ou bar_access. service_role bypass RLS, entao DROP eh seguro.
+        if len(flagged_names) == 2:
+            pol_objs = [p for p in permissive_pols if p["policyname"] in flagged_names]
+            if len(pol_objs) == 2:
+                p1, p2 = pol_objs
+                # Identificar service_role policy
+                sr = None
+                other = None
+                for p in pol_objs:
+                    if is_service_role_check(p.get("qual", "") or "") or is_always_true(p.get("qual", "") or ""):
+                        sr = p
+                    else:
+                        other = p
+                if sr and other:
+                    # Confirma que sr eh redundante (cmd=ALL ou cmd=SELECT) e other tem auth check
+                    bucket_a.append({
+                        "schema": s,
+                        "table": t,
+                        "drop": sr,
+                        "keep": other,
+                        "findings_count": len(entries),
+                    })
+                    continue
+
+        # Pattern C (read/write split): 2 policies, ambas com is_user_admin / user_has_bar_access
+        # Ou outro pattern nao trivial
+        bucket_c.append({
+            "schema": s,
+            "table": t,
+            "policies": [p for p in permissive_pols if p["policyname"] in flagged_names],
+            "findings_count": len(entries),
+        })
+
+    # ---------- preflight md ----------
+    md = []
+    md.append("# Preflight — perf/03-multiple-permissive-policies")
+    md.append("")
+    md.append(f"Findings raw: **{len(findings)}**, parse failures: **{len(parse_failures)}**")
+    md.append(f"Tabelas distintas afetadas: **{len(table_findings)}**")
+    md.append("")
+    md.append("## Sumario por bucket")
+    md.append("")
+    md.append("| Bucket | Tabelas | Significado |")
+    md.append("|---|---:|---|")
+    md.append(f"| A — DROP service_role redundante | {len(bucket_a)} | service_role tem BYPASSRLS=true; policy USING(auth.role()='service_role') OR USING(true) eh no-op. DROP eh seguro. |")
+    md.append(f"| B — Roles distintos | {len(bucket_b)} | Policies com roles diferentes; pode ser intencional. |")
+    md.append(f"| C — Read/write split / complexo | {len(bucket_c)} | Cmds diferentes; merge nao trivial. Precisa decisao. |")
+    total = len(bucket_a) + len(bucket_b) + len(bucket_c)
+    md.append(f"| **Total** | **{total}** | |")
+    md.append("")
+
+    md.append("## Premissa critica (verificada via pg_roles)")
+    md.append("")
+    md.append("```")
+    md.append("rolname            rolbypassrls")
+    md.append("anon               false")
+    md.append("authenticated      false")
+    md.append("authenticator      false")
+    md.append("dashboard_user     false")
+    md.append("postgres           true")
+    md.append("service_role       true   <-- bypassa RLS")
+    md.append("supabase_admin     true")
+    md.append("```")
+    md.append("")
+    md.append("Conclusao: policies do tipo `service_role_full_*` com `USING (auth.role()='service_role')`")
+    md.append("ou `USING (true)` sao redundantes — `service_role` ja bypassa qualquer RLS por default.")
+    md.append("DROP dessas policies NAO altera comportamento de service_role.")
+    md.append("")
+    md.append("Bonus: 2 das policies a dropar (contaazul_*) tem `roles={public}` + `USING (true)`,")
+    md.append("o que vazava SELECT pra TODOS os roles (incluindo `anon`). DROP fortalece seguranca.")
+    md.append("")
+
+    # ---------- Bucket A ----------
+    if bucket_a:
+        md.append("## Bucket A — DROP service_role policy redundante")
+        md.append("")
+        md.append("Pattern: DROP POLICY <service_role_*> + manter <usuarios_leem_*> intacta.")
+        md.append("")
+        md.append("**SEM ALTER POLICY** na que fica — ela ja esta correta.")
+        md.append("**COM DROP POLICY** na redundante (bypass RLS torna inutil).")
+        md.append("")
+        for entry in bucket_a:
+            s, t = entry["schema"], entry["table"]
+            drop = entry["drop"]
+            keep = entry["keep"]
+            md.append(f"### `{s}.{t}` ({entry['findings_count']} findings)")
+            md.append("")
+            md.append("**Atual:**")
+            md.append("```sql")
+            md.append(f"-- DROP candidate (redundante por BYPASSRLS):")
+            md.append(f"--   {drop['policyname']:50s} cmd={drop['cmd']:6s} permissive={drop['permissive']}")
+            md.append(f"--     roles: {drop['roles']}")
+            md.append(f"--     qual:  {drop.get('qual')}")
+            if drop.get("with_check"):
+                md.append(f"--     with_check: {drop.get('with_check')}")
+            md.append(f"")
+            md.append(f"-- KEEP (policy real do usuario):")
+            md.append(f"--   {keep['policyname']:50s} cmd={keep['cmd']:6s} permissive={keep['permissive']}")
+            md.append(f"--     roles: {keep['roles']}")
+            md.append(f"--     qual:  {keep.get('qual')}")
+            if keep.get("with_check"):
+                md.append(f"--     with_check: {keep.get('with_check')}")
+            md.append("```")
+            md.append("")
+            md.append("**SQL proposto:**")
+            md.append("```sql")
+            md.append(f'DROP POLICY "{drop["policyname"]}" ON "{s}"."{t}";')
+            md.append("```")
+            md.append("")
+            # Notas especiais
+            if is_always_true(drop.get("qual", "") or ""):
+                md.append("⚠️ **Nota seguranca**: esta policy tinha `USING (true)` + `roles={public}`,")
+                md.append("permitindo SELECT por TODOS os roles incluindo `anon`. DROP corrige bug de seguranca")
+                md.append("que ja existia. service_role continua acessando via BYPASSRLS.")
+                md.append("")
+
+    # ---------- Bucket B ----------
+    if bucket_b:
+        md.append("## Bucket B — Roles distintos")
+        md.append("")
+        for entry in bucket_b:
+            s, t = entry["schema"], entry["table"]
+            md.append(f"### `{s}.{t}`")
+            md.append("(detalhes pendentes — nenhum caso identificado nesta rodada)")
+            md.append("")
+
+    # ---------- Bucket C ----------
+    if bucket_c:
+        md.append("## Bucket C — Read/write split (precisa decisao)")
+        md.append("")
+        md.append("Estas tabelas tem 2 policies PERMISSIVE com cmds diferentes (uma SELECT, outra ALL).")
+        md.append("Overlap so existe em SELECT. NAO da pra simplesmente DROP — perde funcionalidade.")
+        md.append("")
+        md.append("Opcoes possiveis (escolher por tabela):")
+        md.append("1. **Adiar** — manter como esta. Overhead de 2 policies em SELECT eh pequeno.")
+        md.append("2. **Split cmd** — DROP a policy ALL + CREATE 3 novas (INSERT, UPDATE, DELETE).")
+        md.append("   Mantem semantica, satisfaz advisor. Mas viola 'no DROP+CREATE' (cria 3 novas).")
+        md.append("3. **Merge cmd=ALL com USING e WITH CHECK separados** — DROP read + ALTER write")
+        md.append("   pra `USING (read_cond OR write_cond) WITH CHECK (write_cond)`. Funciona em")
+        md.append("   SELECT/INSERT/UPDATE mas DELETE so checa USING (vaza permissao de delete!).")
+        md.append("   ⚠️ Risco de regressao de seguranca em DELETE.")
+        md.append("")
+        for entry in bucket_c:
+            s, t = entry["schema"], entry["table"]
+            md.append(f"### `{s}.{t}`")
+            md.append("")
+            md.append("**Policies envolvidas:**")
+            md.append("```sql")
+            for p in entry["policies"]:
+                md.append(f"-- {p['policyname']:50s} cmd={p['cmd']:6s} roles={p['roles']}")
+                md.append(f"--   qual: {p.get('qual')}")
+                if p.get("with_check"):
+                    md.append(f"--   with_check: {p.get('with_check')}")
+                md.append("--")
+            md.append("```")
+            md.append("")
+            md.append("**Recomendacao**: opcao 1 (adiar) por default. Opcao 2 se voce quiser")
+            md.append("eliminar todos os warnings. Opcao 3 NAO recomendada (risco DELETE).")
+            md.append("")
+
+    PREFLIGHT.write_text("\n".join(md), encoding="utf-8")
+
+    # ---------- console summary ----------
+    print(f"[ok] {PREFLIGHT.relative_to(ROOT)}")
+    print()
+    print(f"Findings: {len(findings)}, tabelas: {len(table_findings)}")
+    print(f"Bucket A (DROP redundant): {len(bucket_a)}")
+    print(f"Bucket B (roles distintos): {len(bucket_b)}")
+    print(f"Bucket C (read/write split): {len(bucket_c)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Contexto
Supabase Performance Advisor apontava 66 findings `multiple_permissive_policies` (WARN) em 11 tabelas.
Analise revelou padrao uniforme: policies `service_role_full_*` redundantes (`rolbypassrls=TRUE` no service_role, policy nao faz nada) — e 2 com bug critico de privacidade.

## Fix de privacidade (descoberto durante a triagem)
As policies `service_role_full_access` em `integrations.contaazul_categorias` e `integrations.contaazul_centros_custo` tinham `USING (true)` com `roles={public}`, permitindo que qualquer cliente com a `anon_key` (publicada no frontend) lesse todas as 122 categorias financeiras e 158 centros de custo do Zykor — incluindo nomes de fornecedores, classificacoes financeiras e estrutura do plano de contas.

Smoke-before confirmou o leak em prod (`_advisor_snapshots/2026-04-24-permissive-smoke-before.json`):

| Tabela | anon antes | anon depois |
|---|---:|---:|
| `integrations.contaazul_categorias` | **122** ⚠️ | **0** ✅ |
| `integrations.contaazul_centros_custo` | **158** ⚠️ | **0** ✅ |

Total: **280 rows de dados financeiros internos** que estavam expostas — agora fechadas.

Causa raiz: o autor da migration `20260324_contaazul_tables.sql` provavelmente queria a policy aplicar a `service_role` mas usou `roles={public}` (que em Postgres significa "todos os roles" — incluindo `anon`). Combinado com `USING (true)` ficou aberto pra qualquer um.

## Fix de performance
DROP de 9 policies `service_role_full_*` em 9 tabelas. Sem CREATE.
Restaram as policies `usuarios_leem_*` / `authenticated_select_*` que tem a logica de `bar_access`.

| # | Tabela | Policy dropada |
|---|---|---|
| 1 | `crm.crm_segmentacao` | `service_role_full_crm_segmentacao` |
| 2 | `crm.nps_falae_diario_legacy_backup` | `service_role_full_nps_falae_diario` |
| 3 | `crm.nps_falae_diario_pesquisa` | `service_role_full_nps_falae_diario_pesquisa` |
| 4 | `financial.cmv_mensal` | `service_role_full_cmv_mensal` |
| 5 | `integrations.contaazul_categorias` ⚠️ | `service_role_full_access` |
| 6 | `integrations.contaazul_centros_custo` ⚠️ | `service_role_full_access` |
| 7 | `meta.metas_desempenho_historico` | `service_role_full_metas_desempenho_historico` |
| 8 | `system.sync_contagem_historico` | `service_role_full_sync_contagem_historico` |
| 9 | `system.sync_metadata` | `service_role_full_sync_metadata` |

## 2 tabelas adiadas (Bucket C)
`operations.config_metas_planejamento` e `ops.job_camada_mapping` — padrao read/write split com cmds diferentes (read SELECT, write ALL). Overlap so em SELECT mas nao da pra DROP nenhuma sem perder funcionalidade. Adiado pra quando tivermos write-tests dedicados.

## Smoke (verde)
- 7 tabelas nao-contaazul: counts identicos antes/depois pros 3 roles (`authenticated`, `service_role`, `anon`).
- 2 contaazul: `authenticated` e `service_role` identicos (122/158); `anon` cai pra 0 (bug fechado conforme expectativa).

## Evidencia advisor
- Antes: `_advisor_snapshots/2026-04-24-perf-after-02.json` (66 findings `multiple_permissive_policies`).
- Depois: `_advisor_snapshots/2026-04-24-perf-after-03.json` (12 findings — 2 tabelas Bucket C adiadas x 6 roles).
- Total perf findings: 151 -> 97 (-54).

## Risco
- 🟢 Performance: baixo (`rolbypassrls=TRUE` confirmado via pg_roles).
- 🟢 Funcional: zero (smoke confirmou zero divergencia em authenticated/service_role).
- 🟢 Seguranca: positivo (fecha leak existente).

## Rollback
`database/migrations/2026-04-24-perf-consolidate-permissive-policies.rollback.sql` recria as 9 policies. **ATENCAO**: o rollback re-abre o bug em contaazul. Aplicar APENAS se a migration forward causar regressao funcional comprovada.

## Follow-ups
- `perf/04-autovacuum-tuning` (proxima fase)
- Bucket C — reavaliar quando tivermos write-tests
- **Auditar outras tabelas com `USING (true) + roles=public`** — bug em contaazul pode nao ser unico em todo o banco. Track `sec/*` separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)