### PR TITLE
perf/05 batch 3: drop 13 unused_indexes (operations, ~2.3 MB)

### DIFF
--- a/database/_advisor_snapshots/perf05-unused-after-batch3-2026-04-26.json
+++ b/database/_advisor_snapshots/perf05-unused-after-batch3-2026-04-26.json
@@ -1,0 +1,43 @@
+{
+  "snapshot_at": "2026-04-26",
+  "phase": "perf/05 batch 3 — operations + financial",
+  "applied_drops": 13,
+  "schemas_targeted": ["operations", "financial"],
+  "indexes_dropped": [
+    {"schema": "operations", "table": "eventos_base", "index": "idx_eventos_base_conta_assinada", "size_bytes": 1572864, "kind": "partial"},
+    {"schema": "operations", "table": "checklist_agendamentos", "index": "idx_checklist_agendamentos_bar_data", "size_bytes": 212992, "kind": "btree"},
+    {"schema": "operations", "table": "checklist_agendamentos", "index": "idx_checklist_agendamentos_deadline", "size_bytes": 155648, "kind": "btree"},
+    {"schema": "operations", "table": "eventos_base", "index": "idx_eventos_base_cancelamentos", "size_bytes": 106496, "kind": "partial"},
+    {"schema": "operations", "table": "checklist_automation_logs", "index": "idx_checklist_automation_logs_schedule", "size_bytes": 65536, "kind": "btree"},
+    {"schema": "operations", "table": "checklist_automation_logs", "index": "idx_checklist_automation_logs_execution_id", "size_bytes": 65536, "kind": "btree"},
+    {"schema": "operations", "table": "checklist_agendamentos", "index": "idx_checklist_agendamentos_status", "size_bytes": 65536, "kind": "btree"},
+    {"schema": "operations", "table": "checklist_agendamentos", "index": "idx_checklist_agendamentos_responsavel", "size_bytes": 65536, "kind": "btree"},
+    {"schema": "operations", "table": "checklist_automation_logs", "index": "idx_checklist_automation_logs_tipo", "size_bytes": 65536, "kind": "btree"},
+    {"schema": "operations", "table": "config_metas_planejamento", "index": "idx_config_metas_bar_ano", "size_bytes": 16384, "kind": "duplicate-of-unique"},
+    {"schema": "operations", "table": "bares_config", "index": "idx_bares_config_bar_id", "size_bytes": 16384, "kind": "duplicate-of-unique"},
+    {"schema": "operations", "table": "bar_local_mapeamento", "index": "idx_bar_local_mapeamento_bar_id", "size_bytes": 16384, "kind": "prefix-of-unique"},
+    {"schema": "operations", "table": "bar_local_mapeamento", "index": "idx_bar_local_mapeamento_categoria", "size_bytes": 16384, "kind": "btree"}
+  ],
+  "total_freed_bytes": 2441216,
+  "total_freed_pretty": "~2.3 MB",
+  "advisor_unused_index_count_pre": 51,
+  "advisor_unused_index_count_post": 38,
+  "advisor_unused_index_diff": 13,
+  "vacuum_analyze_tables": [
+    "operations.eventos_base",
+    "operations.checklist_agendamentos",
+    "operations.checklist_automation_logs",
+    "operations.config_metas_planejamento",
+    "operations.bares_config",
+    "operations.bar_local_mapeamento"
+  ],
+  "insights": [
+    "idx_eventos_base_conta_assinada (1.5MB partial) — feature ATIVA (35 hits no grep) mas WHERE filter NUNCA usado em pg_stat_statements. Index criado out-of-band sem rastro no git (mesmo anti-pattern de Fase 4 reloptions).",
+    "idx_eventos_base_cancelamentos — mesmo padrão: partial dead apesar da feature alive.",
+    "idx_bares_config_bar_id e idx_config_metas_bar_ano — duplicatas EXATAS de UNIQUE constraints (advisor não detecta dup com UNIQUE).",
+    "idx_bar_local_mapeamento_bar_id — prefix de UNIQUE (bar_id, categoria), redundante.",
+    "checklist_automation_logs é 100% append-only: 6073 INSERTs vs 0 SELECTs com WHERE em (tipo|schedule|execution_id). 3 indexes nunca leram nada.",
+    "checklist_agendamentos: 4 compostos mortos. Top query é WHERE bar_id=X (idx_checklist_agendamentos_bar cobre). Compostos inventados pra padrões que nunca aconteceram.",
+    "financial schema: 0 candidatos pós-pre-flight (todos os indexes têm idx_scan > 0)."
+  ]
+}

--- a/database/migrations/2026-04-26-perf05-unused-indexes-batch3.rollback.sql
+++ b/database/migrations/2026-04-26-perf05-unused-indexes-batch3.rollback.sql
@@ -1,0 +1,57 @@
+-- ROLLBACK perf/05 batch 3 — operations + financial unused_indexes
+-- Recria os 13 índices na configuração exata pré-DROP (extraída de pg_indexes em 2026-04-26).
+-- Aplicar com CONCURRENTLY pra não bloquear writes em produção.
+
+-- 1. operations.eventos_base — partial WHERE conta_assinada > 0
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_eventos_base_conta_assinada
+  ON operations.eventos_base USING btree (conta_assinada)
+  WHERE (conta_assinada > (0)::numeric);
+
+-- 2. operations.checklist_agendamentos — (bar_id, data_agendada)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_checklist_agendamentos_bar_data
+  ON operations.checklist_agendamentos USING btree (bar_id, data_agendada);
+
+-- 3. operations.checklist_agendamentos — (deadline DESC)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_checklist_agendamentos_deadline
+  ON operations.checklist_agendamentos USING btree (deadline DESC);
+
+-- 4. operations.eventos_base — partial WHERE cancelamentos > 0
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_eventos_base_cancelamentos
+  ON operations.eventos_base USING btree (cancelamentos)
+  WHERE (cancelamentos > (0)::numeric);
+
+-- 5. operations.checklist_automation_logs — (checklist_schedule_id)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_checklist_automation_logs_schedule
+  ON operations.checklist_automation_logs USING btree (checklist_schedule_id);
+
+-- 6. operations.checklist_automation_logs — (checklist_auto_execution_id)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_checklist_automation_logs_execution_id
+  ON operations.checklist_automation_logs USING btree (checklist_auto_execution_id);
+
+-- 7. operations.checklist_agendamentos — (status, bar_id)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_checklist_agendamentos_status
+  ON operations.checklist_agendamentos USING btree (status, bar_id);
+
+-- 8. operations.checklist_agendamentos — (responsavel_id, status)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_checklist_agendamentos_responsavel
+  ON operations.checklist_agendamentos USING btree (responsavel_id, status);
+
+-- 9. operations.checklist_automation_logs — (tipo)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_checklist_automation_logs_tipo
+  ON operations.checklist_automation_logs USING btree (tipo);
+
+-- 10. operations.config_metas_planejamento — (bar_id, ano)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_config_metas_bar_ano
+  ON operations.config_metas_planejamento USING btree (bar_id, ano);
+
+-- 11. operations.bares_config — (bar_id)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bares_config_bar_id
+  ON operations.bares_config USING btree (bar_id);
+
+-- 12. operations.bar_local_mapeamento — (bar_id)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bar_local_mapeamento_bar_id
+  ON operations.bar_local_mapeamento USING btree (bar_id);
+
+-- 13. operations.bar_local_mapeamento — (categoria)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bar_local_mapeamento_categoria
+  ON operations.bar_local_mapeamento USING btree (categoria);

--- a/database/migrations/2026-04-26-perf05-unused-indexes-batch3.sql
+++ b/database/migrations/2026-04-26-perf05-unused-indexes-batch3.sql
@@ -1,0 +1,63 @@
+-- perf/05 batch 3 — operations + financial unused_indexes
+-- Drops 13 indexes flagged como unused_index (idx_scan = 0 em janela de 87 dias).
+-- Audit 4 vetores: grep código, composite check, pg_stat_statements, idx_scan/last_idx_scan.
+--
+-- Insights:
+--   * idx_eventos_base_conta_assinada (1.5 MB, parcial WHERE conta_assinada > 0):
+--     feature está ativa (35 hits no grep), mas WHERE filter nunca foi usado.
+--     Index criado fora do controle de migrations (sem rastro no git).
+--   * idx_eventos_base_cancelamentos: mesmo padrão, parcial nunca filtrado.
+--   * idx_bares_config_bar_id: DUPLICATE de UNIQUE bares_config_bar_id_key.
+--   * idx_config_metas_bar_ano: DUPLICATE de UNIQUE uq_config_metas_bar_ano.
+--   * idx_bar_local_mapeamento_bar_id: prefix-cobertura de UNIQUE (bar_id, categoria).
+--   * checklist_agendamentos compostos (4): nenhum query filtra (bar_id,data_agendada),
+--     (deadline DESC), (status,bar_id) ou (responsavel_id,status). Cobertos por
+--     idx_checklist_agendamentos_bar e idx_checklist_agendamentos_data.
+--   * checklist_automation_logs (3): tabela 100% append-only, INSERTs nunca consultam
+--     checklist_schedule_id, checklist_auto_execution_id ou tipo via WHERE.
+--   * financial schema: 0 candidatos pós-pre-flight (nenhum index com idx_scan=0).
+--
+-- Apply mode: DROP INDEX CONCURRENTLY (não pode rodar dentro de transação).
+-- Cada DROP aplicado individualmente via execute_sql, não apply_migration.
+
+-- 1. operations.eventos_base — partial WHERE conta_assinada > 0 (1.5 MB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_eventos_base_conta_assinada;
+
+-- 2. operations.checklist_agendamentos — (bar_id, data_agendada) (208 kB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_checklist_agendamentos_bar_data;
+
+-- 3. operations.checklist_agendamentos — (deadline DESC) (152 kB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_checklist_agendamentos_deadline;
+
+-- 4. operations.eventos_base — partial WHERE cancelamentos > 0 (104 kB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_eventos_base_cancelamentos;
+
+-- 5. operations.checklist_automation_logs — (checklist_schedule_id) (64 kB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_checklist_automation_logs_schedule;
+
+-- 6. operations.checklist_automation_logs — (checklist_auto_execution_id) (64 kB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_checklist_automation_logs_execution_id;
+
+-- 7. operations.checklist_agendamentos — (status, bar_id) (64 kB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_checklist_agendamentos_status;
+
+-- 8. operations.checklist_agendamentos — (responsavel_id, status) (64 kB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_checklist_agendamentos_responsavel;
+
+-- 9. operations.checklist_automation_logs — (tipo) (64 kB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_checklist_automation_logs_tipo;
+
+-- 10. operations.config_metas_planejamento — DUPLICATE de uq_config_metas_bar_ano (16 kB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_config_metas_bar_ano;
+
+-- 11. operations.bares_config — DUPLICATE de bares_config_bar_id_key (16 kB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_bares_config_bar_id;
+
+-- 12. operations.bar_local_mapeamento — prefix de bar_local_mapeamento_bar_id_categoria_key (16 kB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_bar_local_mapeamento_bar_id;
+
+-- 13. operations.bar_local_mapeamento — (categoria) standalone, nunca filtrado (16 kB)
+DROP INDEX CONCURRENTLY IF EXISTS operations.idx_bar_local_mapeamento_categoria;
+
+-- Total esperado liberado: ~2.3 MB
+-- Pós-DROP: VACUUM ANALYZE em 6 tabelas afetadas.


### PR DESCRIPTION
## Summary

Quarto e último batch grande do **perf/05 unused_indexes**: 13 índices em `operations` (financial: 0 candidatos pós-pre-flight). Total liberado: ~2.3 MB.

Audit em 4 vetores: grep código + composite check + pg_stat_statements + idx_scan/last_idx_scan. Janela de stats: 87 dias (uptime desde 2026-01-28).

## Indexes dropped (13)

| # | Schema | Tabela | Index | Tamanho | Motivo |
|---|--------|--------|-------|---------|--------|
| 1 | operations | eventos_base | idx_eventos_base_conta_assinada | 1.5 MB | Partial nunca filtrado |
| 2 | operations | checklist_agendamentos | idx_checklist_agendamentos_bar_data | 208 kB | (bar_id, data_agendada) nunca filtrado junto |
| 3 | operations | checklist_agendamentos | idx_checklist_agendamentos_deadline | 152 kB | Nunca ORDER BY deadline |
| 4 | operations | eventos_base | idx_eventos_base_cancelamentos | 104 kB | Partial nunca filtrado |
| 5 | operations | checklist_automation_logs | idx_checklist_automation_logs_schedule | 64 kB | Tabela append-only |
| 6 | operations | checklist_automation_logs | idx_checklist_automation_logs_execution_id | 64 kB | Tabela append-only |
| 7 | operations | checklist_agendamentos | idx_checklist_agendamentos_status | 64 kB | (status, bar_id) nunca filtrado |
| 8 | operations | checklist_agendamentos | idx_checklist_agendamentos_responsavel | 64 kB | responsavel_id usado em outra tabela |
| 9 | operations | checklist_automation_logs | idx_checklist_automation_logs_tipo | 64 kB | Tabela append-only |
| 10 | operations | config_metas_planejamento | idx_config_metas_bar_ano | 16 kB | **DUPLICATE** de UNIQUE uq_config_metas_bar_ano |
| 11 | operations | bares_config | idx_bares_config_bar_id | 16 kB | **DUPLICATE** de UNIQUE bares_config_bar_id_key |
| 12 | operations | bar_local_mapeamento | idx_bar_local_mapeamento_bar_id | 16 kB | Prefix de UNIQUE (bar_id, categoria) |
| 13 | operations | bar_local_mapeamento | idx_bar_local_mapeamento_categoria | 16 kB | categoria standalone nunca filtrado |

## Insights notáveis

- **`idx_eventos_base_conta_assinada` (1.5 MB)** — feature está **ATIVA** (35 hits no grep), mas o WHERE filter `WHERE conta_assinada > 0` **nunca** apareceu em pg_stat_statements. Code só faz `SELECT conta_assinada` ou `UPDATE` direto. Index criado out-of-band sem rastro no git blame (mesmo anti-pattern do follow-up #40 sobre eventos_base reloptions).
- **`idx_bares_config_bar_id` e `idx_config_metas_bar_ano`** são **duplicatas EXATAS de UNIQUE constraints**. O advisor não detecta dup com UNIQUE — só com PRIMARY KEY ou outro INDEX comum.
- **`checklist_automation_logs`** é 100% append-only: 6073 INSERTs vs 0 SELECTs com WHERE em (tipo|schedule_id|execution_id). Os 3 indexes nunca leram nada — o edge function `checklist-auto-scheduler` só insere.
- **`checklist_agendamentos`**: top query é `WHERE bar_id = X` (20896 calls) coberta por `idx_checklist_agendamentos_bar`. Os 4 compostos foram inventados pra padrões que nunca aconteceram.
- **financial schema: 0 candidatos** — todos os indexes em `dre_manual`, `view_dre`, etc têm `idx_scan > 0`.

## Apply mode

`DROP INDEX CONCURRENTLY` via `execute_sql` (Plano B — `CONCURRENTLY` é incompatível com o transaction wrapper de `apply_migration`). Cada DROP rodado individualmente em paralelo.

Pós-DROP: `VACUUM ANALYZE` em 6 tabelas afetadas.

## Advisor

- **unused_index pré-apply:** 51
- **unused_index pós-apply:** 38
- **Diff:** -13 ✓ (bate exato com o número de DROPs)

## Test plan

- [x] Gate 1: 4-vector audit em 13 candidatos confirmou todos como DROP
- [x] DROP INDEX CONCURRENTLY aplicado em todos os 13 (execute_sql)
- [x] Verificação pós-DROP: pg_stat_user_indexes retorna 0 rows pros 13 indexes
- [x] VACUUM ANALYZE em operations.eventos_base, checklist_agendamentos, checklist_automation_logs, config_metas_planejamento, bares_config, bar_local_mapeamento
- [x] Advisor diff: 51 → 38 unused_index

## Rollback

`database/migrations/2026-04-26-perf05-unused-indexes-batch3.rollback.sql` recria todos os 13 com `CREATE INDEX CONCURRENTLY` (definição idêntica à pré-DROP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)