### PR TITLE
refactor(yuzer): JS-side filter -> SQL ILIKE (-95% payload, 2 callers)

### DIFF
--- a/frontend/src/app/api/analitico/semanal/route.ts
+++ b/frontend/src/app/api/analitico/semanal/route.ts
@@ -361,19 +361,19 @@ export async function GET(request: NextRequest) {
       );
       
       // Buscar pessoas do Yuzer e Sympla
+      // Filtro de produtos (ingresso/entrada) feito no SQL via ILIKE — evita transferir
+      // payload completo e excluir em JS. ILIKE também trata NULL automaticamente.
       const { data: yuzerProdutos } = await supabase
         .from('silver_yuzer_produtos_evento')
-        .select('quantidade, produto_nome')
+        .select('quantidade')
         .eq('bar_id', barIdNum)
         .gte('data_evento', inicioData)
-        .lte('data_evento', fimData);
-      
-      const pessoasYuzer = yuzerProdutos?.filter(item => 
-        item.produto_nome && (
-          item.produto_nome.toLowerCase().includes('ingresso') || 
-          item.produto_nome.toLowerCase().includes('entrada')
-        )
-      ).reduce((sum, item) => sum + (parseInt(item.quantidade) || 0), 0) || 0;
+        .lte('data_evento', fimData)
+        .or('produto_nome.ilike.%ingresso%,produto_nome.ilike.%entrada%');
+
+      const pessoasYuzer = yuzerProdutos?.reduce(
+        (sum, item) => sum + (parseInt(item.quantidade) || 0), 0
+      ) || 0;
       
       const { data: symplaParticipantes } = await supabase
         .from('sympla_participantes')

--- a/frontend/src/app/api/visao-geral/indicadores-mensais/route.ts
+++ b/frontend/src/app/api/visao-geral/indicadores-mensais/route.ts
@@ -390,19 +390,19 @@ export async function GET(request: NextRequest) {
       );
       
       // Buscar pessoas do Yuzer e Sympla (se houver)
+      // Filtro de produtos (ingresso/entrada) feito no SQL via ILIKE — evita transferir
+      // payload completo e excluir em JS. ILIKE também trata NULL automaticamente.
       const { data: yuzerProdutos } = await supabase
         .from('silver_yuzer_produtos_evento')
-        .select('quantidade, produto_nome')
+        .select('quantidade')
         .eq('bar_id', barIdNum)
         .gte('data_evento', inicioMes)
-        .lte('data_evento', fimMes);
-      
-      const pessoasYuzer = yuzerProdutos?.filter(item => 
-        item.produto_nome && (
-          item.produto_nome.toLowerCase().includes('ingresso') || 
-          item.produto_nome.toLowerCase().includes('entrada')
-        )
-      ).reduce((sum, item) => sum + (parseInt(item.quantidade) || 0), 0) || 0;
+        .lte('data_evento', fimMes)
+        .or('produto_nome.ilike.%ingresso%,produto_nome.ilike.%entrada%');
+
+      const pessoasYuzer = yuzerProdutos?.reduce(
+        (sum, item) => sum + (parseInt(item.quantidade) || 0), 0
+      ) || 0;
       
       const { data: symplaParticipantes } = await supabase
         .from('sympla_participantes')


### PR DESCRIPTION
## Summary

**B.2 do Bloco B follow-ups.** Yuzer products: filter \`ingresso\`/\`entrada\` movido de JS pra SQL.

## Pre-flight Gate 1

**Surpresa benigna:** apenas **2 callers** (estimativa era 8). Greps mais amplos (\`yuzerProdutos?.filter\`, \`includes\('ingresso'\)\`) confirmam:
- \`frontend/src/app/api/visao-geral/indicadores-mensais/route.ts\`
- \`frontend/src/app/api/analitico/semanal/route.ts\`

Pattern idêntico nos dois — mesma forma exata de query + filter.

## Mudança

**Antes:**
\`\`\`ts
const { data: yuzerProdutos } = await supabase
  .from('silver_yuzer_produtos_evento')
  .select('quantidade, produto_nome')
  .eq('bar_id', barIdNum)
  .gte('data_evento', inicio)
  .lte('data_evento', fim);

const pessoasYuzer = yuzerProdutos?.filter(item => 
  item.produto_nome && (
    item.produto_nome.toLowerCase().includes('ingresso') || 
    item.produto_nome.toLowerCase().includes('entrada')
  )
).reduce((sum, item) => sum + (parseInt(item.quantidade) || 0), 0) || 0;
\`\`\`

**Depois:**
\`\`\`ts
const { data: yuzerProdutos } = await supabase
  .from('silver_yuzer_produtos_evento')
  .select('quantidade')
  .eq('bar_id', barIdNum)
  .gte('data_evento', inicio)
  .lte('data_evento', fim)
  .or('produto_nome.ilike.%ingresso%,produto_nome.ilike.%entrada%');

const pessoasYuzer = yuzerProdutos?.reduce(
  (sum, item) => sum + (parseInt(item.quantidade) || 0), 0
) || 0;
\`\`\`

## Smoke (cross-check via SQL)

Sample: bar_id IN (3, 4), última janela de 90 dias com dados:

| metric | value |
|--------|-------|
| js_side_total (filter em \`lower(produto_nome) LIKE %ingresso%\` OR \`%entrada%\`) | **4885** |
| sql_side_total (\`produto_nome ILIKE %ingresso%\` OR \`%entrada%\`) | **4885** ✓ |
| total_rows fetched (antes) | 378 |
| matching_rows (depois) | 17 |
| null_produto_rows | 0 |

**Equivalência exata.** Payload reduz de 378 → 17 rows = **-95%** por chamada.

## Test plan

- [x] \`tsc --noEmit\` passou nos 2 arquivos editados
- [x] Smoke SQL cross-check confirmou \`js_side_total = sql_side_total = 4885\`
- [x] ILIKE trata NULL corretamente (NULL ILIKE pattern → NULL → falsy)
- [x] \`.select()\` reduzido (não retorna mais \`produto_nome\` no payload)

## Por que ILIKE e não \`like.lower\`

- ILIKE é nativo Postgres, otimizado pelo planner
- Suporta short-circuit em AND/OR
- Pode usar \`pg_trgm\` GIN index no futuro se traffic justificar

🤖 Generated with [Claude Code](https://claude.com/claude-code)