### PR TITLE
perf/05 batch 1: drop 14 unused_indexes (bronze + system, ~23 MB)

### DIFF
--- a/database/_advisor_snapshots/perf05-unused-after-batch1-2026-04-25.json
+++ b/database/_advisor_snapshots/perf05-unused-after-batch1-2026-04-25.json
@@ -1,0 +1,1519 @@
+[
+  {
+    "name": "unindexed_foreign_keys",
+    "title": "Unindexed foreign keys",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Identifies foreign key constraints without a covering index, which can impact database performance.",
+    "detail": "Table \\`crm.crm_templates\\` has a foreign key \\`crm_templates_bar_id_fkey\\` without a covering index. This can lead to suboptimal query performance.",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys",
+    "metadata": {
+      "name": "crm_templates",
+      "type": "table",
+      "schema": "crm",
+      "fkey_name": "crm_templates_bar_id_fkey",
+      "fkey_columns": [
+        2
+      ]
+    },
+    "cache_key": "unindexed_foreign_keys_crm_crm_templates_crm_templates_bar_id_fkey"
+  },
+  {
+    "name": "unindexed_foreign_keys",
+    "title": "Unindexed foreign keys",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Identifies foreign key constraints without a covering index, which can impact database performance.",
+    "detail": "Table \\`financial.dre_manual\\` has a foreign key \\`dre_manual_bar_id_fkey\\` without a covering index. This can lead to suboptimal query performance.",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys",
+    "metadata": {
+      "name": "dre_manual",
+      "type": "table",
+      "schema": "financial",
+      "fkey_name": "dre_manual_bar_id_fkey",
+      "fkey_columns": [
+        11
+      ]
+    },
+    "cache_key": "unindexed_foreign_keys_financial_dre_manual_dre_manual_bar_id_fkey"
+  },
+  {
+    "name": "unindexed_foreign_keys",
+    "title": "Unindexed foreign keys",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Identifies foreign key constraints without a covering index, which can impact database performance.",
+    "detail": "Table \\`hr.contratos_funcionario\\` has a foreign key \\`contratos_funcionario_funcionario_id_fkey\\` without a covering index. This can lead to suboptimal query performance.",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys",
+    "metadata": {
+      "name": "contratos_funcionario",
+      "type": "table",
+      "schema": "hr",
+      "fkey_name": "contratos_funcionario_funcionario_id_fkey",
+      "fkey_columns": [
+        2
+      ]
+    },
+    "cache_key": "unindexed_foreign_keys_hr_contratos_funcionario_contratos_funcionario_funcionario_id_fkey"
+  },
+  {
+    "name": "unindexed_foreign_keys",
+    "title": "Unindexed foreign keys",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Identifies foreign key constraints without a covering index, which can impact database performance.",
+    "detail": "Table \\`meta.metas_desempenho_historico\\` has a foreign key \\`metas_desempenho_historico_meta_id_fkey\\` without a covering index. This can lead to suboptimal query performance.",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys",
+    "metadata": {
+      "name": "metas_desempenho_historico",
+      "type": "table",
+      "schema": "meta",
+      "fkey_name": "metas_desempenho_historico_meta_id_fkey",
+      "fkey_columns": [
+        2
+      ]
+    },
+    "cache_key": "unindexed_foreign_keys_meta_metas_desempenho_historico_metas_desempenho_historico_meta_id_fkey"
+  },
+  {
+    "name": "unindexed_foreign_keys",
+    "title": "Unindexed foreign keys",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Identifies foreign key constraints without a covering index, which can impact database performance.",
+    "detail": "Table \\`system.dados_bloqueados\\` has a foreign key \\`dados_bloqueados_bar_id_fkey\\` without a covering index. This can lead to suboptimal query performance.",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys",
+    "metadata": {
+      "name": "dados_bloqueados",
+      "type": "table",
+      "schema": "system",
+      "fkey_name": "dados_bloqueados_bar_id_fkey",
+      "fkey_columns": [
+        4
+      ]
+    },
+    "cache_key": "unindexed_foreign_keys_system_dados_bloqueados_dados_bloqueados_bar_id_fkey"
+  },
+  {
+    "name": "unindexed_foreign_keys",
+    "title": "Unindexed foreign keys",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Identifies foreign key constraints without a covering index, which can impact database performance.",
+    "detail": "Table \\`system.sync_contagem_historico\\` has a foreign key \\`sync_contagem_historico_bar_id_fkey\\` without a covering index. This can lead to suboptimal query performance.",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys",
+    "metadata": {
+      "name": "sync_contagem_historico",
+      "type": "table",
+      "schema": "system",
+      "fkey_name": "sync_contagem_historico_bar_id_fkey",
+      "fkey_columns": [
+        2
+      ]
+    },
+    "cache_key": "unindexed_foreign_keys_system_sync_contagem_historico_sync_contagem_historico_bar_id_fkey"
+  },
+  {
+    "name": "no_primary_key",
+    "title": "No Primary Key",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if a table does not have a primary key. Tables without a primary key can be inefficient to interact with at scale.",
+    "detail": "Table \\`public.view_top_produtos_legacy_snapshot\\` does not have a primary key",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0004_no_primary_key",
+    "metadata": {
+      "name": "view_top_produtos_legacy_snapshot",
+      "type": "table",
+      "schema": "public"
+    },
+    "cache_key": "no_primary_key_public_view_top_produtos_legacy_snapshot"
+  },
+  {
+    "name": "no_primary_key",
+    "title": "No Primary Key",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if a table does not have a primary key. Tables without a primary key can be inefficient to interact with at scale.",
+    "detail": "Table \\`meta.desempenho_manual_backup_20260423\\` does not have a primary key",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0004_no_primary_key",
+    "metadata": {
+      "name": "desempenho_manual_backup_20260423",
+      "type": "table",
+      "schema": "meta"
+    },
+    "cache_key": "no_primary_key_meta_desempenho_manual_backup_20260423"
+  },
+  {
+    "name": "no_primary_key",
+    "title": "No Primary Key",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if a table does not have a primary key. Tables without a primary key can be inefficient to interact with at scale.",
+    "detail": "Table \\`meta.desempenho_manual_backup_20260422_v2\\` does not have a primary key",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0004_no_primary_key",
+    "metadata": {
+      "name": "desempenho_manual_backup_20260422_v2",
+      "type": "table",
+      "schema": "meta"
+    },
+    "cache_key": "no_primary_key_meta_desempenho_manual_backup_20260422_v2"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_cancel_prd\\` on table \\`bronze.bronze_contahub_avendas_cancelamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_contahub_avendas_cancelamentos",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_contahub_avendas_cancelamentos_idx_bronze_cancel_prd"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_stockout_raw_prd_venda\\` on table \\`bronze.bronze_contahub_operacional_stockout_raw\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_contahub_operacional_stockout_raw",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_contahub_operacional_stockout_raw_idx_stockout_raw_prd_venda"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_stockout_proc_motivo\\` on table \\`silver.silver_contahub_operacional_stockout_processado\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "silver_contahub_operacional_stockout_processado",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_silver_contahub_operacional_stockout_processado_idx_stockout_proc_motivo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_cmv_manual_bar_periodo\\` on table \\`public.cmv_manual\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "cmv_manual",
+      "type": "table",
+      "schema": "public"
+    },
+    "cache_key": "unused_index_public_cmv_manual_idx_cmv_manual_bar_periodo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bar_local_mapeamento_bar_id\\` on table \\`operations.bar_local_mapeamento\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bar_local_mapeamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_bar_local_mapeamento_idx_bar_local_mapeamento_bar_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bar_local_mapeamento_categoria\\` on table \\`operations.bar_local_mapeamento\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bar_local_mapeamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_bar_local_mapeamento_idx_bar_local_mapeamento_categoria"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_automation_logs_execution_id\\` on table \\`operations.checklist_automation_logs\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_automation_logs",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_automation_logs_idx_checklist_automation_logs_execution_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_provisoes_trabalhistas_funcionario_id_new\\` on table \\`hr.provisoes_trabalhistas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "provisoes_trabalhistas",
+      "type": "table",
+      "schema": "hr"
+    },
+    "cache_key": "unused_index_hr_provisoes_trabalhistas_idx_provisoes_trabalhistas_funcionario_id_new"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_cliente_visitas_cli_id\\` on table \\`silver.cliente_visitas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "cliente_visitas",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_cliente_visitas_idx_cliente_visitas_cli_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`ix_byfh_data_hora\\` on table \\`bronze.bronze_yuzer_fatporhora\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_yuzer_fatporhora",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_yuzer_fatporhora_ix_byfh_data_hora"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_sistema_alertas_bar_id\\` on table \\`system.sistema_alertas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "sistema_alertas",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_sistema_alertas_idx_sistema_alertas_bar_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_cliente_estatisticas_cli_id\\` on table \\`silver.cliente_estatisticas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "cliente_estatisticas",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_cliente_estatisticas_idx_cliente_estatisticas_cli_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`ix_byslog_executed\\` on table \\`bronze.bronze_yuzer_sync_log\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_yuzer_sync_log",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_yuzer_sync_log_ix_byslog_executed"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_produtos_top_categoria\\` on table \\`silver.produtos_top\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "produtos_top",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_produtos_top_idx_produtos_top_categoria"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_eventos_base_cancelamentos\\` on table \\`operations.eventos_base\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "eventos_base",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_eventos_base_idx_eventos_base_cancelamentos"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_eventos_base_conta_assinada\\` on table \\`operations.eventos_base\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "eventos_base",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_eventos_base_idx_eventos_base_conta_assinada"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_insight_events_type\\` on table \\`system.insight_events\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "insight_events",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_insight_events_idx_insight_events_type"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_insight_events_processed\\` on table \\`system.insight_events\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "insight_events",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_insight_events_idx_insight_events_processed"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agent_insights_v2_visualizado\\` on table \\`agent_ai.agent_insights_v2\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agent_insights_v2",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agent_insights_v2_idx_agent_insights_v2_visualizado"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agent_insights_v2_arquivado\\` on table \\`agent_ai.agent_insights_v2\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agent_insights_v2",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agent_insights_v2_idx_agent_insights_v2_arquivado"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_sympla_bilheteria_event_id\\` on table \\`silver.sympla_bilheteria_diaria\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "sympla_bilheteria_diaria",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_sympla_bilheteria_diaria_idx_sympla_bilheteria_event_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agent_insights_v2_tipo\\` on table \\`agent_ai.agent_insights_v2\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agent_insights_v2",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agent_insights_v2_idx_agent_insights_v2_tipo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agent_insights_v2_severidade\\` on table \\`agent_ai.agent_insights_v2\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agent_insights_v2",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agent_insights_v2_idx_agent_insights_v2_severidade"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_sync_metadata_active\\` on table \\`system.sync_metadata\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "sync_metadata",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_sync_metadata_idx_sync_metadata_active"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_google_reviews_date\\` on table \\`bronze.bronze_google_reviews\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_google_reviews",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_google_reviews_idx_bronze_google_reviews_date"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_google_reviews_place\\` on table \\`bronze.bronze_google_reviews\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_google_reviews",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_google_reviews_idx_bronze_google_reviews_place"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_automation_logs_tipo\\` on table \\`operations.checklist_automation_logs\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_automation_logs",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_automation_logs_idx_checklist_automation_logs_tipo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_automation_logs_schedule\\` on table \\`operations.checklist_automation_logs\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_automation_logs",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_automation_logs_idx_checklist_automation_logs_schedule"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_audit_trail_user_operation\\` on table \\`system.audit_trail\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "audit_trail",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_audit_trail_idx_audit_trail_user_operation"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contaazul_lancamentos_valor_nao_pago\\` on table \\`integrations.contaazul_lancamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contaazul_lancamentos",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_contaazul_lancamentos_idx_contaazul_lancamentos_valor_nao_pago"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_agendamentos_bar_data\\` on table \\`operations.checklist_agendamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_agendamentos",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_agendamentos_idx_checklist_agendamentos_bar_data"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_agendamentos_status\\` on table \\`operations.checklist_agendamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_agendamentos",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_agendamentos_idx_checklist_agendamentos_status"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_agendamentos_deadline\\` on table \\`operations.checklist_agendamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_agendamentos",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_agendamentos_idx_checklist_agendamentos_deadline"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_checklist_agendamentos_responsavel\\` on table \\`operations.checklist_agendamentos\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "checklist_agendamentos",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_checklist_agendamentos_idx_checklist_agendamentos_responsavel"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_yuzer_produtos_evento_produto\\` on table \\`silver.yuzer_produtos_evento\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "yuzer_produtos_evento",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_yuzer_produtos_evento_idx_yuzer_produtos_evento_produto"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_ca_cat_pai\\` on table \\`bronze.bronze_contaazul_categorias\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_contaazul_categorias",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_contaazul_categorias_idx_bronze_ca_cat_pai"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_ca_log_bar\\` on table \\`bronze.bronze_contaazul_sync_log\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_contaazul_sync_log",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_contaazul_sync_log_idx_bronze_ca_log_bar"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_planejamento_comercial_diario_recalculo\\` on table \\`gold.planejamento\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "planejamento",
+      "type": "table",
+      "schema": "gold"
+    },
+    "cache_key": "unused_index_gold_planejamento_idx_planejamento_comercial_diario_recalculo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contaazul_categorias_tipo\\` on table \\`integrations.contaazul_categorias\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contaazul_categorias",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_contaazul_categorias_idx_contaazul_categorias_tipo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contaazul_categorias_ativo\\` on table \\`integrations.contaazul_categorias\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contaazul_categorias",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_contaazul_categorias_idx_contaazul_categorias_ativo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contaazul_centros_custo_ativo\\` on table \\`integrations.contaazul_centros_custo\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contaazul_centros_custo",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_contaazul_centros_custo_idx_contaazul_centros_custo_ativo"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_nps_falae_diario_pesquisa_search\\` on table \\`crm.nps_falae_diario_pesquisa\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "nps_falae_diario_pesquisa",
+      "type": "table",
+      "schema": "crm"
+    },
+    "cache_key": "unused_index_crm_nps_falae_diario_pesquisa_idx_nps_falae_diario_pesquisa_search"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_umbler_campanha_destinatarios_campanha_id_new\\` on table \\`integrations.umbler_campanha_destinatarios\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "umbler_campanha_destinatarios",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_umbler_campanha_destinatarios_idx_umbler_campanha_destinatarios_campanha_id_new"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contratos_funcionario_area_id\\` on table \\`hr.contratos_funcionario\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contratos_funcionario",
+      "type": "table",
+      "schema": "hr"
+    },
+    "cache_key": "unused_index_hr_contratos_funcionario_idx_contratos_funcionario_area_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contratos_funcionario_cargo_id\\` on table \\`hr.contratos_funcionario\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contratos_funcionario",
+      "type": "table",
+      "schema": "hr"
+    },
+    "cache_key": "unused_index_hr_contratos_funcionario_idx_contratos_funcionario_cargo_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contaazul_pessoas_documento\\` on table \\`integrations.contaazul_pessoas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contaazul_pessoas",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_contaazul_pessoas_idx_contaazul_pessoas_documento"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_contaazul_pessoas_perfil\\` on table \\`integrations.contaazul_pessoas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "contaazul_pessoas",
+      "type": "table",
+      "schema": "integrations"
+    },
+    "cache_key": "unused_index_integrations_contaazul_pessoas_idx_contaazul_pessoas_perfil"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_umbler_destin_campanha\\` on table \\`bronze.bronze_umbler_campanha_destinatarios\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_umbler_campanha_destinatarios",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_umbler_campanha_destinatarios_idx_bronze_umbler_destin_campanha"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bronze_umbler_destin_msg\\` on table \\`bronze.bronze_umbler_campanha_destinatarios\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bronze_umbler_campanha_destinatarios",
+      "type": "table",
+      "schema": "bronze"
+    },
+    "cache_key": "unused_index_bronze_bronze_umbler_campanha_destinatarios_idx_bronze_umbler_destin_msg"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_reservantes_perfil_segmento\\` on table \\`silver.reservantes_perfil\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "reservantes_perfil",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_reservantes_perfil_idx_reservantes_perfil_segmento"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_reservantes_perfil_vip\\` on table \\`silver.reservantes_perfil\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "reservantes_perfil",
+      "type": "table",
+      "schema": "silver"
+    },
+    "cache_key": "unused_index_silver_reservantes_perfil_idx_reservantes_perfil_vip"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_funcionarios_area_id_new\\` on table \\`hr.funcionarios\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "funcionarios",
+      "type": "table",
+      "schema": "hr"
+    },
+    "cache_key": "unused_index_hr_funcionarios_idx_funcionarios_area_id_new"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_funcionarios_cargo_id_new\\` on table \\`hr.funcionarios\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "funcionarios",
+      "type": "table",
+      "schema": "hr"
+    },
+    "cache_key": "unused_index_hr_funcionarios_idx_funcionarios_cargo_id_new"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_usuarios_bares_bar_id\\` on table \\`public.usuarios_bares\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "usuarios_bares",
+      "type": "table",
+      "schema": "public"
+    },
+    "cache_key": "unused_index_public_usuarios_bares_idx_usuarios_bares_bar_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_config_metas_bar_ano\\` on table \\`operations.config_metas_planejamento\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_config_metas_planejamento_idx_config_metas_bar_ano"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agente_alertas_insight_id\\` on table \\`agent_ai.agente_alertas\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agente_alertas",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agente_alertas_idx_agente_alertas_insight_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agente_configuracoes_bar_id\\` on table \\`agent_ai.agente_configuracoes\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agente_configuracoes",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agente_configuracoes_idx_agente_configuracoes_bar_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_agente_insights_scan_id\\` on table \\`agent_ai.agente_insights\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "agente_insights",
+      "type": "table",
+      "schema": "agent_ai"
+    },
+    "cache_key": "unused_index_agent_ai_agente_insights_idx_agente_insights_scan_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_notificacoes_bar_id\\` on table \\`system.notificacoes\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "notificacoes",
+      "type": "table",
+      "schema": "system"
+    },
+    "cache_key": "unused_index_system_notificacoes_idx_notificacoes_bar_id"
+  },
+  {
+    "name": "unused_index",
+    "title": "Unused Index",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if an index has never been used and may be a candidate for removal.",
+    "detail": "Index \\`idx_bares_config_bar_id\\` on table \\`operations.bares_config\\` has not been used",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index",
+    "metadata": {
+      "name": "bares_config",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "unused_index_operations_bares_config_idx_bares_config_bar_id"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`operations.config_metas_planejamento\\` has multiple permissive policies for role \\`anon\\` for action \\`SELECT\\`. Policies include \\`{config_metas_read_by_bar,config_metas_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "multiple_permissive_policies_operations_config_metas_planejamento_anon_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`ops.job_camada_mapping\\` has multiple permissive policies for role \\`anon\\` for action \\`SELECT\\`. Policies include \\`{job_camada_read_auth,job_camada_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "job_camada_mapping",
+      "type": "table",
+      "schema": "ops"
+    },
+    "cache_key": "multiple_permissive_policies_ops_job_camada_mapping_anon_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`operations.config_metas_planejamento\\` has multiple permissive policies for role \\`authenticated\\` for action \\`SELECT\\`. Policies include \\`{config_metas_read_by_bar,config_metas_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "multiple_permissive_policies_operations_config_metas_planejamento_authenticated_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`ops.job_camada_mapping\\` has multiple permissive policies for role \\`authenticated\\` for action \\`SELECT\\`. Policies include \\`{job_camada_read_auth,job_camada_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "job_camada_mapping",
+      "type": "table",
+      "schema": "ops"
+    },
+    "cache_key": "multiple_permissive_policies_ops_job_camada_mapping_authenticated_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`operations.config_metas_planejamento\\` has multiple permissive policies for role \\`authenticator\\` for action \\`SELECT\\`. Policies include \\`{config_metas_read_by_bar,config_metas_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "multiple_permissive_policies_operations_config_metas_planejamento_authenticator_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`ops.job_camada_mapping\\` has multiple permissive policies for role \\`authenticator\\` for action \\`SELECT\\`. Policies include \\`{job_camada_read_auth,job_camada_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "job_camada_mapping",
+      "type": "table",
+      "schema": "ops"
+    },
+    "cache_key": "multiple_permissive_policies_ops_job_camada_mapping_authenticator_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`operations.config_metas_planejamento\\` has multiple permissive policies for role \\`cli_login_postgres\\` for action \\`SELECT\\`. Policies include \\`{config_metas_read_by_bar,config_metas_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "multiple_permissive_policies_operations_config_metas_planejamento_cli_login_postgres_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`ops.job_camada_mapping\\` has multiple permissive policies for role \\`cli_login_postgres\\` for action \\`SELECT\\`. Policies include \\`{job_camada_read_auth,job_camada_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "job_camada_mapping",
+      "type": "table",
+      "schema": "ops"
+    },
+    "cache_key": "multiple_permissive_policies_ops_job_camada_mapping_cli_login_postgres_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`operations.config_metas_planejamento\\` has multiple permissive policies for role \\`dashboard_user\\` for action \\`SELECT\\`. Policies include \\`{config_metas_read_by_bar,config_metas_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "multiple_permissive_policies_operations_config_metas_planejamento_dashboard_user_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`ops.job_camada_mapping\\` has multiple permissive policies for role \\`dashboard_user\\` for action \\`SELECT\\`. Policies include \\`{job_camada_read_auth,job_camada_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "job_camada_mapping",
+      "type": "table",
+      "schema": "ops"
+    },
+    "cache_key": "multiple_permissive_policies_ops_job_camada_mapping_dashboard_user_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`operations.config_metas_planejamento\\` has multiple permissive policies for role \\`supabase_privileged_role\\` for action \\`SELECT\\`. Policies include \\`{config_metas_read_by_bar,config_metas_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "config_metas_planejamento",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "multiple_permissive_policies_operations_config_metas_planejamento_supabase_privileged_role_SELECT"
+  },
+  {
+    "name": "multiple_permissive_policies",
+    "title": "Multiple Permissive Policies",
+    "level": "WARN",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if multiple permissive row level security policies are present on a table for the same \\`role\\` and \\`action\\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.",
+    "detail": "Table \\`ops.job_camada_mapping\\` has multiple permissive policies for role \\`supabase_privileged_role\\` for action \\`SELECT\\`. Policies include \\`{job_camada_read_auth,job_camada_write_admin}\\`",
+    "remediation": "https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies",
+    "metadata": {
+      "name": "job_camada_mapping",
+      "type": "table",
+      "schema": "ops"
+    },
+    "cache_key": "multiple_permissive_policies_ops_job_camada_mapping_supabase_privileged_role_SELECT"
+  },
+  {
+    "name": "table_bloat",
+    "title": "Table Bloat",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Detects if a table has excess bloat and may benefit from maintenance operations like vacuum full or cluster.",
+    "detail": "Table `operations`.`eventos_base` has excessive bloat",
+    "remediation": "Consider running vacuum full (WARNING: incurs downtime) and tweaking autovacuum settings to reduce bloat.",
+    "metadata": {
+      "name": "eventos_base",
+      "type": "table",
+      "schema": "operations"
+    },
+    "cache_key": "table_bloat_operations_eventos_base"
+  },
+  {
+    "name": "auth_db_connections_absolute",
+    "title": "Auth DB Connection Strategy is not Percentage",
+    "level": "INFO",
+    "facing": "EXTERNAL",
+    "categories": [
+      "PERFORMANCE"
+    ],
+    "description": "Using a percentage based allocation connection strategy for Auth can help to improve the server's performance when increasing instance size.",
+    "detail": "Your project's Auth server is configured to use at most 10 connections. Increasing the instance size without manually adjusting this number will not improve the performance of the Auth server. Switch to a percentage based connection allocation strategy instead.",
+    "cache_key": "auth_db_connections_absolute",
+    "remediation": "https://supabase.com/docs/guides/deployment/going-into-prod",
+    "metadata": {
+      "type": "auth",
+      "entity": "Auth"
+    }
+  }
+]

--- a/database/migrations/2026-04-25-perf05-unused-indexes-batch1.rollback.sql
+++ b/database/migrations/2026-04-25-perf05-unused-indexes-batch1.rollback.sql
@@ -1,0 +1,78 @@
+-- Rollback de 2026-04-25-perf05-unused-indexes-batch1.sql.
+-- Recria os 14 indexes droppados com indexdef fiel ao snapshot
+-- de pg_indexes capturado em 2026-04-25.
+--
+-- IMPORTANTE: indexdef original do Postgres NAO inclui CONCURRENTLY.
+-- Adicionado aqui pra evitar lock pesado em re-criacao em prod (ha
+-- escrita constante nas tabelas bronze de cron jobs de ingestao).
+--
+-- CREATE INDEX CONCURRENTLY tambem nao pode rodar em transaction block —
+-- aplicar via execute_sql um statement por vez (mesmo padrao da Fase 1
+-- rollback).
+--
+-- ATENCAO: este rollback nao e gatilho automatico — so executar se
+-- observarmos degradacao mensuravel atribuivel ao drop deste batch.
+-- 87 dias de stats = 0 scans torna improvavel que a recriacao seja
+-- necessaria, mas mantida pra fidelidade.
+
+-- ============================================
+-- bronze (13 indexes)
+-- ============================================
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contahub_pagamentos_cli_fone
+  ON bronze.bronze_contahub_financeiro_pagamentosrecebidos
+  USING btree (cli_fone) WHERE (cli_fone IS NOT NULL);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bronze_ca_lanc_cc
+  ON bronze.bronze_contaazul_lancamentos
+  USING btree (centro_custo_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bronze_umbler_msg_enviada
+  ON bronze.bronze_umbler_mensagens
+  USING btree (bar_id, enviada_em DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bronze_ca_lanc_cat
+  ON bronze.bronze_contaazul_lancamentos
+  USING btree (categoria_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bronze_sympla_part_order
+  ON bronze.bronze_sympla_participantes
+  USING btree (order_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bronze_umbler_msg_conversa
+  ON bronze.bronze_umbler_mensagens
+  USING btree (conversa_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bronze_sympla_part_email
+  ON bronze.bronze_sympla_participantes
+  USING btree (email);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bronze_sympla_pedidos_email
+  ON bronze.bronze_sympla_pedidos
+  USING btree (buyer_email);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bronze_umbler_msg_telefone
+  ON bronze.bronze_umbler_mensagens
+  USING btree (contato_telefone);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bronze_umbler_conv_telefone
+  ON bronze.bronze_umbler_conversas
+  USING btree (contato_telefone);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contahub_pagamentos_cli_cpf
+  ON bronze.bronze_contahub_financeiro_pagamentosrecebidos
+  USING btree (cli_cpf) WHERE (cli_cpf IS NOT NULL);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bronze_sympla_pedidos_data
+  ON bronze.bronze_sympla_pedidos
+  USING btree (order_date);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bronze_umbler_conv_ult_msg
+  ON bronze.bronze_umbler_conversas
+  USING btree (bar_id, ultima_mensagem_em DESC);
+
+-- ============================================
+-- system (1 index)
+-- ============================================
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_trail_table_record
+  ON system.audit_trail
+  USING btree (table_name, record_id);

--- a/database/migrations/2026-04-25-perf05-unused-indexes-batch1.sql
+++ b/database/migrations/2026-04-25-perf05-unused-indexes-batch1.sql
@@ -1,0 +1,58 @@
+-- perf/05 Batch 1 — DROP de 14 indexes unused (zero idx_scan em 87 dias)
+--
+-- ESCOPO: bronze (13) + system (1) — categorias de menor risco (raw data
+-- + audit logs). silver/gold/operations/financial/integrations ficam pra
+-- batches 2-N quando tivermos mais confianca no padrao.
+--
+-- JANELA: server uptime de 87 dias (started 2026-01-28). Stats acumulando
+-- desde entao. Top index com idx_scan=47M prova que tracking esta ativo.
+-- Verificacao realtime imediatamente antes da geracao desta migration:
+-- 14/14 candidatos ainda com idx_scan=0.
+--
+-- HEURISTICA "why-no-scan":
+-- - bronze.* sao raw data, staging descartavel. Queries reais consomem
+--   silver.* / integrations.*. Indexes em bronze.bronze_umbler_mensagens
+--   por telefone, conversa_id, contato_telefone, etc. nunca foram usados —
+--   queries reais usam integrations.umbler_mensagens.
+-- - bronze.bronze_contahub_financeiro_pagamentosrecebidos.idx_contahub_pagamentos_cli_*
+--   (cli_fone, cli_cpf): lookup CRM por telefone/cpf vai pra silver.cliente_visitas
+--   ou crm.*, nunca bronze.
+-- - bronze.bronze_sympla_*: idem — frontend usa integrations.sympla_*.
+-- - bronze.bronze_contaazul_lancamentos.idx_bronze_ca_lanc_{cat,cc}:
+--   lookups por categoria/centro de custo vao pra integrations.contaazul_lancamentos.
+-- - system.audit_trail.idx_audit_trail_table_record: audit nao tem queries
+--   por (table_name, record_id) hoje — leitura e raramente, sem filtro.
+--
+-- ESPACO LIBERADO: ~22.7 MB (bronze) + 760 kB (system) = ~23.4 MB.
+--
+-- APLICACAO: DROP INDEX CONCURRENTLY nao roda em transaction block.
+-- apply_migration empacota em BEGIN/COMMIT — vai falhar com erro 25001.
+-- Usar mcp__supabase__execute_sql um DROP por chamada (mesmo padrao
+-- da Fase 1 / perf/01).
+--
+-- ROLLBACK: 14 CREATE INDEX CONCURRENTLY IF NOT EXISTS no
+-- 2026-04-25-perf05-unused-indexes-batch1.rollback.sql, com indexdef
+-- fiel extraido de pg_indexes (whithout CONCURRENTLY no original; adicionado
+-- no rollback pra evitar lock pesado em re-criacao).
+
+-- ============================================
+-- bronze (13 indexes, ~22.7 MB)
+-- ============================================
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_contahub_pagamentos_cli_fone;
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_bronze_ca_lanc_cc;
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_bronze_umbler_msg_enviada;
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_bronze_ca_lanc_cat;
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_bronze_sympla_part_order;
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_bronze_umbler_msg_conversa;
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_bronze_sympla_part_email;
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_bronze_sympla_pedidos_email;
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_bronze_umbler_msg_telefone;
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_bronze_umbler_conv_telefone;
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_contahub_pagamentos_cli_cpf;
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_bronze_sympla_pedidos_data;
+DROP INDEX CONCURRENTLY IF EXISTS bronze.idx_bronze_umbler_conv_ult_msg;
+
+-- ============================================
+-- system (1 index, 760 kB)
+-- ============================================
+DROP INDEX CONCURRENTLY IF EXISTS system.idx_audit_trail_table_record;


### PR DESCRIPTION
## O que
DROP de 14 indexes não-usados (`idx_scan = 0`) em `bronze` (13) + `system` (1). Primeiro batch da série `perf/05` que vai endereçar os 75 findings `unused_index` INFO do Supabase Advisor de forma incremental.

## Janela de stats
**87 dias** de tracking acumulado. Server uptime desde 2026-01-28. Top index com `idx_scan = 47M` confirma que stats estão ativos (não foi reset). Janela ~3× maior que o mínimo de 30 dias prudente.

## Escopo (primeiro batch — categorias de menor risco)

| Schema | Indexes | Espaço | Risco |
|---|---:|---:|---|
| `bronze` | 13 | 22.7 MB | 🟢 Staging descartável — queries reais lêem `silver.*` / `integrations.*` |
| `system` | 1 | 760 kB | 🟢 `audit_trail` — auditoria raramente consultada |
| **Total** | **14** | **~23.4 MB** | |

### bronze (13 indexes)
- `bronze.idx_contahub_pagamentos_cli_fone` (5.3 MB) — partial idx em `cli_fone IS NOT NULL`
- `bronze.idx_bronze_ca_lanc_cc` (2.3 MB) — `centro_custo_id`
- `bronze.idx_bronze_umbler_msg_enviada` (2.2 MB) — `(bar_id, enviada_em DESC)`
- `bronze.idx_bronze_ca_lanc_cat` (1.9 MB) — `categoria_id`
- `bronze.idx_bronze_sympla_part_order` (1.7 MB) — `order_id`
- `bronze.idx_bronze_umbler_msg_conversa` (1.6 MB) — `conversa_id`
- `bronze.idx_bronze_sympla_part_email` (1.5 MB) — `email`
- `bronze.idx_bronze_sympla_pedidos_email` (1.4 MB) — `buyer_email`
- `bronze.idx_bronze_umbler_msg_telefone` (1.3 MB) — `contato_telefone`
- `bronze.idx_bronze_umbler_conv_telefone` (1.2 MB) — `contato_telefone`
- `bronze.idx_contahub_pagamentos_cli_cpf` (1.1 MB) — partial idx em `cli_cpf IS NOT NULL`
- `bronze.idx_bronze_sympla_pedidos_data` (952 kB) — `order_date`
- `bronze.idx_bronze_umbler_conv_ult_msg` (920 kB) — `(bar_id, ultima_mensagem_em DESC)`

### system (1 index)
- `system.idx_audit_trail_table_record` (760 kB) — `(table_name, record_id)` btree composite

### Why-no-scan (heurística)
- Indexes em `bronze.bronze_umbler_*` por telefone/conversa/email: queries reais do app vão pra `integrations.umbler_*`, nunca bronze.
- `cli_fone` / `cli_cpf` em bronze pagamentos: lookup CRM por telefone/CPF é em `silver.cliente_visitas` ou `crm.*`.
- `bronze.bronze_sympla_*`: frontend usa `integrations.sympla_*`.
- `system.audit_trail`: leitura sem filtro composto `(table_name, record_id)`.

## Smoke pre-apply (Gate 2)
14/14 candidatos confirmados ainda com `idx_scan = 0` no momento da geração da migration. Nenhum acordou entre Gate 1 e Gate 2.

## Aplicação
`apply_migration` empacota em BEGIN/COMMIT — incompatível com `DROP INDEX CONCURRENTLY`. Usei `mcp__supabase__execute_sql` 14× (mesmo plano B validado em perf/01).

Após apply: `VACUUM ANALYZE` em 7 tabelas afetadas para liberar espaço imediatamente (sem esperar autovacuum natural com `scale_factor=0.20` default em bronze).

## Validação
- ✅ `pg_indexes`: 0 remanescentes dos 14 nomes
- ✅ Advisor `unused_index`: **74 → 60** (-14 exato — bate com batch size)
- ✅ Outros buckets perf inalterados (`multiple_permissive_policies` 12, `unindexed_foreign_keys` 6, etc)
- Total perf findings: 97 → 83

## Risco
🟢 Baixo. Bronze é staging descartável (re-ingerível via cron); `audit_trail` é log. Rollback DDL anexado com `CREATE INDEX CONCURRENTLY IF NOT EXISTS` extraído fiel de `pg_indexes.indexdef`.

## Próximos batches (PRs separados)

| Batch | Escopo | Estimativa | Cuidado especial |
|---|---|---:|---|
| **Batch 2** | `silver` + `gold` | ~17 MB / 9 indexes | `silver.cliente_visitas.idx_cliente_visitas_cli_id` (7 MB) precisa pre-flight extra (grep por joins em `cli_id`) |
| **Batch 3** | `operations` + `financial` | ~2.4 MB / 13 indexes | `eventos_base.idx_eventos_base_conta_assinada` precisa investigar feature `conta_assinada` antes (rg no código) |
| **Batch 4** | `integrations` + `agent_ai` + `hr` + `crm` + `public` | <1 MB / ~21 indexes | Long tail |

## Snapshots
- `database/_advisor_snapshots/perf05-unused-after-batch1-2026-04-25.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)