### PR TITLE
fix(cache): mata service workers (resolve stale data)

### DIFF
--- a/frontend/public/sw-optimized.js
+++ b/frontend/public/sw-optimized.js
@@ -1,265 +1,34 @@
-// ✅ Service Worker Otimizado para Zykor
-// Cache estratégico para performance máxima em produção
+// ============================================================================
+// Service Worker auto-destruct (2026-04-28)
+// Ver sw-zykor.js para contexto completo. Mesmo comportamento.
+// ============================================================================
 
-const CACHE_NAME = 'zykor-v2.0.0';
-const STATIC_CACHE = 'zykor-static-v2.0.0';
-const API_CACHE = 'zykor-api-v2.0.0';
-const IMAGE_CACHE = 'zykor-images-v2.0.0';
-
-// ✅ Recursos para cache imediato (críticos)
-const CRITICAL_RESOURCES = [
-  '/',
-  '/home',
-  '/login',
-  '/manifest.json',
-  '/favicon.ico',
-  '/_next/static/css/app/layout.css',
-  '/_next/static/chunks/webpack.js',
-  '/_next/static/chunks/main.js',
-];
-
-// ✅ APIs para cache (dados não críticos)
-const CACHEABLE_APIS = [
-  '/api/configuracoes/badges',
-  '/api/configuracoes/notifications',
-  '/api/health',
-  '/api/usuarios/me',
-];
-
-// ✅ Recursos para cache sob demanda
-const ON_DEMAND_CACHE = [
-  '/visao-geral',
-  '/configuracoes',
-  '/estrategico',
-  '/operacional',
-];
-
-// ✅ Install: Cache recursos críticos
-self.addEventListener('install', (event) => {
-  console.log('[SW] Installing service worker...');
-  
-  event.waitUntil(
-    Promise.all([
-      // Cache estático crítico
-      caches.open(STATIC_CACHE).then((cache) => {
-        return cache.addAll(CRITICAL_RESOURCES);
-      }),
-      // Cache de imagens
-      caches.open(IMAGE_CACHE),
-      // Cache de API
-      caches.open(API_CACHE),
-    ]).then(() => {
-      console.log('[SW] Critical resources cached');
-      return self.skipWaiting();
-    })
-  );
+self.addEventListener('install', () => {
+  self.skipWaiting();
 });
 
-// ✅ Activate: Limpar caches antigos
 self.addEventListener('activate', (event) => {
-  console.log('[SW] Activating service worker...');
-  
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames.map((cacheName) => {
-          if (
-            cacheName !== CACHE_NAME &&
-            cacheName !== STATIC_CACHE &&
-            cacheName !== API_CACHE &&
-            cacheName !== IMAGE_CACHE
-          ) {
-            console.log('[SW] Deleting old cache:', cacheName);
-            return caches.delete(cacheName);
-          }
-        })
-      );
-    }).then(() => {
-      console.log('[SW] Service worker activated');
-      return self.clients.claim();
-    })
+    (async () => {
+      try {
+        const keys = await caches.keys();
+        await Promise.all(keys.map((k) => caches.delete(k)));
+      } catch (_) { /* swallow */ }
+
+      try {
+        await self.clients.claim();
+      } catch (_) { /* swallow */ }
+
+      try {
+        await self.registration.unregister();
+      } catch (_) { /* swallow */ }
+
+      try {
+        const clients = await self.clients.matchAll({ type: 'window' });
+        for (const client of clients) {
+          client.navigate(client.url);
+        }
+      } catch (_) { /* swallow */ }
+    })()
   );
 });
-
-// ✅ Fetch: Estratégias de cache inteligentes
-self.addEventListener('fetch', (event) => {
-  const { request } = event;
-  const url = new URL(request.url);
-
-  // ✅ Estratégia para APIs
-  if (url.pathname.startsWith('/api/')) {
-    event.respondWith(handleApiRequest(request));
-    return;
-  }
-
-  // ✅ Estratégia para imagens
-  if (request.destination === 'image') {
-    event.respondWith(handleImageRequest(request));
-    return;
-  }
-
-  // ✅ Estratégia para recursos estáticos
-  if (
-    request.destination === 'script' ||
-    request.destination === 'style' ||
-    url.pathname.startsWith('/_next/static/')
-  ) {
-    event.respondWith(handleStaticRequest(request));
-    return;
-  }
-
-  // ✅ Estratégia para páginas
-  if (request.mode === 'navigate') {
-    event.respondWith(handlePageRequest(request));
-    return;
-  }
-});
-
-// ✅ Cache-first para recursos estáticos (performance máxima)
-async function handleStaticRequest(request) {
-  try {
-    const cachedResponse = await caches.match(request);
-    if (cachedResponse) {
-      return cachedResponse;
-    }
-
-    const response = await fetch(request);
-    if (response.ok) {
-      const cache = await caches.open(STATIC_CACHE);
-      cache.put(request, response.clone());
-    }
-    return response;
-  } catch (error) {
-    console.log('[SW] Static resource failed:', error);
-    return new Response('Resource unavailable', { status: 503 });
-  }
-}
-
-// ✅ Network-first para APIs (dados sempre frescos)
-async function handleApiRequest(request) {
-  const url = new URL(request.url);
-  
-  try {
-    // Tentar network primeiro
-    const response = await fetch(request);
-    
-    // Cache apenas GETs bem-sucedidos de APIs específicas
-    if (
-      response.ok && 
-      request.method === 'GET' &&
-      CACHEABLE_APIS.some(api => url.pathname.startsWith(api))
-    ) {
-      const cache = await caches.open(API_CACHE);
-      cache.put(request, response.clone());
-    }
-    
-    return response;
-  } catch (error) {
-    // Fallback para cache se network falhar
-    const cachedResponse = await caches.match(request);
-    if (cachedResponse) {
-      console.log('[SW] Serving API from cache:', url.pathname);
-      return cachedResponse;
-    }
-    
-    // Resposta offline para APIs críticas
-    if (url.pathname === '/api/health') {
-      return new Response(JSON.stringify({
-        status: 'offline',
-        timestamp: Date.now()
-      }), {
-        headers: { 'Content-Type': 'application/json' }
-      });
-    }
-    
-    throw error;
-  }
-}
-
-// ✅ Cache-first para imagens (economia de banda)
-async function handleImageRequest(request) {
-  try {
-    const cachedResponse = await caches.match(request);
-    if (cachedResponse) {
-      return cachedResponse;
-    }
-
-    const response = await fetch(request);
-    if (response.ok) {
-      const cache = await caches.open(IMAGE_CACHE);
-      // Limitar cache de imagens (máx 50MB)
-      const cacheSize = await getCacheSize(IMAGE_CACHE);
-      if (cacheSize < 50 * 1024 * 1024) {
-        cache.put(request, response.clone());
-      }
-    }
-    return response;
-  } catch (error) {
-    // Imagem placeholder offline
-    return new Response(
-      '<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="200" height="200" fill="#f3f4f6"/><text x="100" y="100" text-anchor="middle" fill="#9ca3af">Offline</text></svg>',
-      { headers: { 'Content-Type': 'image/svg+xml' } }
-    );
-  }
-}
-
-// ✅ Network-first para páginas (conteúdo sempre atualizado)
-async function handlePageRequest(request) {
-  try {
-    const response = await fetch(request);
-    
-    // Cache páginas bem-sucedidas
-    if (response.ok) {
-      const cache = await caches.open(CACHE_NAME);
-      cache.put(request, response.clone());
-    }
-    
-    return response;
-  } catch (error) {
-    // Fallback para cache
-    const cachedResponse = await caches.match(request);
-    if (cachedResponse) {
-      return cachedResponse;
-    }
-    
-    // Página offline padrão
-    return caches.match('/') || new Response('Offline', { status: 503 });
-  }
-}
-
-// ✅ Utilitário para calcular tamanho do cache
-async function getCacheSize(cacheName) {
-  const cache = await caches.open(cacheName);
-  const requests = await cache.keys();
-  let size = 0;
-  
-  for (const request of requests) {
-    const response = await cache.match(request);
-    if (response) {
-      const blob = await response.blob();
-      size += blob.size;
-    }
-  }
-  
-  return size;
-}
-
-// ✅ Limpeza automática de cache (evitar crescimento excessivo)
-self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'CLEAN_CACHE') {
-    cleanOldCaches();
-  }
-});
-
-async function cleanOldCaches() {
-  const cacheNames = await caches.keys();
-  const oldCaches = cacheNames.filter(name => 
-    name.includes('zykor') && 
-    !name.includes('v2.0.0')
-  );
-  
-  await Promise.all(oldCaches.map(name => caches.delete(name)));
-  console.log('[SW] Cleaned old caches:', oldCaches);
-}
-
-console.log('[SW] Zykor Service Worker loaded successfully');

--- a/frontend/public/sw-zykor.js
+++ b/frontend/public/sw-zykor.js
@@ -1,138 +1,47 @@
-const CACHE_NAME = 'zykor-gestao-v1'
-const STATIC_CACHE = 'zykor-static-v1'
+// ============================================================================
+// Service Worker auto-destruct (2026-04-28)
+//
+// Por que: o SW antigo cacheava paginas dinamicas (estrategico/desempenho etc)
+// com estrategia "cache-first" sem TTL. Resultado: usuarios viam dados de dias
+// atras mesmo apos F5/Ctrl+R. Projeto nao usa PWA real (offline, push), entao
+// optamos por matar os SWs e voltar ao cache padrao do navegador.
+//
+// Este SW:
+// 1. No install: ativa imediatamente (skipWaiting)
+// 2. No activate: limpa todos os caches, toma controle dos clientes,
+//    desregistra a si mesmo, e recarrega todas as abas abertas
+// 3. NAO intercepta nenhum fetch (sem listener 'fetch' = network default)
+//
+// Apos rodar uma vez por cliente, o SW some completamente. Pode deletar este
+// arquivo no proximo deploy quando confirmar que ninguem mais tem SW antigo.
+// ============================================================================
 
-// Arquivos essenciais para gestão offline
-const STATIC_FILES = [
-  '/dashboard',
-  '/operacoes/qr-scanner',
-  '/logos/zykor-logo.png',
-  '/manifest-zykor.json'
-]
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
 
-// Install event
-self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches.open(STATIC_CACHE)
-      .then((cache) => cache.addAll(STATIC_FILES))
-      .then(() => self.skipWaiting())
-  )
-})
-
-// Activate event
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames.map((cacheName) => {
-          if (cacheName !== CACHE_NAME && cacheName !== STATIC_CACHE) {
-            return caches.delete(cacheName)
-          }
-        })
-      )
-    }).then(() => self.clients.claim())
-  )
-})
+    (async () => {
+      try {
+        const keys = await caches.keys();
+        await Promise.all(keys.map((k) => caches.delete(k)));
+      } catch (_) { /* swallow */ }
 
-// Fetch event - Otimizado para gestão
-self.addEventListener('fetch', (event) => {
-  const url = new URL(event.request.url)
-  
-  // Para APIs de gestão, sempre buscar dados frescos
-  if (url.pathname.includes('/api/')) {
-    event.respondWith(
-      fetch(event.request)
-        .then((response) => {
-          // Cache apenas se a resposta for bem-sucedida
-          if (response.status === 200) {
-            const responseClone = response.clone()
-            caches.open(CACHE_NAME)
-              .then((cache) => cache.put(event.request, responseClone))
-          }
-          return response
-        })
-        .catch(() => {
-          // Fallback para cache se offline
-          return caches.match(event.request)
-        })
-    )
-    return
-  }
+      try {
+        await self.clients.claim();
+      } catch (_) { /* swallow */ }
 
-  // Para páginas administrativas, cache com network fallback
-  if (url.pathname.includes('/dashboard') || 
-      url.pathname.includes('/operacoes') || 
-      url.pathname.includes('/configuracoes') ||
-      url.pathname.includes('/relatorios')) {
-    event.respondWith(
-      caches.match(event.request)
-        .then((response) => {
-          return response || fetch(event.request)
-            .then((response) => {
-              if (response.status === 200) {
-                const responseClone = response.clone()
-                caches.open(CACHE_NAME)
-                  .then((cache) => cache.put(event.request, responseClone))
-              }
-              return response
-            })
-        })
-    )
-    return
-  }
+      try {
+        await self.registration.unregister();
+      } catch (_) { /* swallow */ }
 
-  // Para outros recursos, comportamento padrão
-  event.respondWith(
-    caches.match(event.request)
-      .then((response) => response || fetch(event.request))
-  )
-})
-
-// Push notifications para gestores
-self.addEventListener('push', (event) => {
-  if (event.data) {
-    const data = event.data.json()
-    
-    const options = {
-      body: data.body || 'Nova notificação do SGB',
-      icon: '/logos/logo_640x640.png',
-      badge: '/logos/logo_640x640.png',
-      tag: 'sgb-notification',
-      actions: [
-        {
-          action: 'open-dashboard',
-          title: 'Ver Dashboard'
-        },
-        {
-          action: 'dismiss',
-          title: 'Dispensar'
+      try {
+        const clients = await self.clients.matchAll({ type: 'window' });
+        for (const client of clients) {
+          client.navigate(client.url);
         }
-      ],
-      data: {
-        url: data.url || '/dashboard'
-      }
-    }
-    
-    event.waitUntil(
-      self.registration.showNotification(data.title || 'SGB', options)
-    )
-  }
-})
-
-// Notification click para gestores
-self.addEventListener('notificationclick', (event) => {
-  event.notification.close()
-  
-  if (event.action === 'open-dashboard') {
-    event.waitUntil(
-      self.clients.openWindow('/dashboard')
-    )
-  } else if (event.action === 'dismiss') {
-    // Apenas fecha a notificação
-  } else {
-    // Click na notificação (sem action específica)
-    const url = event.notification.data?.url || '/dashboard'
-    event.waitUntil(
-      self.clients.openWindow(url)
-    )
-  }
-})
+      } catch (_) { /* swallow */ }
+    })()
+  );
+});

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,89 +1,34 @@
-﻿// Service Worker com estratÃ©gia NETWORK FIRST
-// VersÃ£o atualizada automaticamente a cada deploy
-const CACHE_VERSION = 'v' + Date.now();
-const CACHE_NAME = 'zykor-cache-' + CACHE_VERSION;
+// ============================================================================
+// Service Worker auto-destruct (2026-04-28)
+// Ver sw-zykor.js para contexto completo. Mesmo comportamento.
+// ============================================================================
 
-// Arquivos que podem ser cacheados para offline
-const OFFLINE_CACHE = [
-  '/offline.html'
-];
-
-// Install - prÃ©-cachear apenas recursos essenciais offline
-self.addEventListener('install', (event) => {
-  console.log('[SW] Installing new version:', CACHE_VERSION);
-  // ForÃ§a o novo SW a tomar controle imediatamente
+self.addEventListener('install', () => {
   self.skipWaiting();
 });
 
-// Activate - limpa caches antigos
 self.addEventListener('activate', (event) => {
-  console.log('[SW] Activating new version:', CACHE_VERSION);
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames
-          .filter((name) => name.startsWith('zykor-cache-') && name !== CACHE_NAME)
-          .map((name) => {
-            console.log('[SW] Deleting old cache:', name);
-            return caches.delete(name);
-          })
-      );
-    }).then(() => {
-      // ForÃ§a todos os clients a usar o novo SW
-      return self.clients.claim();
-    })
-  );
-});
+    (async () => {
+      try {
+        const keys = await caches.keys();
+        await Promise.all(keys.map((k) => caches.delete(k)));
+      } catch (_) { /* swallow */ }
 
-// Fetch - NETWORK FIRST para tudo (exceto assets estÃ¡ticos)
-self.addEventListener('fetch', (event) => {
-  const url = new URL(event.request.url);
-  
-  // Ignorar requests que nÃ£o sÃ£o HTTP/HTTPS
-  if (!url.protocol.startsWith('http')) return;
-  
-  // Ignorar APIs externas
-  if (!url.origin.includes('zykor.com.br') && !url.origin.includes('localhost')) return;
-  
-  // Para APIs, sempre network only (sem cache)
-  if (url.pathname.startsWith('/api/')) {
-    return; // Deixa o browser lidar normalmente
-  }
-  
-  // Para assets estÃ¡ticos (_next/static), podemos cachear
-  if (url.pathname.startsWith('/_next/static/')) {
-    event.respondWith(
-      caches.match(event.request).then((cached) => {
-        if (cached) return cached;
-        return fetch(event.request).then((response) => {
-          if (response.ok) {
-            const clone = response.clone();
-            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
-          }
-          return response;
-        });
-      })
-    );
-    return;
-  }
-  
-  // Para todo o resto (HTML, JS dinÃ¢mico), NETWORK FIRST
-  event.respondWith(
-    fetch(event.request)
-      .then((response) => {
-        // Se conseguiu da rede, retorna (nÃ£o cacheia HTML/JS dinÃ¢mico)
-        return response;
-      })
-      .catch(() => {
-        // Se offline, tenta o cache
-        return caches.match(event.request);
-      })
-  );
-});
+      try {
+        await self.clients.claim();
+      } catch (_) { /* swallow */ }
 
-// Listener para mensagens do app (forÃ§ar update)
-self.addEventListener('message', (event) => {
-  if (event.data === 'skipWaiting') {
-    self.skipWaiting();
-  }
+      try {
+        await self.registration.unregister();
+      } catch (_) { /* swallow */ }
+
+      try {
+        const clients = await self.clients.matchAll({ type: 'window' });
+        for (const client of clients) {
+          client.navigate(client.url);
+        }
+      } catch (_) { /* swallow */ }
+    })()
+  );
 });

--- a/frontend/src/app/api/estrategico/desempenho-v2/route.ts
+++ b/frontend/src/app/api/estrategico/desempenho-v2/route.ts
@@ -228,25 +228,31 @@ export async function GET(request: NextRequest) {
 
     console.log(`✅ V2: ${semanasFiltradas.length} semanas retornadas`);
 
-    return NextResponse.json({
-      success: true,
-      mes,
-      ano,
-      semanas: semanasFiltradas,
-      total_semanas: semanasFiltradas.length,
-      totais_mensais: {
-        faturamento_total: Math.round(totaisMensais.faturamento_total * 100) / 100,
-        clientes_total: totaisMensais.clientes_total,
-        ticket_medio: Math.round(ticketMedioMensal * 100) / 100,
-        performance_media: Math.round(performanceMediaMensal * 100) / 100,
-        eventos_total: totaisMensais.eventos_total
+    return NextResponse.json(
+      {
+        success: true,
+        mes,
+        ano,
+        semanas: semanasFiltradas,
+        total_semanas: semanasFiltradas.length,
+        totais_mensais: {
+          faturamento_total: Math.round(totaisMensais.faturamento_total * 100) / 100,
+          clientes_total: totaisMensais.clientes_total,
+          ticket_medio: Math.round(ticketMedioMensal * 100) / 100,
+          performance_media: Math.round(performanceMediaMensal * 100) / 100,
+          eventos_total: totaisMensais.eventos_total
+        },
+        _metadata: {
+          api_version: 'v2',
+          fonte: 'gold.desempenho + meta.desempenho_manual',
+          arquitetura: 'medalion_puro'
+        }
       },
-      _metadata: {
-        api_version: 'v2',
-        fonte: 'gold.desempenho + meta.desempenho_manual',
-        arquitetura: 'medalion_puro'
+      {
+        // Dashboard data — sempre fresh. Bloqueia cache do navegador/CDN.
+        headers: { 'Cache-Control': 'no-store, must-revalidate' }
       }
-    });
+    );
 
   } catch (error) {
     console.error('❌ Erro API V2:', error);

--- a/frontend/src/components/PWAManager.tsx
+++ b/frontend/src/components/PWAManager.tsx
@@ -1,86 +1,29 @@
 'use client'
 
-import { useEffect, useCallback } from 'react'
-import { usePathname } from 'next/navigation'
+import { useEffect } from 'react'
 
+// Antes este componente registrava SWs (sw-zykor.js) com estrategia cache-first
+// que segurava dados antigos por dias. Projeto nao usa PWA real, entao agora
+// ele apenas garante que qualquer SW antigo seja desregistrado e os caches
+// limpos pro-ativamente. Defesa em profundidade junto com sw-zykor.js
+// (self-destruct) — se browser servir SW antigo do disco antes de re-checar,
+// este codigo client-side limpa mesmo assim.
 export function PWAManager() {
-  const pathname = usePathname()
+  useEffect(() => {
+    if (typeof window === 'undefined') return
 
-  const registerGestaoPWA = useCallback(async () => {
-    try {
-      // Limpar service workers antigos se necessário
-      const registrations = await navigator.serviceWorker.getRegistrations()
-      for (const registration of registrations) {
-        // Limpar registros antigos se necessário
-        if (registration.scope !== '/') {
-          await registration.unregister()
-        }
-      }
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations()
+        .then((regs) => Promise.all(regs.map((r) => r.unregister())))
+        .catch(() => {})
+    }
 
-      // Registrar service worker de gestão
-      const registration = await navigator.serviceWorker.register('/sw-zykor.js', {
-        scope: '/'
-      })
-
-      // Atualizar manifest
-      updateManifest('/manifest-zykor.json')
-
-      console.log('PWA Zykor registrado:', registration)
-    } catch (error) {
-      console.error('Erro ao registrar PWA Zykor:', error)
+    if ('caches' in window) {
+      caches.keys()
+        .then((keys) => Promise.all(keys.map((k) => caches.delete(k))))
+        .catch(() => {})
     }
   }, [])
 
-  useEffect(() => {
-    // Verificar se service workers são suportados
-    if ('serviceWorker' in navigator) {
-      // Registrar PWA apenas para área de gestão
-      const isGestaoArea = pathname.startsWith('/dashboard') || 
-                          pathname.startsWith('/operacoes') || 
-                          pathname.startsWith('/configuracoes') ||
-                          pathname.startsWith('/relatorios') ||
-                          pathname.startsWith('/visao-geral')
-
-      if (isGestaoArea) {
-        // Registrar PWA apenas para gestão
-        registerGestaoPWA()
-      }
-    }
-  }, [pathname, registerGestaoPWA])
-
-
-  const updateManifest = (manifestPath: string) => {
-    // Remover manifests anteriores
-    const existingManifests = document.querySelectorAll('link[rel="manifest"]')
-    existingManifests.forEach(manifest => manifest.remove())
-
-    // Adicionar novo manifest
-    const manifestLink = document.createElement('link')
-    manifestLink.rel = 'manifest'
-    manifestLink.href = manifestPath
-    document.head.appendChild(manifestLink)
-  }
-
-  return null // Componente invisível
-}
-
-// Hook para instalação PWA
-export function usePWAInstall() {
-  const pathname = usePathname()
-
-  const promptInstall = async () => {
-    // Instruções para gestores
-    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
-    const isAndroid = /Android/.test(navigator.userAgent)
-    
-    if (isIOS) {
-      alert(`📱 Para instalar o SGB:\n\n1. Toque no botão compartilhar (⬆️)\n2. Selecione "Adicionar à Tela de Início"\n3. Toque em "Adicionar"\n\nO sistema ficará como um app para acesso rápido!`)
-    } else if (isAndroid) {
-      alert(`📱 Para instalar o SGB:\n\n1. Toque no menu do navegador (⋮)\n2. Selecione "Adicionar à tela inicial"\n3. Confirme "Adicionar"\n\nO sistema ficará como um app!`)
-    } else {
-      alert(`💻 Para acesso rápido:\n\nSalve esta página nos favoritos para acessar rapidamente o sistema de gestão.`)
-    }
-  }
-
-  return { promptInstall }
+  return null
 }

--- a/frontend/src/hooks/usePWA.ts
+++ b/frontend/src/hooks/usePWA.ts
@@ -54,43 +54,32 @@ export function usePWA(): PWAState & PWAActions {
     setState(prev => ({ ...prev, isInstalled }));
   }, []);
 
-  // Registrar Service Worker
+  // Antes registrava /sw.js (cache-first sem TTL = stale data por dias).
+  // Projeto nao usa PWA real — agora desregistra qualquer SW e limpa caches.
+  // Mantem assinatura pra nao quebrar callers.
   const registerServiceWorker =
     useCallback(async (): Promise<ServiceWorkerRegistration | null> => {
       if (typeof window === 'undefined' || !('serviceWorker' in navigator))
         return null;
 
       try {
-        const registration = await navigator.serviceWorker.register('/sw.js', {
-          scope: '/',
-        });
+        const regs = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(regs.map((r) => r.unregister()));
+      } catch { /* swallow */ }
 
-        setState(prev => ({
-          ...prev,
-          serviceWorkerRegistration: registration,
-        }));
+      try {
+        if ('caches' in window) {
+          const keys = await caches.keys();
+          await Promise.all(keys.map((k) => caches.delete(k)));
+        }
+      } catch { /* swallow */ }
 
-        // Escutar atualizações do Service Worker
-        registration.addEventListener('updatefound', () => {
-          const newWorker = registration.installing;
-          if (newWorker) {
-            newWorker.addEventListener('statechange', () => {
-              if (
-                newWorker.state === 'installed' &&
-                typeof window !== 'undefined' &&
-                navigator.serviceWorker.controller
-              ) {
-                // Aqui você pode mostrar uma notificação para o usuário sobre a atualização
-              }
-            });
-          }
-        });
+      setState(prev => ({
+        ...prev,
+        serviceWorkerRegistration: null,
+      }));
 
-        return registration;
-      } catch (error) {
-        console.error('❌ PWA: Erro ao registrar Service Worker:', error);
-        return null;
-      }
+      return null;
     }, []);
 
   // Detectar conectividade


### PR DESCRIPTION
## Sintoma

Socio (e outros usuarios em diferentes momentos) viam tabela de desempenho com indicadores de **~7 dias atras**, mesmo apos F5/Ctrl+R. So unregister manual via DevTools resolvia.

## Causa raiz

\`public/sw-zykor.js\` (registrado pelo \`PWAManager\`) tinha estrategia **\"cache-first sem TTL\"** pra todas as rotas que nao caem em \`/dashboard\`, \`/operacoes\`, \`/configuracoes\`, \`/relatorios\`. \`/estrategico/desempenho\` cai aqui. Resultado: HTML, JS e responses de API serviam do cache do SW indefinidamente.

\`\`\`js
// sw-zykor.js linhas 84-87 (antigo)
event.respondWith(
  caches.match(event.request)
    .then((response) => response || fetch(event.request))  // ← CACHE FIRST
)
\`\`\`

Projeto nao usa PWA real — sem fluxo offline, sem push notif funcional. Opcao limpa: matar os SWs.

## Mudancas

| Arquivo | Mudanca |
|---|---|
| \`public/sw{,-zykor,-optimized}.js\` (3 arquivos) | Substituidos por **self-destruct**: limpa caches, unregister, reload das abas |
| \`src/components/PWAManager.tsx\` | Ao montar, desregistra SWs pre-existentes + limpa caches (em vez de registrar). Removeu \`usePWAInstall\` (nao usado) |
| \`src/hooks/usePWA.ts\` | \`registerServiceWorker\` reescrito pra cleanup em vez de register. Mantem assinatura pra nao quebrar callers (PWAInstallBanner, PWAStatus, ZykorPWABanner) |
| \`src/app/api/estrategico/desempenho-v2/route.ts\` | Adiciona \`Cache-Control: no-store, must-revalidate\` (cinto-suspensorios contra cache HTTP) |

## Defesa em profundidade

3 camadas garantem que nenhum cliente fique stale:

1. **SW self-destruct**: quando browser checar update do SW (max 24h), instala novo, ativa, limpa tudo, unregister, recarrega abas
2. **Cleanup client-side** (PWAManager + usePWA): primeira vez que qualquer pagina carrega o JS novo, desregistra SWs e limpa caches independente do SW estar vigente
3. **Cache-Control: no-store**: garante que mesmo sem SW, browser/CDN nao vao segurar response da API

## Garantias pos-deploy

- **F5/Ctrl+R**: sempre traz dado fresco
- **Victim existente (aba aberta com SW antigo)**: proxima navegacao detecta SW novo, executa cleanup, reload automatico. Sem F5 manual
- **Socio (stale ha mais de 24h)**: proximo open de qualquer aba dispara o check imediatamente

## Caveat

Existe janela de ate 24h em que browsers que JA tinham o SW antigo podem demorar pra perceber o SW novo (regra do browser de checar updates). Camada #2 cobre esse buraco — assim que QUALQUER pagina do site carregar o JS novo, o cleanup roda.

## Cleanup futuro

Apos confirmar que ninguem mais tem SW antigo (1-2 semanas), pode-se deletar:

- \`public/sw{,-zykor,-optimized}.js\`
- \`src/components/PWAManager.tsx\` (ou esvaziar pra zero)
- \`src/components/PWAInstallBanner.tsx\`, \`PWAStatus.tsx\`, \`ZykorPWABanner.tsx\` (funcionalidade morta)
- \`src/hooks/usePWA.ts\` (esvaziar ou deletar)

Mantido nesse PR pra nao multiplicar a area de mudanca.

## Tipo de merge

Squash. Fix unico contextual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)