### PR TITLE
feat(cache): defesa em profundidade contra stale data (A+B+C)

### DIFF
--- a/frontend/src/app/api/version/route.ts
+++ b/frontend/src/app/api/version/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * GET /api/version
+ *
+ * Devolve o SHA do commit do deploy atual. Cliente compara com a versão
+ * embutida no bundle (NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA) — se diferente,
+ * mostra banner "nova versão disponível".
+ *
+ * Em dev (sem Vercel), retorna 'dev' e cliente nunca dispara o banner.
+ */
+export async function GET() {
+  const version = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? 'dev';
+
+  return NextResponse.json(
+    {
+      version,
+      deployedAt: process.env.VERCEL_DEPLOYMENT_ID ?? null,
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store, must-revalidate',
+      },
+    }
+  );
+}

--- a/frontend/src/app/estrategico/desempenho/components/DesempenhoClient.tsx
+++ b/frontend/src/app/estrategico/desempenho/components/DesempenhoClient.tsx
@@ -46,6 +46,7 @@ import {
 import { useBar } from '@/contexts/BarContext';
 import { useUser } from '@/contexts/UserContext';
 import { useToast } from '@/hooks/use-toast';
+import { useRefreshOnVisible } from '@/hooks/useRefreshOnVisible';
 import { cn } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
 import { DadosSemana, SecaoConfig, GrupoMetricas, MetricaConfig, TipoAgregacao, MetasDesempenhoMap } from '../types';
@@ -847,6 +848,14 @@ export function DesempenhoClient({
       router.refresh();
     }
   }, [selectedBar?.id, barId, router]);
+
+  // Quando usuario volta pra aba (visibilitychange => 'visible'), revalida
+  // os dados do server. Throttle de 30s pra evitar spam quando o usuario
+  // fica trocando entre janelas. Faz a pagina sempre refletir o estado mais
+  // recente sem exigir F5 manual.
+  useRefreshOnVisible(() => {
+    router.refresh();
+  });
 
   // Semana selecionada (para metas reativas)
   const semanaSelecionada = useMemo(() => {

--- a/frontend/src/components/VersionChecker.tsx
+++ b/frontend/src/components/VersionChecker.tsx
@@ -5,88 +5,70 @@ import { RefreshCw, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 /**
- * Componente que detecta quando há uma nova versão do app disponível
- * e oferece ao usuário a opção de atualizar.
- * 
- * Funciona verificando se o Service Worker foi atualizado.
+ * Detecta nova versao do app comparando o SHA embutido no bundle com o SHA
+ * retornado por /api/version. Quando diferentes, exibe banner com botao
+ * "Atualizar agora" que faz reload.
+ *
+ * Antes dependia de Service Worker (sw-zykor.js). Como matamos os SWs em
+ * 79330d41, a logica foi trocada por polling do endpoint.
+ *
+ * Frequencia: 5min de intervalo + check ao voltar pra aba.
  */
+
+const BUILD_VERSION =
+  process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? 'dev';
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+async function fetchDeployedVersion(): Promise<string | null> {
+  try {
+    const res = await fetch('/api/version', { cache: 'no-store' });
+    if (!res.ok) return null;
+    const json = await res.json();
+    return typeof json?.version === 'string' ? json.version : null;
+  } catch {
+    return null;
+  }
+}
+
 export function VersionChecker() {
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
-    if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
+    if (typeof window === 'undefined') return;
+    if (BUILD_VERSION === 'dev') return; // local dev: nao polla
 
-    const checkForUpdates = async () => {
-      try {
-        const registration = await navigator.serviceWorker.getRegistration();
-        
-        if (registration) {
-          // Verificar atualizações
-          registration.addEventListener('updatefound', () => {
-            const newWorker = registration.installing;
-            if (newWorker) {
-              newWorker.addEventListener('statechange', () => {
-                if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                  // Nova versão instalada, mas ainda não ativa
-                  console.log('[VersionChecker] Nova versão disponível!');
-                  setUpdateAvailable(true);
-                }
-              });
-            }
-          });
+    let cancelled = false;
 
-          // Forçar check de atualização
-          registration.update().catch(console.error);
-        }
-
-        // Também verificar se já há um worker esperando
-        if (registration?.waiting) {
-          setUpdateAvailable(true);
-        }
-      } catch (error) {
-        console.error('[VersionChecker] Erro:', error);
+    const check = async () => {
+      const deployed = await fetchDeployedVersion();
+      if (cancelled || !deployed) return;
+      if (deployed !== BUILD_VERSION) {
+        setUpdateAvailable(true);
       }
     };
 
-    // Verificar ao carregar
-    checkForUpdates();
+    check();
 
-    // Verificar periodicamente (a cada 5 minutos)
-    const interval = setInterval(checkForUpdates, 5 * 60 * 1000);
+    const interval = setInterval(check, POLL_INTERVAL_MS);
 
-    // Listener para quando a página ganha foco
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
-        checkForUpdates();
+        check();
       }
     };
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
+      cancelled = true;
       clearInterval(interval);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, []);
 
-  const handleUpdate = async () => {
-    try {
-      const registration = await navigator.serviceWorker.getRegistration();
-      
-      if (registration?.waiting) {
-        // Envia mensagem para o SW ativar imediatamente
-        registration.waiting.postMessage('skipWaiting');
-      }
-
-      // Aguarda um momento e recarrega
-      setTimeout(() => {
-        window.location.reload();
-      }, 100);
-    } catch (error) {
-      console.error('[VersionChecker] Erro ao atualizar:', error);
-      // Em caso de erro, simplesmente recarrega
-      window.location.reload();
-    }
+  const handleUpdate = () => {
+    window.location.reload();
   };
 
   if (!updateAvailable || dismissed) return null;
@@ -120,9 +102,10 @@ export function VersionChecker() {
             </Button>
           </div>
         </div>
-        <button 
+        <button
           onClick={() => setDismissed(true)}
           className="text-blue-200 hover:text-white transition-colors"
+          aria-label="Fechar"
         >
           <X className="w-4 h-4" />
         </button>

--- a/frontend/src/hooks/useRefreshOnVisible.ts
+++ b/frontend/src/hooks/useRefreshOnVisible.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+type Options = {
+  /**
+   * Intervalo minimo entre refreshes (ms). Evita spam quando usuario fica
+   * trocando de aba toda hora. Default: 30s.
+   */
+  minIntervalMs?: number;
+  /**
+   * Se false, o hook fica inerte. Util pra desabilitar via feature flag
+   * ou quando o componente nao quer refresh automatico em alguns estados.
+   */
+  enabled?: boolean;
+};
+
+/**
+ * Roda `callback` quando a aba volta a ficar visivel (visibilitychange =>
+ * 'visible'), respeitando um intervalo minimo desde o ultimo refresh.
+ *
+ * Caso de uso: paginas de dashboard que devem trazer dado fresh quando o
+ * usuario volta da reuniao / volta de outra aba. Sem precisar F5.
+ *
+ * @example
+ *   useRefreshOnVisible(() => fetchDados());
+ *   useRefreshOnVisible(fetchDados, { minIntervalMs: 60_000 });
+ */
+export function useRefreshOnVisible(
+  callback: () => void | Promise<void>,
+  options: Options = {}
+) {
+  const { minIntervalMs = 30_000, enabled = true } = options;
+
+  // Mantem ref atualizada pra callback nao virar dep do useEffect
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  const lastRunRef = useRef<number>(Date.now());
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof document === 'undefined') return;
+
+    const handler = () => {
+      if (document.visibilityState !== 'visible') return;
+      const now = Date.now();
+      if (now - lastRunRef.current < minIntervalMs) return;
+      lastRunRef.current = now;
+      try {
+        const ret = callbackRef.current();
+        if (ret && typeof (ret as Promise<unknown>).catch === 'function') {
+          (ret as Promise<unknown>).catch(() => {});
+        }
+      } catch {
+        /* swallow */
+      }
+    };
+
+    document.addEventListener('visibilitychange', handler);
+    return () => {
+      document.removeEventListener('visibilitychange', handler);
+    };
+  }, [minIntervalMs, enabled]);
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+/**
+ * Middleware Next.js — adiciona Cache-Control: no-store em todas as rotas
+ * /api/*. Razao: dashboards do Zykor sao 100% dinamicos e qualquer cache
+ * (browser, CDN, ISP proxy) pode entregar dado stale ao usuario. Cinto-
+ * suspensorios universal.
+ *
+ * Endpoints especificos podem reescrever o header se precisarem de cache
+ * (ex: /api/version retorna no-store explicito; rotas que nao re-usam o
+ * mesmo header simplesmente sobrescrevem na resposta).
+ *
+ * NOTE: middleware roda em edge. NextResponse.next() encaminha pro handler
+ * e os headers seteados aqui sao mesclados com a resposta final.
+ */
+export function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+  response.headers.set('Cache-Control', 'no-store, must-revalidate');
+  return response;
+}
+
+export const config = {
+  matcher: '/api/:path*',
+};


### PR DESCRIPTION
## Resumo

3 melhorias complementares de cache pra garantir que F5 sempre traga versao atualizada e que usuario seja avisado quando ha deploy novo (cenario "deploys constantes").

## A) Middleware Cache-Control: no-store em /api/*

\`src/middleware.ts\` (novo) — header \`Cache-Control: no-store, must-revalidate\` em todas as respostas \`/api/*\`. Cinto-suspensorios universal contra cache do browser/CDN/proxies.

\`\`\`ts
export function middleware(request) {
  const response = NextResponse.next();
  response.headers.set('Cache-Control', 'no-store, must-revalidate');
  return response;
}
export const config = { matcher: '/api/:path*' };
\`\`\`

## B) Auto-refresh ao voltar pra aba

\`src/hooks/useRefreshOnVisible.ts\` (novo) — escuta \`visibilitychange\`, dispara callback quando aba fica visivel, com throttle default de 30s pra evitar spam.

Wirado em \`DesempenhoClient\` chamando \`router.refresh()\`. Caso de uso: socio volta da reuniao, painel ja reflete venda do almoco. Sem F5.

## C) Banner "Nova versao disponivel"

\`src/app/api/version/route.ts\` (novo) — devolve SHA do commit do deploy atual via \`NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\`.

\`src/components/VersionChecker.tsx\` (reescrito) — antes dependia de Service Worker (morto no PR #32). Agora faz polling de \`/api/version\` a cada 5min + ao voltar pra aba. Compara com a versao embutida no bundle (build-time). Se divergente, exibe banner azul com botao "Atualizar agora".

UI do banner ja existia, so trocamos o detector. Em dev local (sem Vercel) nao polla.

## Cobertura combinada (com PR #32)

| Cenario | Camada |
|---|---|
| F5/Ctrl+R sempre fresh | SW kill (PR #32) + middleware (A) |
| Aba aberta, sem F5, voltou | useRefreshOnVisible (B) |
| Deploy novo enquanto aba aberta | VersionChecker polling (C) |
| Browser cache HTTP | middleware Cache-Control: no-store (A) |
| CDN cache | middleware (A) + Vercel default nao cacheia dynamic |

## UX final

- Usuario nunca precisa F5 manual pra ter dado atualizado
- Quando deploy novo sai, recebe aviso explicito (nao surpresa silenciosa)
- "Deploy constante" vira UX premium em vez de fonte de bug

## Tipo de merge

Squash. 3 features complementares, 1 escopo (cache strategy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)