### PR TITLE
perf/05 batch 2: drop 9 unused_indexes (silver/gold, ~16.5 MB)

### DIFF
--- a/database/_advisor_snapshots/perf05-unused-after-batch2-2026-04-26.json
+++ b/database/_advisor_snapshots/perf05-unused-after-batch2-2026-04-26.json
@@ -1,0 +1,46 @@
+{
+  "captured_at": "2026-04-26",
+  "batch": 2,
+  "scope": "silver/gold",
+  "summary": {
+    "indexes_dropped": 9,
+    "espaco_liberado_aprox_mb": 16.5,
+    "advisor_unused_index_before": 60,
+    "advisor_unused_index_after": 51,
+    "delta_advisor": -9,
+    "user_scope_unused_dropable_remaining": 51,
+    "supabase_managed_unused_dropable": 44
+  },
+  "indexes_dropped": [
+    {"schema": "silver", "table": "cliente_visitas",                                    "index": "idx_cliente_visitas_cli_id",                       "size": "7 MB",     "verdict_reason": "cli_id_contahub: ZERO callers em todo codebase (frontend/backend/db/scripts)"},
+    {"schema": "silver", "table": "cliente_estatisticas",                                "index": "idx_cliente_estatisticas_cli_id",                  "size": "5.2 MB",   "verdict_reason": "idem cli_id_contahub"},
+    {"schema": "silver", "table": "reservantes_perfil",                                  "index": "idx_reservantes_perfil_segmento",                  "size": "3.2 MB",   "verdict_reason": "segmento_reserva: ZERO callers"},
+    {"schema": "silver", "table": "reservantes_perfil",                                  "index": "idx_reservantes_perfil_vip",                       "size": "480 kB",   "verdict_reason": "is_vip hits sao em cliente_estatisticas.eh_vip context, nao reservantes_perfil"},
+    {"schema": "silver", "table": "silver_contahub_operacional_stockout_processado",    "index": "idx_stockout_proc_motivo",                         "size": "88 kB",    "verdict_reason": "motivo_exclusao aparece em SELECT clause, nao em WHERE filter"},
+    {"schema": "silver", "table": "yuzer_produtos_evento",                              "index": "idx_yuzer_produtos_evento_produto",                "size": "56 kB",    "verdict_reason": "produto_nome eh filtrado JS-side (substring includes), SQL nunca usa idx"},
+    {"schema": "silver", "table": "produtos_top",                                        "index": "idx_produtos_top_categoria",                       "size": "40 kB",    "verdict_reason": "produtos_top com filter categoria: ZERO callers"},
+    {"schema": "silver", "table": "sympla_bilheteria_diaria",                           "index": "idx_sympla_bilheteria_event_id",                   "size": "16 kB",    "verdict_reason": "idx_sympla_bilheteria_bar_data eh o composite usado"},
+    {"schema": "gold",   "table": "planejamento",                                        "index": "idx_planejamento_comercial_diario_recalculo",      "size": "8 kB",     "verdict_reason": "precisa_recalculo eh manipulado em operations.eventos_base, nao gold.planejamento (nao incluido no SELECT do refactor 2026-04-20)"}
+  ],
+  "vacuum_analyze_executado": [
+    "silver.cliente_visitas",
+    "silver.cliente_estatisticas",
+    "silver.reservantes_perfil",
+    "silver.silver_contahub_operacional_stockout_processado",
+    "silver.yuzer_produtos_evento",
+    "silver.produtos_top",
+    "silver.sympla_bilheteria_diaria",
+    "gold.planejamento"
+  ],
+  "insights_arquiteturais": [
+    "cli_id_contahub eh feature fantasma — 12.2 MB de indexes em colunas ContaHub que nunca foram consumidas no codebase",
+    "reservantes_perfil tem 3 dos 5 indexes sem caller — tabela sobreindexada, possivelmente abandonada em refactor de CRM",
+    "gold.planejamento.precisa_recalculo virou no-op apos refactor 2026-04-20 que migrou queries sem incluir esse campo no SELECT (campo continua sendo manipulado em operations.eventos_base)",
+    "yuzer.produto_nome usa pattern JS-side filter em 8 callers (produto_nome.toLowerCase().includes('ingresso')); SQL index em coluna pura nao serve substring-includes — follow-up arquitetural pra mover filtros pra SQL WHERE ILIKE"
+  ],
+  "follow_up_yuzer_jsside_filter": {
+    "tracked_as": "task pendente (sem id formal ainda — anotar no proximo plano de melhorias)",
+    "descricao": "Investigar movimentacao dos filtros yuzer JS-side -> SQL WHERE ILIKE/regex. 6+ callers identificados em Batch 2 perf/05 fazendo produto_nome.toLowerCase().includes('ingresso') em vez de WHERE produto_nome ILIKE '%ingresso%'.",
+    "ganho_esperado": "Usa indices reais (com gin trgm se necessario), reduz transferencia de dados client-side, simplifica codigo. Pode justificar criacao de novo index gin trigram em (bar_id, produto_nome) se filtros forem frequentes."
+  }
+}

--- a/database/migrations/2026-04-26-perf05-unused-indexes-batch2.rollback.sql
+++ b/database/migrations/2026-04-26-perf05-unused-indexes-batch2.rollback.sql
@@ -1,0 +1,58 @@
+-- Rollback de 2026-04-26-perf05-unused-indexes-batch2.sql.
+-- Recria 9 indexes com indexdef fiel ao snapshot capturado em 2026-04-26.
+-- Partials (WHERE clauses) preservados exatamente.
+--
+-- CREATE INDEX CONCURRENTLY: nao pode rodar em transaction block.
+-- Aplicar via execute_sql um statement por vez.
+--
+-- ATENCAO: 88 dias de stats = 0 scans em cada index. Recriacao deve
+-- acontecer apenas se observarmos degradacao mensuravel atribuivel ao
+-- drop deste batch. Cuidado especial com:
+-- - cliente_visitas/cliente_estatisticas: source of truth operacional
+--   (DOMAIN_MAP). Se alguma feature comecar a usar cli_id_contahub,
+--   recriar antes do rollout.
+-- - gold.planejamento.precisa_recalculo: se o refactor 2026-04-20
+--   evoluir pra usar precisa_recalculo na gold (em vez de eventos_base),
+--   recriar.
+
+-- ============================================
+-- silver (8 indexes)
+-- ============================================
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cliente_visitas_cli_id
+  ON silver.cliente_visitas
+  USING btree (bar_id, cli_id_contahub) WHERE (cli_id_contahub IS NOT NULL);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cliente_estatisticas_cli_id
+  ON silver.cliente_estatisticas
+  USING btree (bar_id, cli_id_contahub) WHERE (cli_id_contahub IS NOT NULL);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_reservantes_perfil_segmento
+  ON silver.reservantes_perfil
+  USING btree (bar_id, segmento_reserva);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_reservantes_perfil_vip
+  ON silver.reservantes_perfil
+  USING btree (bar_id, is_vip) WHERE (is_vip = true);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_stockout_proc_motivo
+  ON silver.silver_contahub_operacional_stockout_processado
+  USING btree (motivo_exclusao) WHERE (motivo_exclusao IS NOT NULL);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_yuzer_produtos_evento_produto
+  ON silver.yuzer_produtos_evento
+  USING btree (bar_id, produto_nome);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_produtos_top_categoria
+  ON silver.produtos_top
+  USING btree (bar_id, categoria) WHERE (categoria IS NOT NULL);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sympla_bilheteria_event_id
+  ON silver.sympla_bilheteria_diaria
+  USING btree (bar_id, event_id) WHERE (event_id IS NOT NULL);
+
+-- ============================================
+-- gold (1 index)
+-- ============================================
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_planejamento_comercial_diario_recalculo
+  ON gold.planejamento
+  USING btree (precisa_recalculo) WHERE (precisa_recalculo = true);

--- a/database/migrations/2026-04-26-perf05-unused-indexes-batch2.sql
+++ b/database/migrations/2026-04-26-perf05-unused-indexes-batch2.sql
@@ -1,0 +1,55 @@
+-- perf/05 Batch 2 — DROP de 9 indexes unused em silver/gold (~16.5 MB)
+--
+-- ESCOPO: silver (8) + gold (1) — categoria operacional, exigiu pre-flight
+-- redobrado (silver e source of truth para queries operacionais).
+--
+-- JANELA: server uptime de 88 dias (~3 meses de stats acumulados).
+-- last_idx_scan = NULL em todos os 9 — nunca foram scanned desde boot.
+--
+-- PRE-FLIGHT REDOBRADO (Gate 1) — 4 vetores de validacao por index:
+-- (a) Grep no codigo (frontend/backend/database/scripts) por colunas
+--     indexadas
+-- (b) Composite check em pg_indexes (outros indexes que cubram o mesmo padrao)
+-- (c) pg_stat_statements check (queries reais que filtrem nas colunas)
+-- (d) pg_stat_user_indexes idx_scan = 0 + last_idx_scan = NULL
+--
+-- TODOS os 9 confirmados dead em todos os 4 vetores. Insights:
+-- - cli_id_contahub: ZERO callers em 12.2 MB combinados (cliente_visitas
+--   + cliente_estatisticas). Feature fantasma — provavelmente era pra
+--   "ID externo ContaHub" que nunca shippou.
+-- - reservantes_perfil: 3 dos 5 indexes sem caller. is_vip confunde com
+--   cliente_estatisticas.eh_vip (que TEM index e callers reais).
+-- - gold.planejamento.precisa_recalculo: refactor 2026-04-20 migrou
+--   queries pra gold.planejamento mas precisa_recalculo continua sendo
+--   manipulado em operations.eventos_base. Index virou no-op em gold.
+-- - yuzer.produto_nome: 8 callers usam JS-side filter
+--   (produto_nome.toLowerCase().includes(...)) em vez de SQL WHERE.
+--   SQL index em produto_nome puro nunca seria usado por padrao
+--   substring-includes. Anotado como follow-up arquitetural.
+--
+-- ESPACO LIBERADO: ~16.5 MB.
+--
+-- APLICACAO: DROP INDEX CONCURRENTLY nao roda em transaction block.
+-- Usar mcp__supabase__execute_sql um DROP por chamada (mesmo padrao
+-- da Fase 1 / perf/01 / batch 1).
+--
+-- ROLLBACK: 9 CREATE INDEX CONCURRENTLY IF NOT EXISTS no
+-- 2026-04-26-perf05-unused-indexes-batch2.rollback.sql, com indexdef
+-- fiel (incluindo partials WHERE cli_id_contahub IS NOT NULL, etc).
+
+-- ============================================
+-- silver (8 indexes, ~16.5 MB)
+-- ============================================
+DROP INDEX CONCURRENTLY IF EXISTS silver.idx_cliente_visitas_cli_id;
+DROP INDEX CONCURRENTLY IF EXISTS silver.idx_cliente_estatisticas_cli_id;
+DROP INDEX CONCURRENTLY IF EXISTS silver.idx_reservantes_perfil_segmento;
+DROP INDEX CONCURRENTLY IF EXISTS silver.idx_reservantes_perfil_vip;
+DROP INDEX CONCURRENTLY IF EXISTS silver.idx_stockout_proc_motivo;
+DROP INDEX CONCURRENTLY IF EXISTS silver.idx_yuzer_produtos_evento_produto;
+DROP INDEX CONCURRENTLY IF EXISTS silver.idx_produtos_top_categoria;
+DROP INDEX CONCURRENTLY IF EXISTS silver.idx_sympla_bilheteria_event_id;
+
+-- ============================================
+-- gold (1 index, 8 kB)
+-- ============================================
+DROP INDEX CONCURRENTLY IF EXISTS gold.idx_planejamento_comercial_diario_recalculo;


### PR DESCRIPTION
## O que
DROP de 9 indexes em `silver` (8) + `gold` (1) com **`idx_scan = 0` e `last_idx_scan = NULL`** ao longo de 88 dias. Pre-flight redobrado em silver (source of truth para queries operacionais segundo DOMAIN_MAP) com 4 vetores de validação por index.

## Pre-flight redobrado (Gate 1)

Cada index passou por 4 sondagens:
- (a) Grep no código (frontend/backend/database/scripts) por colunas indexadas
- (b) Composite check em `pg_indexes` (outros indexes que cubram o mesmo padrão)
- (c) `pg_stat_statements` (queries reais filtrando nas colunas)
- (d) `idx_scan = 0` + `last_idx_scan = NULL`

**9/9 confirmados dead em todos os 4 vetores. Zero SKIPs.**

| # | Index | Tamanho | Verdict reason |
|---|---|---:|---|
| 1 | `silver.cliente_visitas.idx_cliente_visitas_cli_id` | 7 MB | `cli_id_contahub`: ZERO callers em todo codebase |
| 2 | `silver.cliente_estatisticas.idx_cliente_estatisticas_cli_id` | 5.2 MB | idem |
| 3 | `silver.reservantes_perfil.idx_reservantes_perfil_segmento` | 3.2 MB | `segmento_reserva`: ZERO callers |
| 4 | `silver.reservantes_perfil.idx_reservantes_perfil_vip` | 480 kB | `is_vip` hits são em `cliente_estatisticas.eh_vip` context |
| 5 | `silver.silver_contahub_operacional_stockout_processado.idx_stockout_proc_motivo` | 88 kB | `motivo_exclusao` aparece em SELECT, não em WHERE |
| 6 | `silver.yuzer_produtos_evento.idx_yuzer_produtos_evento_produto` | 56 kB | `produto_nome` filtrado JS-side, não SQL |
| 7 | `silver.produtos_top.idx_produtos_top_categoria` | 40 kB | filtro `produtos_top.categoria`: ZERO callers |
| 8 | `silver.sympla_bilheteria_diaria.idx_sympla_bilheteria_event_id` | 16 kB | `idx_sympla_bilheteria_bar_data` é o composite usado |
| 9 | `gold.planejamento.idx_planejamento_comercial_diario_recalculo` | 8 kB | `precisa_recalculo` manipulado em `eventos_base`, não gold |
| **Total** | | **~16.5 MB** | |

## Insights arquiteturais (do Gate 1)

### 1. `cli_id_contahub` é feature fantasma (12.2 MB combinados)

Os 2 maiores indexes do batch (`silver.cliente_visitas` 7 MB + `silver.cliente_estatisticas` 5.2 MB) estão na coluna `cli_id_contahub`. **Zero hits no codebase inteiro** (frontend/backend/database/scripts). Provavelmente era pra hipotetizada feature de "ID externo ContaHub" que nunca shippou.

### 2. `silver.reservantes_perfil` foi sobre-indexada

3 dos 5 indexes não-PK/UNIQUE não têm caller. O `is_vip` aqui confunde com `cliente_estatisticas.eh_vip` (que TEM index `idx_cliente_estatisticas_vip` e callers reais). Hipótese: tabela paralela legada de refactor de CRM.

### 3. `gold.planejamento.precisa_recalculo` virou no-op

Refactor 2026-04-20 migrou queries de planejamento pra `gold.planejamento` mas não incluiu `precisa_recalculo` no SELECT do gold. O campo continua sendo manipulado em `operations.eventos_base` (que é o lugar certo, baseado na lógica de "marcar evento como pending recalculation"). O index gold ficou órfão.

### 4. ⚠️ Pattern arquitetural: yuzer JS-side filter (anotado como follow-up)

8 callers fazem filtro JS-side em `produto_nome`:
```ts
item.produto_nome.toLowerCase().includes('ingresso')
```
SQL index em coluna pura **nunca** seria usado por padrão substring-includes. **Follow-up arquitetural**: investigar movimentação dos filtros yuzer JS-side → SQL `WHERE produto_nome ILIKE '%ingresso%'`. Ganho: usa indices reais (com gin trgm se necessário), reduz transferência client-side, simplifica código. Pode justificar criação de novo gin trgm index em `(bar_id, produto_nome)` se filtros forem frequentes.

## Validação
- ✅ `pg_indexes`: 0 remanescentes dos 9 nomes
- ✅ Advisor `unused_index`: **60 → 51** (delta -9 exato)
- ✅ User-scope unused dropable: 60 → 51 (bate com advisor)
- ✅ Outros buckets perf inalterados (`multiple_permissive_policies` 12, `unindexed_foreign_keys` 6, etc)

## Aplicação
- 9 `mcp__supabase__execute_sql DROP CONCURRENTLY` em paralelo (plano A `apply_migration` não funciona com CONCURRENTLY — mesmo padrão validado em perf/01 e batch 1)
- `VACUUM ANALYZE` pós-DROP em 8 tabelas afetadas pra liberar espaço imediatamente

## Risco
🟢 Baixo. Pre-flight redobrado em silver (source of truth) eliminou todas as ambiguidades. Rollback DDL anexado com partials WHERE preservados exatamente (`cli_id_contahub IS NOT NULL`, `is_vip = true`, `motivo_exclusao IS NOT NULL`, `categoria IS NOT NULL`, `event_id IS NOT NULL`, `precisa_recalculo = true`).

## Próximos batches

| Batch | Escopo | Estimativa | Cuidado especial |
|---|---|---:|---|
| **Batch 3** | operations + financial | ~13 indexes / ~2.4 MB | `eventos_base.idx_eventos_base_conta_assinada` precisa investigação prévia (`rg "conta_assinada"` no repo) |
| **Batch 4** | integrations + agent_ai + hr + crm + public | ~20 indexes / <1 MB | Long tail |

## Snapshots
- `database/_advisor_snapshots/perf05-unused-after-batch2-2026-04-26.json`

## Sprint perf/05 — progresso

| Batch | Indexes | Espaço | Advisor delta |
|---|---:|---:|---:|
| Batch 1 (PR #20) | 14 | ~23.4 MB | 74 → 60 |
| **Batch 2 (este PR)** | **9** | **~16.5 MB** | **60 → 51** |
| Total acumulado | **23** | **~39.9 MB** | **74 → 51** (-31%) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)