### PR TITLE
refactor: consolidate RLS helpers — alias deprecated user_has_access_to_bar (#42 Fase 1)

### DIFF
--- a/database/functions/user_has_access_to_bar.sql
+++ b/database/functions/user_has_access_to_bar.sql
@@ -1,3 +1,14 @@
-﻿-- Função: user_has_access_to_bar
-CREATE OR REPLACE FUNCTION public.user_has_access_to_bar(p_bar_id integer) RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public', 'pg_temp'
-AS $$ SELECT EXISTS (SELECT 1 FROM user_bars WHERE user_id = auth.uid() AND bar_id = p_bar_id); $$;
+-- Função: user_has_access_to_bar
+-- DEPRECATED 2026-04-26 (#42 Fase 1): alias delega para public.user_has_bar_access.
+-- Não usar em código novo. Plano de remoção em #42 Fases 2-3.
+CREATE OR REPLACE FUNCTION public.user_has_access_to_bar(p_bar_id integer)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  SELECT public.user_has_bar_access(p_bar_id);
+$$;
+
+COMMENT ON FUNCTION public.user_has_access_to_bar(integer) IS
+  'DEPRECATED 2026-04-26: alias para public.user_has_bar_access. Não usar em código novo.';

--- a/database/migrations/2026-04-26-rls-helpers-consolidation.rollback.sql
+++ b/database/migrations/2026-04-26-rls-helpers-consolidation.rollback.sql
@@ -1,0 +1,18 @@
+-- ROLLBACK B.1 — restaurar corpo original de user_has_access_to_bar (com JOIN)
+
+CREATE OR REPLACE FUNCTION public.user_has_access_to_bar(p_bar_id integer)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.usuarios_bares ub
+    JOIN public.usuarios u ON u.auth_id = auth.uid()
+    WHERE ub.usuario_id = u.auth_id
+      AND ub.bar_id = p_bar_id
+  );
+$function$;
+
+COMMENT ON FUNCTION public.user_has_access_to_bar(integer) IS NULL;

--- a/database/migrations/2026-04-26-rls-helpers-consolidation.sql
+++ b/database/migrations/2026-04-26-rls-helpers-consolidation.sql
@@ -1,0 +1,42 @@
+-- B.1 — RLS helpers consolidation (#42 follow-up)
+--
+-- Estado atual: dois helpers semanticamente equivalentes coexistem.
+--
+--   public.user_has_bar_access(check_bar_id integer)    [49 policies]
+--     → SELECT EXISTS (SELECT 1 FROM public.usuarios_bares
+--                      WHERE usuario_id = auth.uid() AND bar_id = check_bar_id)
+--
+--   public.user_has_access_to_bar(p_bar_id integer)     [71 policies]
+--     → SELECT EXISTS (SELECT 1 FROM public.usuarios_bares ub
+--                      JOIN public.usuarios u ON u.auth_id = auth.uid()
+--                      WHERE ub.usuario_id = u.auth_id AND ub.bar_id = p_bar_id)
+--
+-- Equivalência semântica confirmada via:
+--   - FK: usuarios_bares.usuario_id → usuarios.auth_id ON DELETE CASCADE
+--   - Zero órfãs em SELECT … LEFT JOIN usuarios … WHERE u.auth_id IS NULL
+--
+-- Performance: user_has_bar_access faz 1 index lookup; user_has_access_to_bar
+-- faz 2 (JOIN extra). Versão canônica é user_has_bar_access.
+--
+-- Estratégia (Fase 1): substituir corpo de user_has_access_to_bar para
+-- DELEGAR pra user_has_bar_access. Marcar como deprecated. Zero policies
+-- precisam ser reescritas — o alias preserva 100% do contrato. As 71 policies
+-- que usam user_has_access_to_bar ganham 1 index lookup a menos automaticamente.
+--
+-- Fase 2 (futuro PR): reescrever 71 policies para chamar user_has_bar_access
+-- diretamente, depois Fase 3 droparia user_has_access_to_bar.
+
+CREATE OR REPLACE FUNCTION public.user_has_access_to_bar(p_bar_id integer)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  -- DEPRECATED: use public.user_has_bar_access(check_bar_id) directly em novo código.
+  -- Mantido como alias para preservar contrato com 71 policies existentes.
+  -- Plano de remoção: ver task #42 (Fase 2 reescreve policies, Fase 3 dropa).
+  SELECT public.user_has_bar_access(p_bar_id);
+$function$;
+
+COMMENT ON FUNCTION public.user_has_access_to_bar(integer) IS
+  'DEPRECATED 2026-04-26: alias para public.user_has_bar_access. Não usar em código novo.';


### PR DESCRIPTION
## Summary

**B.1 do Bloco B follow-ups.** Resolve #42 (helpers RLS duplicados) em **3 fases** — esta é a Fase 1 (alias), de baixo risco.

## Pre-flight Gate 1

Dois helpers semanticamente equivalentes coexistem:

| Função | Policies | Lookups | Body |
|--------|----------|---------|------|
| \`public.user_has_bar_access(check_bar_id)\` | **49** | 1 (index direto) | \`SELECT 1 FROM usuarios_bares WHERE usuario_id = auth.uid() AND bar_id = check_bar_id\` |
| \`public.user_has_access_to_bar(p_bar_id)\` | **71** | 2 (JOIN extra com usuarios) | \`SELECT 1 FROM usuarios_bares ub JOIN usuarios u ON u.auth_id = auth.uid() WHERE ub.usuario_id = u.auth_id AND ub.bar_id = p_bar_id\` |

**Equivalência semântica confirmada via:**
- FK \`usuarios_bares.usuario_id → usuarios.auth_id ON DELETE CASCADE\`
- Zero órfãs em \`SELECT … LEFT JOIN usuarios u ON u.auth_id = ub.usuario_id WHERE u.auth_id IS NULL\`

## Decisão

**Canônica:** \`user_has_bar_access\` — mais simples, 1 lookup a menos, e foi adotada como padrão na sprint sec/01-03.

## Estratégia (3 fases)

- **Fase 1 (este PR):** substituir corpo de \`user_has_access_to_bar\` para **delegar** a \`user_has_bar_access\`. Zero policies reescritas — alias preserva 100% do contrato. As 71 policies que usam o helper deprecated ganham 1 index lookup a menos automaticamente.
- **Fase 2** (PR futuro): \`ALTER POLICY\` em 71 policies pra chamar \`user_has_bar_access\` diretamente.
- **Fase 3** (PR futuro): \`DROP FUNCTION user_has_access_to_bar\` após confirmar zero refs.

## Smoke

\`\`\`sql
-- Before
SELECT user_has_bar_access(3), user_has_access_to_bar(3),
       user_has_bar_access(99), user_has_access_to_bar(99);
-- → false, false, false, false (service_role context, sem auth.uid)

-- After (mesmo resultado)
-- → false, false, false, false ✓
\`\`\`

## Test plan

- [x] Pre-flight: FK + LEFT JOIN órfãs check confirmou equivalência semântica
- [x] Migration aplicada via apply_migration (DDL transactional, sem CONCURRENTLY)
- [x] Smoke after: comportamento idêntico
- [x] \`pg_get_functiondef\` confirma que body novo é \`SELECT public.user_has_bar_access(p_bar_id)\`

## Rollback

\`database/migrations/2026-04-26-rls-helpers-consolidation.rollback.sql\` restaura corpo original com JOIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)