### PR TITLE
perf/04: autovacuum tuning em silver.cliente_visitas + silver.tempos_producao

### DIFF
--- a/database/_advisor_snapshots/2026-04-25-perf04-bloat-before.json
+++ b/database/_advisor_snapshots/2026-04-25-perf04-bloat-before.json
@@ -1,0 +1,70 @@
+{
+  "captured_at": "2026-04-25",
+  "cluster_defaults": {
+    "autovacuum_vacuum_scale_factor": 0.2,
+    "autovacuum_analyze_scale_factor": 0.1,
+    "autovacuum_vacuum_threshold": 50,
+    "autovacuum_analyze_threshold": 50,
+    "autovacuum_naptime_s": 60
+  },
+  "tables": [
+    {
+      "schema": "operations",
+      "table": "eventos_base",
+      "n_live_tup": 959,
+      "n_dead_tup": 0,
+      "dead_pct": 0.00,
+      "last_vacuum": "2026-01-08 21:05:56-03",
+      "last_autovacuum": "2026-04-24 23:02:25-03",
+      "last_analyze": "2026-04-17 12:34:01-03",
+      "last_autoanalyze": "2026-04-24 23:01:26-03",
+      "vacuum_count": 4,
+      "autovacuum_count": 1677,
+      "analyze_count": 16,
+      "autoanalyze_count": 1466,
+      "total_size": "61 MB",
+      "reloptions": [
+        "autovacuum_vacuum_threshold=50",
+        "autovacuum_vacuum_scale_factor=0.05",
+        "autovacuum_analyze_scale_factor=0.02"
+      ],
+      "note": "JA TUNADO com os mesmos valores que o plano propunha. dead_pct=0%, autovacuum rodou 1677 vezes desde a configuracao. Nao precisa mudar."
+    },
+    {
+      "schema": "silver",
+      "table": "cliente_visitas",
+      "n_live_tup": 227962,
+      "n_dead_tup": 31576,
+      "dead_pct": 13.85,
+      "last_vacuum": null,
+      "last_autovacuum": "2026-04-19 21:10:24-03",
+      "last_analyze": null,
+      "last_autoanalyze": "2026-04-24 08:05:27-03",
+      "vacuum_count": 0,
+      "autovacuum_count": 5,
+      "analyze_count": 0,
+      "autoanalyze_count": 7,
+      "total_size": "228 MB",
+      "reloptions": null,
+      "note": "Defaults do cluster (scale_factor=0.2). Autovacuum so dispara aos 45k dead — alvo do tuning."
+    },
+    {
+      "schema": "silver",
+      "table": "tempos_producao",
+      "n_live_tup": 685908,
+      "n_dead_tup": 72914,
+      "dead_pct": 10.63,
+      "last_vacuum": null,
+      "last_autovacuum": "2026-04-22 07:30:20-03",
+      "last_analyze": "2026-04-17 12:33:53-03",
+      "last_autoanalyze": "2026-04-22 20:26:35-03",
+      "vacuum_count": 0,
+      "autovacuum_count": 13,
+      "analyze_count": 2,
+      "autoanalyze_count": 31,
+      "total_size": "207 MB",
+      "reloptions": null,
+      "note": "Defaults do cluster (scale_factor=0.2). Autovacuum so dispara aos 137k dead — alvo do tuning."
+    }
+  ]
+}

--- a/database/migrations/2026-04-25-perf04-autovacuum-tuning.rollback.sql
+++ b/database/migrations/2026-04-25-perf04-autovacuum-tuning.rollback.sql
@@ -1,0 +1,19 @@
+-- Rollback de 2026-04-25-perf04-autovacuum-tuning.sql.
+-- RESET volta os 2 parametros pros defaults do cluster (0.2 / 0.1).
+--
+-- Baseline pre-fix (capturado em 2026-04-25):
+--   silver.cliente_visitas reloptions = NULL  -> RESET equivale ao estado original.
+--   silver.tempos_producao reloptions = NULL  -> idem.
+--
+-- Aplicar APENAS se observarmos comportamento adverso em prod (autovacuum
+-- saturando I/O, etc). Validacao 24h-72h dos novos valores e pre-requisito.
+
+ALTER TABLE silver.cliente_visitas RESET (
+  autovacuum_vacuum_scale_factor,
+  autovacuum_analyze_scale_factor
+);
+
+ALTER TABLE silver.tempos_producao RESET (
+  autovacuum_vacuum_scale_factor,
+  autovacuum_analyze_scale_factor
+);

--- a/database/migrations/2026-04-25-perf04-autovacuum-tuning.sql
+++ b/database/migrations/2026-04-25-perf04-autovacuum-tuning.sql
@@ -1,0 +1,37 @@
+-- Tuning de autovacuum/autoanalyze em 2 silver tables high-churn.
+-- Pre-flight: database/_advisor_snapshots/2026-04-25-perf04-bloat-before.json
+--
+-- Cluster default: autovacuum_vacuum_scale_factor=0.2, analyze=0.1.
+-- Em tabelas grandes da camada silver isso significa lag enorme antes do
+-- autovacuum entrar (45k dead em cliente_visitas, 137k dead em tempos_producao).
+--
+-- Baseline em 2026-04-25:
+--   silver.cliente_visitas    : 228k rows, 13.85% dead, defaults (NULL reloptions)
+--   silver.tempos_producao    : 686k rows, 10.63% dead, defaults (NULL reloptions)
+--
+-- Valores escolhidos (mesmo padrao de operations.eventos_base, ja tunada
+-- out-of-band com 0.05/0.02 e operando com dead_pct=0%):
+--   autovacuum_vacuum_scale_factor  = 0.05  (dispara a 5% dead, 4x mais cedo)
+--   autovacuum_analyze_scale_factor = 0.02  (analyze a 2%, plano sempre fresco)
+--
+-- Out of scope:
+--   - operations.eventos_base: ja esta tunada com mesmos valores (dead_pct=0%).
+--     A reloption foi aplicada out-of-band, sem migration no historico
+--     (anotado em task #40 pra investigacao).
+--   - VACUUM FULL / pg_repack pra bloat fisico: lock pesado, exige janela
+--     fora de horario comercial. Ver task #41.
+--
+-- Validacao imediata: pg_class.reloptions deve mostrar os 2 parametros novos.
+-- Validacao 24h: dead_pct deve cair (<5% conforme novo threshold).
+-- Snapshot pos: database/_advisor_snapshots/2026-04-26-perf04-bloat-after.json
+-- (task #11).
+
+ALTER TABLE silver.cliente_visitas SET (
+  autovacuum_vacuum_scale_factor = 0.05,
+  autovacuum_analyze_scale_factor = 0.02
+);
+
+ALTER TABLE silver.tempos_producao SET (
+  autovacuum_vacuum_scale_factor = 0.05,
+  autovacuum_analyze_scale_factor = 0.02
+);


### PR DESCRIPTION
## Contexto
Cluster default: `autovacuum_vacuum_scale_factor=0.2` (autovacuum so dispara aos 20% dead). Em silver tables grandes da camada medallion isso significa lag substancial antes de o autovacuum entrar.

Baseline em 2026-04-25 ([snapshot](../blob/perf/04-autovacuum-tuning/database/_advisor_snapshots/2026-04-25-perf04-bloat-before.json)):

| Tabela | Live | Dead | %Dead | Tamanho | reloptions atuais |
|---|---:|---:|---:|---|---|
| `silver.cliente_visitas` | 227.962 | 31.576 | **13,85%** | 228 MB | NULL (defaults) |
| `silver.tempos_producao` | 685.908 | 72.914 | **10,63%** | 207 MB | NULL (defaults) |

## Fix aplicado
`ALTER TABLE ... SET` em ambas com os mesmos valores que `operations.eventos_base` ja usa (ver "Out of scope" abaixo):

```sql
ALTER TABLE silver.cliente_visitas SET (
  autovacuum_vacuum_scale_factor = 0.05,
  autovacuum_analyze_scale_factor = 0.02
);

ALTER TABLE silver.tempos_producao SET (
  autovacuum_vacuum_scale_factor = 0.05,
  autovacuum_analyze_scale_factor = 0.02
);
```

## Math check (threshold de dead tuples antes de autovacuum)

| Tabela | Default (0.2) | Novo (0.05) | Multiplicador |
|---|---:|---:|---:|
| `cliente_visitas` (228k rows) | ~45.6k | ~11.4k | **4x mais cedo** |
| `tempos_producao` (686k rows) | ~137k | ~34k | **4x mais cedo** |

`autovacuum_vacuum_threshold` mantem o default (50) — em tabelas dessa escala e desprezivel diante do scale_factor.

## Validacao imediata (verde)

`pg_class.reloptions` confirma os 2 parametros novos em ambas tabelas:

```
silver.cliente_visitas → {autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.02}
silver.tempos_producao → {autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.02}
```

## Validacao 24h (pendente)

**Task #11**: capturar `database/_advisor_snapshots/2026-04-26-perf04-bloat-after.json` em ~24h apos merge e comparar `dead_pct` + `last_autovacuum`. Esperado:
- `dead_pct` cai pra <5% nas 2 tables (autovacuum disparando aos 5% em vez de 20%).
- `last_autovacuum` mais recente que o baseline.

VACUUM ANALYZE manual nao foi rodado — invasivo em horario comercial dos bares (228 MB / 207 MB exigem I/O significativo). O proximo trigger natural pega os novos parametros.

## Out of scope

### `operations.eventos_base` removido do escopo
Esta tabela **ja estava tunada** com exatamente os mesmos valores propostos (`scale_factor=0.05`, `analyze=0.02`):
- `dead_pct=0%` atualmente.
- 1677 autovacuums desde a configuracao (heavy churn por triggers `calcular_real_r` + `fill_semana_on_insert`).

**Anti-pattern descoberto**: as reloptions de `eventos_base` foram aplicadas **out-of-band** — nao existem em nenhum arquivo de `database/migrations/`. Mesmo problema de drift visto na Fase 1 (composite index em `contaazul_lancamentos`). Anotado como **task #40** pra investigar quem/quando aplicou e eventualmente materializar em migration retroativa.

### `table_bloat` advisor finding em `eventos_base`
Bloat **fisico** (relpages > esperado), nao dead tuples. Autovacuum nao resolve — so `VACUUM FULL` ou `pg_repack`, ambos exigem janela sem trafego. Anotado como **task #41**.

## Rollback
[`2026-04-25-perf04-autovacuum-tuning.rollback.sql`](../blob/perf/04-autovacuum-tuning/database/migrations/2026-04-25-perf04-autovacuum-tuning.rollback.sql) usa `RESET` — volta aos defaults do cluster (estado original era `NULL`/defaults). Aplicar APENAS se observarmos comportamento adverso (autovacuum saturando I/O, etc) apos validacao 24h-72h.

## Risco
- 🟢 Funcional: zero. Nao altera dados, so reduz threshold de quando o autovacuum dispara.
- 🟢 Performance: positivo no medio prazo (menos bloat, planos com estatisticas mais frescas).
- 🟡 Operacional: I/O do autovacuum acontece com mais frequencia — overhead pequeno em tabelas dessa escala, mas observavel se houver problema de capacity.

## Follow-ups
- **Task #11**: re-snapshot 24h pos-merge (esta PR).
- **Task #40**: investigar reloptions out-of-band em `operations.eventos_base`.
- **Task #41**: VACUUM FULL / pg_repack pra bloat fisico em `eventos_base` (janela agendada).
- **Task #31**: `perf/05-unused-indexes` (75 findings INFO no advisor) — proxima fase de performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)