### PR TITLE
chore: formalize eventos_base autovacuum tuning + ban out-of-band DDL (#40)

### DIFF
--- a/database/CONVENTIONS.md
+++ b/database/CONVENTIONS.md
@@ -199,3 +199,52 @@ Nomeação: `trigger_{ação}_{contexto}` ou `trg_{ação}_{tabela}`
 | **EXPERIMENTAL** | 0 rows + feature não lançada | `public` | `staging` |
 
 > **Classificação completa das 229 tabelas**: Realizada em 2026-03-19. Documento de referência na conversa de auditoria (não publicado como arquivo ainda). Será formalizado antes da criação dos schemas.
+
+---
+
+## DDL out-of-band — proibido [REGRA OBRIGATÓRIA]
+
+Toda mudança de schema **DEVE** ser aplicada via migration em `database/migrations/`. Aplica-se a:
+
+- `CREATE / ALTER / DROP TABLE`
+- `CREATE / ALTER / DROP INDEX`
+- `CREATE / ALTER / DROP CONSTRAINT` (PRIMARY KEY, FOREIGN KEY, UNIQUE, CHECK)
+- `ALTER TABLE … SET (reloptions)` — incluindo autovacuum tuning, fillfactor, etc.
+- `CREATE / ALTER / DROP POLICY` (RLS)
+- `GRANT / REVOKE`
+- `CREATE OR REPLACE FUNCTION / TRIGGER / VIEW`
+- `CREATE / DROP SCHEMA`
+
+### Por quê
+
+Mudanças out-of-band ficam **invisíveis** pra `git history` e induzem auditorias futuras a "redescobrir do zero" o que já foi decidido. Migration history é a única fonte canônica de "por que essa coisa existe e quem decidiu".
+
+**Caso real (sprint perf+sec abril 2026):**
+- `operations.eventos_base` tinha `autovacuum_vacuum_scale_factor = 0.05` aplicado out-of-band. Não havia rastro no git. Durante perf/04, redescobriu-se. Tracked como #40 e formalizado retroativamente em PR `chore/formalize-eventos-base-tuning`.
+- `idx_eventos_base_conta_assinada` (1.5 MB partial index) também criado out-of-band. Não havia rastro. Dropado em perf/05 batch 3 — sem o index, nenhuma performance regressão (era dead).
+
+Ambos custaram **horas de investigação** que não existiriam se a regra estivesse formalizada.
+
+### Exceção
+
+Apenas operações de manutenção que **não alteram schema**:
+
+- `VACUUM` / `VACUUM ANALYZE` ad-hoc
+- `ANALYZE` ad-hoc
+- `REINDEX` ad-hoc (recomendado fazer via migration se for parte de um plano)
+- `CLUSTER` ad-hoc
+
+Para operações pesadas (`VACUUM FULL`, `pg_repack`), criar issue de planejamento + janela.
+
+### Como detectar drift no futuro
+
+Script de monitoring (low priority, follow-up):
+```sql
+-- Comparar reloptions reais vs últimas declaradas em migrations
+SELECT n.nspname || '.' || c.relname AS table_name, c.reloptions
+FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
+WHERE c.reloptions IS NOT NULL
+  AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'auth', 'storage')
+ORDER BY 1;
+```
+Cross-check com `database/migrations/` via grep `ALTER TABLE ... SET (`.

--- a/database/migrations/2026-04-26-formalize-eventos-base-autovacuum.rollback.sql
+++ b/database/migrations/2026-04-26-formalize-eventos-base-autovacuum.rollback.sql
@@ -1,0 +1,10 @@
+-- ROLLBACK B.3 — restaurar defaults do cluster (sem reloptions custom)
+-- ATENÇÃO: rollback aqui faz a tabela perder o tuning aggressive e voltar
+-- a usar os defaults globais. Bloat tende a subir. Só fazer se realmente
+-- necessário desfazer.
+
+ALTER TABLE operations.eventos_base RESET (
+  autovacuum_vacuum_threshold,
+  autovacuum_vacuum_scale_factor,
+  autovacuum_analyze_scale_factor
+);

--- a/database/migrations/2026-04-26-formalize-eventos-base-autovacuum.sql
+++ b/database/migrations/2026-04-26-formalize-eventos-base-autovacuum.sql
@@ -1,0 +1,37 @@
+-- B.3 — Formalizar tuning out-of-band em operations.eventos_base (#40 follow-up)
+--
+-- CONTEXTO
+-- ========
+-- Reloptions de autovacuum em operations.eventos_base foram aplicadas out-of-band
+-- (sem migration registrada). Descoberto durante perf/04 (autovacuum_tuning) e
+-- documentado em docs/investigations/2026-04-eventos-base-out-of-band.md.
+--
+-- ESTADO PRÉ E PÓS-APLY (devem ser idênticos)
+-- ===========================================
+-- pg_class.reloptions já contém:
+--   autovacuum_vacuum_threshold      = 50
+--   autovacuum_vacuum_scale_factor   = 0.05
+--   autovacuum_analyze_scale_factor  = 0.02
+--
+-- Os mesmos valores que perf/04 (PR #14) aplicou em silver.cliente_visitas
+-- e silver.tempos_producao via migration registrada.
+--
+-- POR QUE ESTA MIGRATION
+-- ======================
+-- Este SET é operacionalmente NO-OP (valores idênticos), mas registra a INTENÇÃO
+-- e a justificativa no histórico de migrations. Próxima auditoria não vai
+-- redescobrir "do zero" o que já foi decidido.
+--
+-- Regra que está sendo reforçada (database/CONVENTIONS.md, seção nova):
+-- toda mudança de schema (incluindo SET reloptions) DEVE ser via migration.
+-- Out-of-band DDL é dívida arquitetural silenciosa.
+
+ALTER TABLE operations.eventos_base SET (
+  autovacuum_vacuum_threshold     = 50,
+  autovacuum_vacuum_scale_factor  = 0.05,
+  autovacuum_analyze_scale_factor = 0.02
+);
+
+-- Validação pós-apply: os 3 reloptions abaixo devem aparecer (mesmos valores).
+-- SELECT relname, reloptions FROM pg_class
+-- WHERE relnamespace = 'operations'::regnamespace AND relname = 'eventos_base';

--- a/docs/changelogs/2026-04-sprint-perf-sec.md
+++ b/docs/changelogs/2026-04-sprint-perf-sec.md
@@ -124,6 +124,7 @@ Pra cada candidato:
 | **Index parcial dead** apesar da feature ativa | perf/05 b3 + b4 — `conta_assinada` e `valor_nao_pago` partials nunca usados | Sempre validar via pg_stat_statements, não só por presença de coluna no código |
 | **Stats window** pode estar resetada | Pre-flight de perf/05 — `idx_scan=0` pode significar tabela jovem, não dead | Confirmar `pg_postmaster_start_time()` + idx_scan em hot indexes |
 | **Out-of-band DDL** sem rastro no git | perf/05 b3 — `idx_eventos_base_conta_assinada` não está em nenhuma migration; fase 4 também viu `eventos_base.reloptions` modificadas out-of-band | Tracked como follow-up #40, follow-up #41 |
+| **DDL out-of-band como anti-pattern** (consolidação dos casos acima) | Sprint inteira viu **dois** casos out-of-band — index parcial criado fora de migration + reloptions de autovacuum aplicadas via Studio/psql. Em ambos, próxima auditoria descobriria "do zero". | **Mitigação aplicada** (pós-Bloco B follow-ups): regra explícita em `database/CONVENTIONS.md` seção "DDL out-of-band — proibido" + migration retroativa formalizando `eventos_base` reloptions (PR #28). |
 
 ---
 


### PR DESCRIPTION
## Summary

**B.3 do Bloco B follow-ups.** Fecha o loop de [#40](../investigations/2026-04-eventos-base-out-of-band.md): tuning out-of-band em \`operations.eventos_base\` agora está rastreável pelo git history.

Investigação prévia: [PR #25](https://github.com/Dgzikaa/zykor/pull/25) (Bloco A) confirmou que reloptions atuais (\`scale_factor=0.05\`, \`analyze_scale_factor=0.02\`) são **idênticas** às que [PR #14 (perf/04)](https://github.com/Dgzikaa/zykor/pull/14) aplicou em silver tables.

## 3 deliverables

### 1. Migration declarativa retroativa

\`database/migrations/2026-04-26-formalize-eventos-base-autovacuum.sql\`

\`\`\`sql
ALTER TABLE operations.eventos_base SET (
  autovacuum_vacuum_threshold     = 50,
  autovacuum_vacuum_scale_factor  = 0.05,
  autovacuum_analyze_scale_factor = 0.02
);
\`\`\`

**NO-OP operacional** (valores já existem em produção), mas registra intent + justificativa no histórico de migrations.

**Pre/Post apply (validado):**
| moment | reloptions |
|--------|-----------|
| pre | \`{autovacuum_vacuum_threshold=50, autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.02}\` |
| post | \`{autovacuum_vacuum_threshold=50, autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.02}\` ✓ idênticas |

### 2. Nova seção em \`database/CONVENTIONS.md\`

\`## DDL out-of-band — proibido [REGRA OBRIGATÓRIA]\`

Cobre:
- Lista explícita de operações que DEVEM ir via migration (CREATE/ALTER/DROP table/index/constraint, SET reloptions, RLS policies, GRANT/REVOKE, functions/triggers/views, schemas)
- Caso real do sprint perf+sec como justificativa (eventos_base reloptions + \`idx_eventos_base_conta_assinada\` partial)
- Exceções permitidas (VACUUM, ANALYZE, REINDEX, CLUSTER ad-hoc)
- Script de drift detection sugerido (low-priority follow-up)

### 3. Update na retrospectiva

\`docs/changelogs/2026-04-sprint-perf-sec.md\` — adiciona **blind spot 7** consolidando os 2 casos out-of-band do sprint, com mitigação aplicada apontando pra este PR.

## Por quê

Mudanças out-of-band ficam **invisíveis** pra git history. Próxima auditoria redescobre "do zero" — custou horas de investigação no sprint que não existiriam se a regra estivesse formalizada.

Casos reais do sprint:
1. \`operations.eventos_base\` reloptions (este PR formaliza)
2. \`idx_eventos_base_conta_assinada\` partial — descoberto em perf/05 b3, dropado sem regressão

## Test plan

- [x] Migration aplicada via apply_migration (DDL transactional)
- [x] Reloptions pré-apply = pós-apply (confirmado)
- [x] CONVENTIONS.md tem nova seção visível
- [x] Retrospectiva tem blind spot 7

## Rollback

\`database/migrations/2026-04-26-formalize-eventos-base-autovacuum.rollback.sql\` reseta reloptions para defaults do cluster. **Aviso**: rollback faz a tabela perder o tuning aggressive — bloat tende a subir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)