### PR TITLE
docs(domain-map): refresh para realidade pós-medallion (#29)

### DIFF
--- a/database/DOMAIN_MAP.md
+++ b/database/DOMAIN_MAP.md
@@ -1,278 +1,335 @@
 # Mapa de Domínios — Zykor
 
-## Visão Geral do Sistema
+> **Última revisão:** 2026-04-25 (post-medallion migration)
+> Counts e tamanhos abaixo são **ordem de magnitude**. Consultar números reais com as queries inline antes de tomar decisões críticas.
+
+---
+
+## 1. Visão Geral do Sistema
 
 ```
 SGB v2.0 — Sistema de Gestão de Bares
-├── Ordinário Bar (bar_id=3) — operação completa, GetIn, 850 pessoas
+├── Ordinário Bar (bar_id=3) — operação completa, GetIn, ~850 pessoas
 └── Deboche Bar (bar_id=4) — operação simplificada, fechado segundas
 ```
 
-**Stack**: Next.js 15 + Supabase Edge Functions (Deno) + PostgreSQL + pg_cron
+**Stack**: Next.js 15 + Supabase Edge Functions (Deno) + PostgreSQL 17 + pg_cron
 
 ---
 
-## Fluxo de Dados (5 camadas)
+## 2. Arquitetura de Schemas
 
+> Para a fonte da verdade no frontend, ver [`frontend/src/lib/supabase/table-schemas.ts`](../frontend/src/lib/supabase/table-schemas.ts) — mapa `tabela → schema` usado pelo helper `tbl()` e `schemaOf()`.
+
+Para listar todos os schemas e seus counts atuais:
+```sql
+SELECT schemaname, COUNT(*) AS tables
+FROM pg_tables
+WHERE schemaname NOT IN ('pg_catalog','information_schema','pg_toast',
+  'extensions','graphql','graphql_public','realtime','storage','vault',
+  'auth','pgsodium','pgsodium_masks','net','supabase_functions')
+GROUP BY schemaname ORDER BY tables DESC;
 ```
-CAMADA 1: INGESTÃO (APIs externas → banco)
-    │
-CAMADA 2: PROCESSAMENTO (raw → tipado)
-    │
-CAMADA 3: CÁLCULO (tipado → métricas por evento)
-    │
-CAMADA 4: AGREGAÇÃO (métricas → KPIs semanais)
-    │
-CAMADA 5: CONSUMO (KPIs → dashboards, AI, relatórios)
+
+### 2.1 Medallion (`bronze` / `silver` / `gold`)
+
+Camadas de processamento de dados externos (principalmente ContaHub) seguindo o pattern medallion da Databricks. Sentido do fluxo: **bronze → silver → gold → consumo**.
+
+| Schema | ~Tables | Purpose | Exemplos |
+|--------|--------:|---------|----------|
+| `bronze` | ~35 | Raw data ingerido sem transformação. JSONB blobs ou tabelas estruturadas espelhando a fonte 1:1. Cobre ContaHub, ContaAzul, GetIn, Sympla, Umbler, Yuzer, Google Reviews, Falaê. | `bronze.bronze_contahub_raw_data`, `bronze.bronze_contahub_avendas_porproduto_analitico`, `bronze.bronze_contaazul_lancamentos`, `bronze.bronze_yuzer_eventos` |
+| `silver` | ~17 | Bronze processado: tipado, deduplicado, enriquecido com `bar_id`. **Source of truth para queries operacionais.** | `silver.tempos_producao`, `silver.faturamento_pagamentos`, `silver.vendas_item`, `silver.cliente_visitas`, `silver.cliente_estatisticas`, `silver.reservantes_perfil` |
+| `gold` | ~5 | Agregações analíticas pré-calculadas pra dashboards. | `gold.gold_contahub_avendas_porproduto_analitico`, `gold.gold_contahub_avendas_vendasperiodo`, `gold.gold_contahub_operacional_stockout`, `gold.gold_contahub_produtos_temposproducao` |
+
+> **Tabelas pré-medallion (extintas)**: `contahub_analitico`, `contahub_tempo`, `contahub_pagamentos`, `contahub_periodo`, `contahub_fatporhora`, `contahub_vendas`, `contahub_stockout` foram **substituídas** pelo medallion. Equivalências aproximadas:
+> - `contahub_analitico` → `silver.vendas_item` + `bronze.bronze_contahub_avendas_porproduto_analitico`
+> - `contahub_tempo` → `silver.tempos_producao` + `bronze.bronze_contahub_produtos_temposproducao`
+> - `contahub_pagamentos` → `silver.faturamento_pagamentos` + `bronze.bronze_contahub_financeiro_pagamentosrecebidos`
+> - `contahub_periodo` → `bronze.bronze_contahub_avendas_vendasperiodo`
+> - `contahub_stockout` → `gold.gold_contahub_operacional_stockout`
+
+### 2.2 Schemas Operacionais
+
+| Schema | ~Tables | Purpose | Tabelas-chave |
+|--------|--------:|---------|---------------|
+| `operations` | ~23 | Core operacional do bar — eventos, mesas, contagem, checklist, configurações de bar. | `operations.eventos_base`, `operations.bares`, `operations.bares_config`, `operations.contagem_estoque_insumos`, `operations.checklist_*` |
+| `financial` | ~14 | Financeiro: caixa, DRE manual, CMV, orçamentação, PIX. | `financial.dre_manual`, `financial.cmv_semanal`, `financial.cmv_mensal`, `financial.orcamentacao`, `financial.caixa_*`, `financial.pix_enviados` |
+| `system` | ~22 | Logs, alertas, notificações, audit trail, sync metadata, uploads. Service-role-heavy. | `system.system_logs`, `system.notificacoes`, `system.cron_heartbeats`, `system.automation_logs`, `system.audit_trail` |
+| `integrations` | ~26 | APIs externas: ContaAzul, Umbler, Sympla, Yuzer, GetIn, Google Reviews, Falaê. Cada vendor tem suas próprias tabelas. | `integrations.contaazul_lancamentos`, `integrations.umbler_conversas`, `integrations.sympla_pedidos`, `integrations.yuzer_*`, `integrations.getin_reservations`, `integrations.google_reviews` |
+| `meta` | ~11 | Metas, marketing, planejamento estratégico, OKRs. | `meta.metas_anuais`, `meta.metas_desempenho_historico`, `meta.marketing_semanal`, `meta.organizador_okrs`, `meta.semanas_referencia` |
+| `agent_ai` | ~15 | AI agent — alertas, conversas, insights, métricas, padrões detectados, memória vetorial. | `agent_ai.agent_insights_v2`, `agent_ai.agente_alertas`, `agent_ai.agente_conversas`, `agent_ai.agente_memoria_vetorial` |
+| `crm` | ~8 | CRM — NPS, voz do cliente, segmentação, perfis de consumo. | `crm.nps`, `crm.nps_falae_diario_pesquisa`, `crm.voz_cliente`, `crm.crm_segmentacao` |
+| `hr` | ~7 | RH — funcionários, contratos, folha, pesquisa de felicidade, áreas, cargos. | `hr.funcionarios`, `hr.contratos_funcionario`, `hr.folha_pagamento`, `hr.pesquisa_felicidade` |
+| `auth_custom` | ~4 | Autenticação custom — usuários da app, vínculo usuário↔bar, empresas, grupos. | `auth_custom.usuarios`, `auth_custom.usuarios_bares`, `auth_custom.empresas` |
+| `ops` | 1 | Observability — mapeamento de jobs/edge functions a camadas medallion. Schema novo (criado em commit `13f6072e`, abril/2026). | `ops.job_camada_mapping` |
+
+### 2.3 `public` — Legacy
+
+5 tabelas remanescentes em `public` (de ~229 originais antes da migração de schemas). Não criar novas tabelas aqui.
+
+```sql
+SELECT relname FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+WHERE n.nspname='public' AND c.relkind='r' ORDER BY relname;
 ```
+
+| Tabela | Status |
+|--------|--------|
+| `public.usuarios`, `public.usuarios_bares` | **Espelho** de `auth_custom.usuarios_bares` (conteúdo idêntico — verificado, sem drift). RLS helper `public.user_has_bar_access()` lê daqui. Investigação tracked em task #44 (eventual collapse via view-alias). |
+| `public.api_credentials` | Resíduo da migração (também existe em `integrations`). Tracked em task de cleanup. |
+| `public.cmv_manual` | Legacy — consolidação CMV manual antiga. |
+| `public.view_top_produtos_legacy_snapshot` | Snapshot histórico, marcada como legacy no nome. |
+
+### 2.4 Como descobrir o schema certo
+
+1. **Frontend (browser/server-side TypeScript)**: usar `tbl()` e `schemaOf()` de [`frontend/src/lib/supabase/table-schemas.ts`](../frontend/src/lib/supabase/table-schemas.ts):
+   ```ts
+   import { tbl } from '@/lib/supabase/table-schemas';
+   const { data } = await tbl(supabase, 'eventos_base').select('*').eq('bar_id', barId);
+   ```
+2. **Backend (edge functions / scripts)**: usar `.schema('<schema>')` explicitamente:
+   ```ts
+   await supabase.schema('operations').from('eventos_base').select('*');
+   ```
+3. **SQL direto**: prefixar o schema (`SELECT ... FROM operations.eventos_base`).
+4. **Convenções de naming**: ver [`database/CONVENTIONS.md`](CONVENTIONS.md) para prefixos/sufixos.
 
 ---
 
-## Camada 1: Ingestão
+## 3. Fluxo de Dados (5 camadas)
 
-Dados entram via edge functions chamadas por pg_cron.
+### Camada 1: Ingestão
 
-> Horários abaixo são do snapshot de 2026-03-19. Podem mudar — verificar com `SELECT * FROM cron.job WHERE active = true`.
+Dados entram via edge functions chamadas por `pg_cron`.
 
-| Fonte | Edge Function | Frequência | Tabela Destino | Volume |
-|-------|--------------|------------|----------------|--------|
-| ContaHub API | `contahub-sync-automatico` | 2x/dia (04:00, 19:00 BRT) | `contahub_raw_data` | ~1.2K rows (staging) |
-| NIBO API | `nibo-sync` | 2x/dia (05:00, 19:00 BRT) | `nibo_agendamentos` | 50K rows |
-| GetIn API v2 | `getin-sync-continuous` | Cada 4h | `getin_reservations` | 5K rows |
-| Google Sheets | `google-sheets-sync` | 1x/dia (02:00 BRT) | `nps`, `nps_reservas`, `voz_cliente`, `pesquisa_felicidade` | ~10K rows total |
-| Google Sheets | `sync-cmv-sheets` | 1x/dia (05:00 BRT) | `cmv_semanal` | 163 rows |
-| Google Sheets | `sync-contagem-sheets` | 1x/dia | `contagem_estoque_insumos` | 199K rows |
-| Apify | `google-reviews-apify-sync` | 1x/dia (06:00 BRT) | `google_reviews` | 9.5K rows |
-| Sympla API | `integracao-dispatcher` | On-demand | `sympla_eventos`, `sympla_pedidos`, `sympla_participantes` | 30K rows total |
-| Umbler/WhatsApp | `webhook-dispatcher` | Webhook real-time | `umbler_conversas`, `umbler_mensagens` | 48K rows total |
-| Windsor | Externo | Periódico | `windsor_google`, `windsor_instagram_*` | 24K rows total |
-| Manual (frontend) | API routes Next.js | User action | `eventos_base`, `dre_manual`, `folha_pagamento` | Variável |
+| Fonte | Edge Function | Frequência | Schema/Tabela Destino | Volume |
+|-------|--------------|------------|------------------------|--------|
+| ContaHub API | `contahub-sync-automatico` | 2x/dia (04:00, 19:00 BRT) | `bronze.bronze_contahub_raw_data` | ~5K rows (staging JSONB) |
+| ContaAzul API | `contaazul-sync` | Periódico | `bronze.bronze_contaazul_lancamentos` → `integrations.contaazul_lancamentos` | ~74K rows |
+| GetIn API v2 | `getin-sync-continuous` | Cada 4h | `integrations.getin_reservations` | ~5K rows |
+| Google Sheets | `google-sheets-sync` | 1x/dia (02:00 BRT) | `crm.nps`, `crm.nps_reservas`, `crm.voz_cliente`, `hr.pesquisa_felicidade` | ~10K rows |
+| Google Sheets | `sync-cmv-sheets` | 1x/dia (05:00 BRT) | `financial.cmv_semanal` | ~163 rows |
+| Google Sheets | `sync-contagem-sheets` | 1x/dia | `operations.contagem_estoque_insumos` | ~200K rows |
+| Apify (Google Reviews) | `google-reviews-apify-sync` | 1x/dia (06:00 BRT) | `integrations.google_reviews` | ~10K rows |
+| Sympla API | `integracao-dispatcher` | On-demand | `integrations.sympla_eventos`, `sympla_pedidos`, `sympla_participantes` | ~30K rows |
+| Umbler/WhatsApp | `webhook-dispatcher` | Webhook real-time | `integrations.umbler_conversas`, `umbler_mensagens` | ~50K rows |
+| Yuzer | Externo + bronze | Periódico | `bronze.bronze_yuzer_*` → `integrations.yuzer_*` | ~5K rows |
+| Manual (frontend) | API routes Next.js | User action | `operations.eventos_base`, `financial.dre_manual`, `hr.folha_pagamento` | Variável |
 
----
+> **Nota NIBO → ContaAzul**: o sistema migrou de NIBO para ContaAzul em **2026-03-24** (migration `database/migrations/20260324_contaazul_tables.sql`). As tabelas `nibo_agendamentos`, `nibo_categorias`, `nibo_centros_custo`, `nibo_stakeholders`, `nibo_logs_sincronizacao` foram **substituídas** pelo conjunto `integrations.contaazul_*`. Equivalência: `nibo_agendamentos` ≈ `integrations.contaazul_lancamentos`. Quem busca "NIBO" no código provavelmente quer um dos 6 ContaAzul.
 
-## Camada 2: Processamento
+### Camada 2: Processamento (Bronze → Silver)
 
-Raw JSON → tabelas tipadas. Chamadas por `contahub-processor` edge function.
+Edge function `contahub-processor` lê do `bronze` e escreve em `silver`. Mesma lógica para ContaAzul, Yuzer, Sympla.
 
 ```
-contahub_raw_data (JSON blob)
+bronze.bronze_contahub_raw_data (JSONB blob)
     │
-    ├── process_analitico_data()  → contahub_analitico   (797K rows, 48MB)
-    ├── process_tempo_data()      → contahub_tempo        (603K rows, 36MB)
-    ├── process_pagamentos_data() → contahub_pagamentos   (216K rows, 12MB)
-    ├── process_periodo_data()    → contahub_periodo       (212K rows, 12MB)
-    └── process_fatporhora_data() → contahub_fatporhora    (8K rows, 256KB)
+    ├── process_analitico_data()    → silver.vendas_item
+    ├── process_tempo_data()        → silver.tempos_producao
+    ├── process_pagamentos_data()   → silver.faturamento_pagamentos
+    └── process_*_data()            → silver.* (etc)
+
+bronze.bronze_contahub_avendas_porproduto_analitico
+    └── (Já tipado, sem processor adicional — bronze já é consumível)
+
+bronze.bronze_yuzer_*           → integrations.yuzer_*  (sync direto)
+bronze.bronze_contaazul_*       → integrations.contaazul_* (sync direto)
 ```
 
-Triggers automáticos na inserção:
-- `set_categoria_mix_contahub_analitico` → categoriza em BEBIDA/COMIDA/DRINK
-- `set_categoria_mix_contahub_stockout` → categoriza stockout
+Triggers automáticos em `silver.vendas_item` e equivalentes:
+- `set_categoria_mix_*` → categoriza em BEBIDA / COMIDA / DRINK
 - `map_categoria_tempo` → mapeia categoria de tempo
 
----
+### Camada 3: Cálculo por Evento
 
-## Camada 3: Cálculo por Evento
-
-`calculate_evento_metrics()` é chamada manualmente ou por recálculo batch — **não por triggers automáticos nas tabelas ContaHub** (os triggers de auto-recálculo via tabelas-fonte que existiam no repo foram removidos de produção).
+`calculate_evento_metrics(evento_id)` é chamada manualmente ou por recálculo batch.
 
 ```
-contahub_analitico ────┐
-contahub_tempo ────────┤
-contahub_pagamentos ───┤
-contahub_periodo ──────┤
-contahub_fatporhora ───┤──→ calculate_evento_metrics(evento_id)
-nibo_agendamentos ─────┤       │
-yuzer_fatporhora ──────┤       │ calcula 30+ campos:
-yuzer_pagamento ───────┤       │ cl_real, real_r, te_real, tb_real,
-sympla_pedidos ────────┤       │ percent_b/c/d, t_coz, t_bar,
-getin_reservations ────┘       │ fat_19h_percent, c_art, c_prod,
-                               │ percent_art_fat, res_tot, res_p,
-                               │ lot_max, sympla_liquido, yuzer_liquido
-                               ▼
-                         eventos_base (833 rows, 71 colunas)
+silver.vendas_item ───────────┐
+silver.tempos_producao ───────┤
+silver.faturamento_pagamentos ┤
+bronze.bronze_contahub_*      ┤──→ calculate_evento_metrics(evento_id)
+integrations.contaazul_lancamentos ─┤       │
+integrations.yuzer_fatporhora ──────┤       │ calcula 30+ campos:
+integrations.yuzer_pagamento ───────┤       │ cl_real, real_r, te_real, tb_real,
+integrations.sympla_pedidos ────────┤       │ percent_b/c/d, t_coz, t_bar,
+integrations.getin_reservations ────┘       │ fat_19h_percent, c_art, c_prod, …
+                                            ▼
+                              operations.eventos_base (~960 rows, 71 colunas)
 ```
 
-Triggers auxiliares em `eventos_base`:
-- `calcular_real_r` → calcula `real_r` (faturamento real = ContaHub + Sympla + Yuzer)
-- `fill_semana_on_insert` → preenche `semana` (ISO week number)
+Triggers em `operations.eventos_base`:
+- `calcular_real_r` → `real_r` = ContaHub + Sympla + Yuzer
+- `fill_semana_on_insert` → preenche ISO week number
 
----
+### Camada 4: Agregação Semanal
 
-## Camada 4: Agregação Semanal
-
-`recalcular-desempenho-v2` (edge function, pg_cron diário 08:00 BRT) agrega tudo em KPIs semanais.
+`recalcular-desempenho-v2` (edge function, `pg_cron` diário 08:00 BRT).
 
 ```
-eventos_base ────────────────┐
-nibo_agendamentos ───────────┤
-nps_agregado_semanal (VIEW) ─┤
-contahub_fatporhora ─────────┤
-contahub_cancelamentos ──────┤──→ 6 calculators independentes:
-contahub_periodo ────────────┤       calc-faturamento
-                             │       calc-custos
-RPCs:                        │       calc-operacional (4 RPCs)
-  calcular_stockout_semanal ─┤       calc-satisfacao (2 RPCs)
-  calcular_mix_vendas ───────┤       calc-distribuicao
-  calcular_tempo_saida ──────┤       calc-clientes (2 RPCs)
-  calcular_atrasos_tempo ────┤           │
-  get_google_reviews_*  ─────┤           ▼
-  calcular_nps_semanal_* ────┤   desempenho_semanal
-  calcular_metricas_clientes ┤   (128 rows, 147 colunas)
-  get_count_base_ativa ──────┘
+operations.eventos_base ─────┐
+integrations.contaazul_lancamentos ─┤
+crm.nps_agregado_semanal (VIEW) ────┤
+silver.faturamento_pagamentos ──────┤──→ 6 calculators:
+                                    │       calc-faturamento, calc-custos,
+RPCs:                               │       calc-operacional (4 RPCs),
+  calcular_stockout_semanal         │       calc-satisfacao (2 RPCs),
+  calcular_mix_vendas               │       calc-distribuicao,
+  calcular_tempo_saida              │       calc-clientes (2 RPCs)
+  calcular_atrasos_tempo            │           │
+  get_google_reviews_stars_by_date  │           ▼
+  calcular_nps_semanal_*            │   meta.metas_desempenho_historico
+  calcular_metricas_clientes        │   (~130 rows × 147 colunas — god table)
+  get_count_base_ativa ─────────────┘
 ```
 
 Outros agregadores:
-- `cmv-semanal-auto` → `cmv_semanal` (CMV = Est.Inicial + Compras - Est.Final - Consumos + Bonificações)
-- `sync-cmv-mensal` → `cmv_mensal` (consolidação mensal)
+- `cmv-semanal-auto` → `financial.cmv_semanal`
+- `sync-cmv-mensal` → `financial.cmv_mensal`
 
----
-
-## Camada 5: Consumo
+### Camada 5: Consumo
 
 ```
-desempenho_semanal ──┬── /estrategico/desempenho (dashboard principal)
-                     ├── /estrategico/visao-geral (overview executivo)
-                     ├── /estrategico/orcamentacao (budgeting)
-                     ├── agente-dispatcher → Gemini AI → Discord (análise diária/semanal/mensal)
-                     ├── alertas-dispatcher → Discord (alertas proativos)
-                     └── relatorio-pdf → Discord (relatórios PDF)
+meta.metas_desempenho_historico ──┬── /estrategico/desempenho
+                                  ├── /estrategico/visao-geral
+                                  ├── /estrategico/orcamentacao
+                                  ├── agente-dispatcher → Gemini AI → Discord
+                                  ├── alertas-dispatcher → Discord
+                                  └── relatorio-pdf → Discord
 
-eventos_base ────────┬── /ferramentas/calendario (calendário operacional)
-                     ├── /analitico/eventos (análise de eventos)
-                     └── /analitico/atracoes (análise de atrações)
+operations.eventos_base ──────────┬── /ferramentas/calendario
+                                  ├── /analitico/eventos
+                                  └── /analitico/atracoes
 
-cmv_semanal ─────────── /ferramentas/cmv-semanal (dashboard CMV)
-
-google_reviews ──────── /analitico/ (reviews)
-
-nps + voz_cliente ───── /crm/ (CRM dashboards)
-
-umbler_conversas ────── /crm/conversas (WhatsApp)
+financial.cmv_semanal ──────────────── /ferramentas/cmv-semanal
+integrations.google_reviews ────────── /analitico/ (reviews)
+crm.nps + crm.voz_cliente ──────────── /crm/ (CRM dashboards)
+integrations.umbler_conversas ──────── /crm/conversas (WhatsApp)
+financial.dre_manual ────────────────── /operacional/dre, /ferramentas/dre
 ```
 
 ---
 
-## Tabelas Críticas (Top 10 por impacto — snapshot 2026-03-19)
+## 4. Tabelas Críticas (Top por volume)
 
-> Volumes crescem diariamente. Consultar tamanhos atuais com:
+> Volumes mudam diariamente. Consultar atual com:
 > ```sql
-> SELECT relname, n_live_tup, pg_size_pretty(pg_total_relation_size(relid))
-> FROM pg_stat_user_tables WHERE schemaname = 'public' ORDER BY n_live_tup DESC LIMIT 15;
+> SELECT schemaname, relname, n_live_tup,
+>        pg_size_pretty(pg_total_relation_size((schemaname||'.'||relname)::regclass)) AS size
+> FROM pg_stat_user_tables
+> WHERE schemaname IN ('bronze','silver','gold','operations','financial','system','integrations','meta','agent_ai','crm','hr','auth_custom','public','ops')
+> ORDER BY n_live_tup DESC LIMIT 20;
 > ```
 
-| # | Tabela | Rows (mar/26) | Colunas | Tamanho | Por que é crítica |
-|---|--------|------|---------|---------|-------------------|
-| 1 | `contahub_analitico` | 797K | 29 | 48MB | Maior tabela. Fonte de faturamento, mix, categorias. |
-| 2 | `contahub_tempo` | 603K | 39 | 36MB | Tempos de preparo e entrega. Alimenta atrasos. |
-| 3 | `contahub_pagamentos` | 216K | 29 | 12MB | Formas de pagamento. Alimenta real_r e DRE. |
-| 4 | `contahub_periodo` | 212K | 28 | 12MB | Público, couvert, comissão. Alimenta cl_real. |
-| 5 | `contagem_estoque_insumos` | 199K | 23 | 18MB | Contagem de estoque. Alimenta CMV. |
-| 6 | `contahub_vendas` | 135K | 72 | 8.2MB | Detalhamento de vendas por produto. |
-| 7 | `cliente_estatisticas` | 84K | 17 | 2.5MB | Estatísticas de clientes (CRM). |
-| 8 | `nibo_agendamentos` | 50K | 50 | 3.2MB | Despesas e receitas. Alimenta custo_atracao. |
-| 9 | `contahub_stockout` | 37K | 49 | 2.1MB | Disponibilidade de produtos. |
-| 10 | `desempenho_semanal` | 128 | **147** | 256KB | God table. 147 colunas. Alimenta TUDO downstream. |
+| # | Tabela | ~Rows | ~Size | Por que é crítica |
+|---|--------|------:|-------|-------------------|
+| 1 | `silver.vendas_item` | 915K | 401 MB | Fonte de faturamento, mix de produtos. |
+| 2 | `bronze.bronze_contahub_avendas_porproduto_analitico` | 840K | 221 MB | Bronze do analítico ContaHub. |
+| 3 | `silver.tempos_producao` | 645K | 207 MB | Tempos de preparo/entrega. Alimenta atrasos. Tunada em `perf/04` (`scale_factor=0.05`). |
+| 4 | `bronze.bronze_contahub_produtos_temposproducao` | 619K | 169 MB | Bronze de tempos. |
+| 5 | `silver.faturamento_pagamentos` | 237K | 51 MB | Formas de pagamento. Alimenta `real_r` e DRE. |
+| 6 | `bronze.bronze_contahub_avendas_vendasperiodo` | 229K | 55 MB | |
+| 7 | `bronze.bronze_contahub_financeiro_pagamentosrecebidos` | 221K | 72 MB | |
+| 8 | `silver.cliente_visitas` | 220K | 228 MB | Tunada em `perf/04`. |
+| 9 | `operations.contagem_estoque_insumos` | 202K | 65 MB | Alimenta CMV. |
+| 10 | `integrations.contaazul_lancamentos` | 75K | 172 MB | Substitui `nibo_agendamentos`. Despesas/receitas. |
+| 11 | `gold.gold_contahub_operacional_stockout` | 55K | 163 MB | Stockout pré-agregado. |
+| 12 | `meta.metas_desempenho_historico` | ~130 | <1 MB | God table — 147 colunas. Alimenta TUDO downstream. |
 
 ---
 
-## Cadeia de Dependências Completa
+## 5. Cron Jobs Ativos (pg_cron)
 
-```
-NIVEL 0: Triggers de categorização
-  set_categoria_mix_contahub_analitico    ← contahub_analitico INSERT/UPDATE
-  set_categoria_mix_contahub_stockout     ← contahub_stockout INSERT/UPDATE
-  map_categoria_tempo                     ← contahub_tempo INSERT/UPDATE
-
-NIVEL 1: Triggers em eventos_base
-  calcular_real_r                         ← eventos_base INSERT/UPDATE
-  fill_semana_on_insert                   ← eventos_base INSERT/UPDATE
-
-NIVEL 2: Cálculo por evento
-  calculate_evento_metrics(evento_id)     ← chamado por triggers ou manual
-    Lê: contahub_analitico, contahub_tempo, contahub_pagamentos,
-        contahub_periodo, contahub_fatporhora, nibo_agendamentos,
-        yuzer_fatporhora, yuzer_pagamento, sympla_pedidos, getin_reservations
-    Escreve: eventos_base (30+ campos calculados)
-
-NIVEL 3: Agregação semanal
-  recalcular-desempenho-v2 (edge function)
-    Lê: eventos_base, nibo_agendamentos, nps_agregado_semanal,
-        contahub_fatporhora, contahub_cancelamentos, contahub_periodo
-    Chama 8 RPCs: calcular_stockout_semanal, calcular_mix_vendas,
-                  calcular_tempo_saida, calcular_atrasos_tempo,
-                  get_google_reviews_stars_by_date,
-                  calcular_nps_semanal_por_pesquisa,
-                  calcular_metricas_clientes, get_count_base_ativa
-    Escreve: desempenho_semanal (147 colunas)
-
-NIVEL 4: Consumo
-  dashboards, AI agents, relatórios, alertas
-    Lê: desempenho_semanal, eventos_base, cmv_semanal
-```
-
-Se NIVEL 0 falha → NIVEL 2 calcula errado → NIVEL 3 propaga → NIVEL 4 mostra dados falsos.
-
----
-
-## Cron Jobs Ativos (pg_cron)
-
-> **Esta tabela é um snapshot de 2026-03-19.** Cron jobs mudam com frequência. Para ver o estado real, executar:
+> Snapshot de 2026-04-25. Cron jobs mudam com frequência. Estado real:
 > ```sql
 > SELECT jobname, schedule, active FROM cron.job WHERE active = true ORDER BY jobname;
 > ```
 
 | Horário BRT | Job | Edge Function | Criticidade |
 |-------------|-----|--------------|-------------|
-| 02:00 | google-sheets-sync | `google-sheets-sync` | MEDIA |
-| 04:00 | contahub-daily-sync | `contahub-sync-automatico` | CRITICA |
-| 04:10 | contahub-processor-1 | `contahub-processor` | CRITICA |
-| 04:25 | contahub-processor-2 | `contahub-processor` | CRITICA |
-| 05:00 | nibo-sync | `nibo-sync` | ALTA |
+| 02:00 | google-sheets-sync | `google-sheets-sync` | MÉDIA |
+| 04:00 | contahub-daily-sync | `contahub-sync-automatico` | CRÍTICA |
+| 04:10 / 04:25 | contahub-processor-{1,2} | `contahub-processor` | CRÍTICA |
+| 05:00 | nibo-sync (legado) / contaazul-sync | `contaazul-sync` | ALTA |
 | 05:00 | sync-cmv-sheets | `sync-cmv-sheets` | ALTA |
 | 06:00 | google-reviews | `google-reviews-apify-sync` | BAIXA |
 | Cada 4h | getin-continuous | `getin-sync-continuous` | ALTA |
-| 08:00 | desempenho-v2-diario | `recalcular-desempenho-v2` | CRITICA |
-| 09:00 seg | desempenho-v2-segunda | `recalcular-desempenho-v2` | CRITICA |
-| 09:00 | agente-diario | `agente-dispatcher` | MEDIA |
+| 08:00 | desempenho-v2-diario | `recalcular-desempenho-v2` | CRÍTICA |
+| 09:00 seg | desempenho-v2-segunda | `recalcular-desempenho-v2` | CRÍTICA |
+| 09:00 | agente-diario | `agente-dispatcher` | MÉDIA |
 | 10:00 | sync-eventos | `sync-dispatcher` | ALTA |
-| 19:00 | contahub-evening | `contahub-sync-automatico` | CRITICA |
+| 19:00 | contahub-evening | `contahub-sync-automatico` | CRÍTICA |
 | 19:00 | stockout-sync | `contahub-stockout-sync` | ALTA |
 | Cada 30min | cron-watchdog | `cron-watchdog` | ALTA |
 
-> **Nota**: Os jobs `desempenho-auto-diario` e `desempenho-auto-segunda` (v1) foram desativados em 2026-03-19 após cutover para v2.
-
 ---
 
-## Regras de Negócio por Bar
+## 6. Regras de Negócio por Bar
 
-> **Estado atual**: Estas regras estão **hardcoded** em múltiplos arquivos (edge functions, RPCs SQL, frontend). Não existe tabela de configuração por bar. Adicionar um 3o bar hoje requer mudanças em 10+ arquivos. Centralização planejada via tabela `bar_config` (não implementada).
+> Estas regras estão **hardcoded** em múltiplos arquivos (edge functions, RPCs SQL, frontend). Não existe tabela de configuração por bar. Adicionar um 3º bar hoje requer mudanças em 10+ arquivos. Centralização planejada via `operations.bares_config`.
 
 | Regra | Ordinário (bar_id=3) | Deboche (bar_id=4) |
 |-------|---------------------|-------------------|
 | Dias operação | Qua-Dom | Ter-Sab |
-| Fechado fixo | - | Segunda-feira |
+| Fechado fixo | — | Segunda-feira |
 | Locais bar (drinks) | Preshh, Montados, Mexido, Drinks, Drinks Autorais, Shot e Dose, Batidos | Bar |
 | Locais cozinha | Cozinha, Cozinha 1, Cozinha 2 | Cozinha, Cozinha 2 |
 | Tempo bar usa | t0_t3 | t0_t2 |
 | Atraso bar threshold | >600s (10min) | >600s (10min) |
 | Atraso cozinha threshold | >1200s (20min) | >1200s (20min) |
-| Categorias NIBO atração | Atrações Programação, Produção Eventos | Atrações/Eventos |
+| Categorias ContaAzul atração | Atrações Programação, Produção Eventos | Atrações/Eventos |
 | GetIn ativo | Sim | Não |
 | Agregação semanal | Qui+Sab+Dom | Ter+Qua+Qui e Sex+Sab |
 
 ---
 
-## Multi-Tenancy
+## 7. Multi-Tenancy
 
 Toda tabela operacional tem `bar_id`. A cadeia é:
 
 ```
-empresas (1 row) → bares_config (2 rows) → usuarios_bares (22 rows) → usuarios (12 rows)
-                         │
-                    bar_id = 3 (Ordinário)
-                    bar_id = 4 (Deboche)
-                         │
-                    Presente em 82 tabelas como FK
+auth_custom.empresas (1 row)
+  → operations.bares_config (~2 rows)
+    → auth_custom.usuarios_bares (~24 rows)  -- ver SELECT abaixo
+      → auth_custom.usuarios (~12 rows)
+                │
+        bar_id = 3 (Ordinário)
+        bar_id = 4 (Deboche)
+                │
+        Presente em ~80 tabelas como FK ou coluna
 ```
 
-Frontend: `BarContext` gerencia seleção. `UserContext` valida permissões. Troca de bar recarrega página.
+> Counts atuais:
+> ```sql
+> SELECT 'usuarios_bares' AS tabela, count(*) FROM auth_custom.usuarios_bares
+> UNION ALL SELECT 'usuarios', count(*) FROM auth_custom.usuarios
+> UNION ALL SELECT 'bares', count(*) FROM operations.bares;
+> ```
+
+**Frontend**: `BarContext` gerencia seleção. `UserContext` valida permissões. Troca de bar recarrega página.
+
+**RLS**: helper `public.user_has_bar_access(check_bar_id)` lê de `public.usuarios_bares` (espelho de `auth_custom.usuarios_bares`). Policies multi-tenant usam:
+```sql
+USING (bar_id IS NULL OR public.user_has_bar_access(bar_id))
+WITH CHECK (bar_id IS NOT NULL AND public.user_has_bar_access(bar_id))
+```
+
+---
+
+## 8. Como Pesquisar
+
+| Pergunta | Onde achar |
+|----------|------------|
+| Em qual schema está a tabela X? | [`frontend/src/lib/supabase/table-schemas.ts`](../frontend/src/lib/supabase/table-schemas.ts) |
+| Convenções de naming (prefixos, sufixos) | [`database/CONVENTIONS.md`](CONVENTIONS.md) |
+| Histórico de mudanças DDL | `database/migrations/` (ordem cronológica por nome) |
+| Edge functions e o que cada uma faz | `backend/supabase/functions/` (cada pasta tem `index.ts`) |
+| Regras de negócio de cálculo | [`docs/regras-negocio.md`](../docs/regras-negocio.md) |
+| Cron jobs ativos | `SELECT jobname, schedule, active FROM cron.job WHERE active = true` |
+
+---
+
+## Histórico de revisões
+
+- **2026-04-25**: Refresh pós-medallion migration (37 dias de drift). Adiciona Seção 2 (arquitetura de schemas), substitui Camadas 1-5 que referenciavam `contahub_analitico/tempo/pagamentos/etc` extintas, adiciona nota NIBO→ContaAzul, transforma counts cravados em ordem-de-magnitude + queries vivas.
+- **2026-03-19**: Revisão anterior (snapshot que ficou drifting). Maioria das tabelas ainda em `public`.


### PR DESCRIPTION
## O que
Refresh do `database/DOMAIN_MAP.md` (37 dias de drift acumulado entre o doc e o estado real do banco).

**Stats**: 242 insertions / 185 deletions / 335 linhas final.

## Por que
Doc ainda referenciava tabelas pré-medallion **extintas** (`contahub_analitico`, `contahub_tempo`, `contahub_pagamentos`, `contahub_periodo`, `contahub_fatporhora`) e **9 schemas inteiros** ficaram invisíveis (`bronze`, `silver`, `gold`, `operations`, `financial`, `system`, `integrations`, `meta`, `agent_ai`, `crm`, `hr`, `auth_custom`, `ops`).

Drift induz erro real:
- Onboarding: novo dev procura `contahub_analitico`, não acha, abre ticket
- DDL: alguém cria nova tabela em `public` por padrão (era o "ativo" no doc antigo)
- AI agents lendo doc para gerar queries: alucinam tabelas inexistentes

## Mudanças principais

### Adicionado
- **Seção 2 (Arquitetura de Schemas)**: medallion (bronze/silver/gold) + 10 schemas operacionais, cada um com table-count ordem de magnitude e tabelas-chave
- **Nota NIBO → ContaAzul** (migration 20260324) com tabela de equivalências — quem busca "NIBO" agora encontra a pista
- **Seção 8 (Como Pesquisar)**: tabela "pergunta → onde achar" pra reduzir tempo de onboarding
- **Histórico de revisões** no final do doc

### Substituído
- Listas Camadas 1-5 reescritas com schemas explícitos (`bronze.bronze_contahub_*`, `silver.vendas_item`, `integrations.contaazul_lancamentos`, etc)
- Top 10 tabelas críticas: substituído por top 12 atual (silver.vendas_item agora é #1 com 915k rows)

### Política de números
- Counts viraram **ordem de magnitude** (`~24` em vez de `24`)
- Para o número exato, doc mostra a query SQL pra rodar (`SELECT count(*) FROM ...`)
- Razão: cravar números congela o doc; daqui a 30 dias volta a ser drift

## Validação
3 tabelas-amostra confirmadas existem no schema atribuído via `SELECT 1 FROM <schema>.<table> LIMIT 1`:
- `bronze.bronze_contahub_avendas_porproduto_analitico` ✅
- `silver.tempos_producao` ✅
- `operations.eventos_base` ✅

## Backlinks
16 referências ao DOMAIN_MAP em outros arquivos do repo (`CLAUDE.md`, `database/README.md`, `docs/README.md`, `docs/domains/database.md`, `docs/planning/*.md`). Nenhum precisa atualizar junto — todos apontam pro path correto (`database/DOMAIN_MAP.md`).

## Risco
🟢 Zero — só doc, sem mudança de comportamento. Build/runtime intocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)