### PR TITLE
chore: remove unused findById method from BaresRepository

### DIFF
--- a/frontend/src/lib/repositories/bares.repo.ts
+++ b/frontend/src/lib/repositories/bares.repo.ts
@@ -10,19 +10,6 @@ import type { Bar, BarConfigOperacao } from '@/lib/domain/bar.types';
 export class BaresRepository {
   constructor(private client: SupabaseClient) {}
 
-  /** Busca dados basicos de um bar. */
-  async findById(id: number): Promise<Bar | null> {
-    const { data, error } = await this.client
-      .schema('operations')
-      .from('bares')
-      .select('id, nome, ativo')
-      .eq('id', id)
-      .maybeSingle();
-
-    if (error) throw new RepositoryError('bares.findById', error);
-    return (data as Bar | null) ?? null;
-  }
-
   /** Lista bares ativos por ids. */
   async findActiveByIds(ids: number[]): Promise<Bar[]> {
     if (ids.length === 0) return [];


### PR DESCRIPTION
## O que
Remove `BaresRepository.findById()` — método sem callers no codebase.

## Por que
Auditoria em #39 (2026-04-25) com grep canônico por método via `bares.<método>`:

| Método | Callers | Status |
|---|---|---|
| `findById` | **0 hits** | ✅ Dead — removido neste PR |
| `findActiveByIds` | 1 hit (`listar-bares-do-usuario.ts:35`) | ❌ Vivo — preservado |
| `getConfigOperacao` | 1 hit (`listar-planejamento.ts:39`) | ❌ Vivo — preservado |

Cobertura paranoica de aliases (`const { bares: <alias> }`) também rodou — zero matches. Cobertura limpa.

## Não-mudança
- Classe `BaresRepository` permanece
- Factory `repos()` em `index.ts` permanece
- 2 métodos vivos intocados
- Login flow (que usa `findActiveByIds`) intocado
- Planejamento comercial (que usa `getConfigOperacao`) intocado

## Validação
- `npm run build`: ✅ clean
- `npx tsc --noEmit`: ✅ clean (sem erros TypeScript)
- Smoke `rg "bares\.findById" src/`: ✅ zero hits
- Diff: `-11 / +0` linhas

## Risco
🟢 Baixíssimo — código não-executado sendo removido. Sem mudança em comportamento runtime.

## Contexto histórico
Pre-flight de PRs anteriores (sec/01 #13) afirmaram incorretamente que `BaresRepository` seria dead code completo. Auditoria de #39 corrigiu: a classe é usada em 6 callers via factory pattern + destructuring (que o grep direto em `BaresRepository` não pega). Comentário retroativo adicionado ao PR #13. Lição salva pra futuras auditorias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)