### PR TITLE
fix(stockout): elimina race condition cron sync vs processar (A+B)

### DIFF
--- a/database/migrations/2026-04-28-stockout-cron-d1-and-gap.sql
+++ b/database/migrations/2026-04-28-stockout-cron-d1-and-gap.sql
@@ -1,0 +1,62 @@
+-- ============================================================================
+-- Stockout pipeline: fix race condition entre sync (bronze) e processar (silver)
+-- 2026-04-28
+--
+-- Sintoma: silver_contahub_operacional_stockout_processado ficava vazia em
+-- alguns dias mesmo com bronze populada. Sócio do Deboche reportou
+-- "stockout não puxa categorias" — era silver vazia em datas especificas.
+--
+-- Causa raiz: 4 crons em sequência separados por 5min:
+--   19:00 — contahub-stockout-sync Ord (puxa bronze)
+--   19:05 — stockout-processar Ord (processa silver) <-- gap pequeno demais
+--   19:10 — contahub-stockout-sync Deb
+--   19:15 — stockout-processar Deb                    <-- mesmo problema
+--
+-- Cron pgcron retorna "succeeded" só porque o net.http_post foi enviado, NAO
+-- significa que a edge function de sync já tinha terminado de gravar bronze.
+-- Quando o sync demorava ou tinha erro silencioso, o processar rodava com
+-- bronze ainda vazia → silver ficava vazia. Em pgcron logs tudo aparece OK.
+--
+-- Fix combinado (A+B):
+--   A) Aumenta gap 5min → 30min (suspensórios contra timing)
+--   B) Processar agora processa D-1 (ontem) em vez de D0 (hoje). Bronze de
+--      ontem tem 24h de antiguidade — race condition impossível.
+--
+-- Resultado:
+--   19:00 — sync Ord D0 (bronze)
+--   19:10 — sync Deb D0 (bronze)
+--   19:30 — processar Ord D-1 (silver)        [gap 30min, data anterior]
+--   19:45 — processar Deb D-1 (silver, ter-dom)
+--
+-- Aplicado: 2026-04-28 via cron.alter_job (pg_cron). Aplicar este script
+-- novamente em ambiente novo (preview/staging) recria o estado.
+-- ============================================================================
+
+-- Ord (bar_id=3): processa todos os dias D-1
+SELECT cron.alter_job(
+  job_id := 402,
+  schedule := '30 22 * * *',
+  command := $cmd$
+    SELECT net.http_post(
+      url := get_supabase_url() || '/functions/v1/stockout-processar',
+      headers := jsonb_build_object('Authorization', 'Bearer ' || get_service_role_key(), 'Content-Type', 'application/json'),
+      body := jsonb_build_object('bar_id', 3, 'data_date', (CURRENT_DATE - INTERVAL '1 day')::date::text),
+      timeout_milliseconds := 60000
+    )
+  $cmd$
+);
+
+-- Deb (bar_id=4): processa D-1 todos exceto segunda (Deboche fechado, sem
+-- bronze pra processar de domingo).
+SELECT cron.alter_job(
+  job_id := 403,
+  schedule := '45 22 * * 0,2,3,4,5,6',
+  command := $cmd$
+    SELECT net.http_post(
+      url := get_supabase_url() || '/functions/v1/stockout-processar',
+      headers := jsonb_build_object('Authorization', 'Bearer ' || get_service_role_key(), 'Content-Type', 'application/json'),
+      body := jsonb_build_object('bar_id', 4, 'data_date', (CURRENT_DATE - INTERVAL '1 day')::date::text),
+      timeout_milliseconds := 60000
+    )
+  $cmd$
+);


### PR DESCRIPTION
## Sintoma

Socio do Deboche reportou \`/ferramentas/stockout\` sem categorias em alguns dias. Auditoria mostrou silver \`silver_contahub_operacional_stockout_processado\` ficando vazia em datas onde bronze \`bronze_contahub_operacional_stockout_raw\` estava populada.

Dias afetados (pre-fix):
- bar 3 (Ord): 2026-04-26, 2026-03-31
- bar 4 (Deb): 2026-04-13, 2026-03-31

## Causa raiz

4 crons em cascata separados por **apenas 5min**:

\`\`\`
19:00 — sync Ord (popula bronze)
19:05 — processar Ord (le bronze, popula silver) <-- gap curto
19:10 — sync Deb
19:15 — processar Deb
\`\`\`

\`pg_cron\` retorna \`succeeded\` apenas porque o \`net.http_post\` foi enviado. Nao espera a edge function de sync terminar. Quando o sync demorava ou tinha erro silencioso, o \`stockout-processar\` rodava com bronze ainda vazia. Cron logs aparecem todos OK.

## Fix combinado A+B

| Fix | O que faz | Defesa |
|---|---|---|
| **A** | Aumenta gap sync->processar de 5min para 30min | Protege contra latencia do sync |
| **B** | Processar agora trabalha em D-1 (ontem) em vez de D0 (hoje) | Bronze de ontem tem 24h de margem — race impossivel |

Novos schedules:

\`\`\`
19:00 — sync Ord D0 (bronze)
19:10 — sync Deb D0 (bronze, ter-dom)
19:30 — processar Ord D-1 (silver)
19:45 — processar Deb D-1 (silver, ter-dom)
\`\`\`

## Aplicado em prod

\`cron.alter_job\` nos jobs 402 e 403. Migration SQL preservada em \`database/migrations/2026-04-28-stockout-cron-d1-and-gap.sql\` para replay em staging.

## Backfill historico

4 dias missing recuperados via call manual ao \`stockout-processar\`:

| Bar | Data | Incluidos |
|---|---|---:|
| 3 | 2026-04-26 | 183 |
| 3 | 2026-03-31 | 136 |
| 4 | 2026-04-13 | 161 |
| 4 | 2026-03-31 | 167 |

Periodo 2026-04-15 a 2026-04-23 nao recuperavel — bronze tambem vazia. \`contahub-stockout-sync\` rodou nesses dias mas retornou vazio (motivo separado, nao investigado nesta sessao). Stockout e snapshot de momento, nao da pra reconstituir o passado a partir de outros dados.

## Tipo de merge

Squash. Fix de cron unico e contextual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)