### PR TITLE
fix(cmv-auto): respeitar estoque_final da planilha

### DIFF
--- a/backend/supabase/functions/cmv-semanal-auto/index.ts
+++ b/backend/supabase/functions/cmv-semanal-auto/index.ts
@@ -678,15 +678,22 @@ serve(async (req) => {
           mesa_adm_casa: consumacoes.mesa_adm_casa,
           mesa_beneficios_cliente: consumacoes.mesa_beneficios_cliente,
           mesa_banda_dj: consumacoes.mesa_banda_dj,
-          // Estoques finais detalhados
-          estoque_final_cozinha: estoqueFinalDetalhado.estoque_final_cozinha,
-          estoque_final_bebidas: estoqueFinalDetalhado.estoque_final_bebidas,
-          estoque_final_drinks: estoqueFinalDetalhado.estoque_final_drinks,
-          estoque_final: estoqueFinalDetalhado.estoque_final_cozinha + estoqueFinalDetalhado.estoque_final_bebidas + estoqueFinalDetalhado.estoque_final_drinks,
           // Propagar estoque inicial da semana anterior (só se não veio da planilha)
           ...estoqueInicialUpdate,
           updated_at: new Date().toISOString()
         };
+
+        // Estoques finais detalhados — só sobrescrever se NÃO veio da planilha.
+        // Mantém comportamento "puxar do Excel" enquanto bottom-up das contagens
+        // não estiver consolidado. Quando contagens estão atrasadas/órfãs, o
+        // cálculo retorna 0 e sobrescrevia o valor correto vindo do Sheets.
+        // Espelha o guard de cmv_real abaixo.
+        if (!dadosAtuais.estoque_final || dadosAtuais.estoque_final === 0) {
+          updateData.estoque_final_cozinha = estoqueFinalDetalhado.estoque_final_cozinha;
+          updateData.estoque_final_bebidas = estoqueFinalDetalhado.estoque_final_bebidas;
+          updateData.estoque_final_drinks = estoqueFinalDetalhado.estoque_final_drinks;
+          updateData.estoque_final = estoqueFinalDetalhado.estoque_final_cozinha + estoqueFinalDetalhado.estoque_final_bebidas + estoqueFinalDetalhado.estoque_final_drinks;
+        }
         
         // Adicionar CMV calculado se válido
         // NOTA: cmv_percentual é GENERATED ALWAYS no banco — NÃO incluir no update


### PR DESCRIPTION
## Resumo

\`cmv-semanal-auto\` (cron 12h) sobrescrevia \`estoque_final\` em toda execucao com calculo das contagens, ignorando o que \`sync-cmv-sheets\` tinha gravado da planilha. Quando contagens estao orfas/desatualizadas, o calculo retorna 0 e zerava tudo.

## Sintoma reportado

Pagina \`/ferramentas/cmv-semanal/tabela\` mostrava \`estoque_inicial/final = 0\` em todas as semanas de 2026 (S01-S17), quebrando CMV % cascata. Bar 3 e Bar 4 ambos afetados. \`updated_at\` recente (cron rodava ok), so com valores zerados.

## Causa raiz

\`backend/supabase/functions/cmv-semanal-auto/index.ts\` linhas 681-685 (antes do fix):

\`\`\`typescript
estoque_final_cozinha: estoqueFinalDetalhado.estoque_final_cozinha,
estoque_final_bebidas: estoqueFinalDetalhado.estoque_final_bebidas,
estoque_final_drinks: estoqueFinalDetalhado.estoque_final_drinks,
estoque_final: estoqueFinalDetalhado.estoque_final_cozinha + ...
\`\`\`

Sem guard. Inconsistente com \`cmv_real\` (linha 700) e \`estoque_inicial\` (linha 594) que JA respeitam o que veio da planilha.

Bar 3 (Ord) tem 89% de contagens orfas (\`insumo_id NULL\`) + ultima contagem 30/mar. Bar 4 (Deb) ultima contagem 13/abr. Calculo bottom-up retorna 0 para todas as semanas recentes -> grava 0.

## Fix

Espelha guard de \`cmv_real\`: so sobrescreve \`estoque_final*\` se nao veio da planilha.

\`\`\`typescript
if (!dadosAtuais.estoque_final || dadosAtuais.estoque_final === 0) {
  updateData.estoque_final_cozinha = ...
  // etc
}
\`\`\`

## Validacao em prod

1. \`supabase functions deploy cmv-semanal-auto\` ✅
2. Trigger manual \`sync-cmv-sheets\` para 2026 -> 66 semanas atualizadas (44 Ord + 22 Deb) ✅
3. Trigger manual \`cmv-semanal-auto\` -> 36 semanas processadas, **estoque_final preservado** dos valores do Sheets ✅
4. Query final em \`financial.cmv_semanal\` confirma S14-S16 com dados completos, S17 parcial (planilha ainda nao foi fechada pela equipe). ✅

## Caveat

Mudanca de comportamento permanente: enquanto Etapa 2 (bottom-up via contagens) nao estiver consolidada, o auto sempre prefere o valor da planilha. Quando contagens estiverem em dia + sem orfas, inverter precedencia.

## Tipo de merge

Squash. Fix unico em 1 arquivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)