### PR TITLE
fix(recalcular-desempenho-v2): schema refs + FIELD_MAPPING (3 bugs)

### DIFF
--- a/backend/supabase/functions/_shared/calculators/calc-custos.ts
+++ b/backend/supabase/functions/_shared/calculators/calc-custos.ts
@@ -111,13 +111,15 @@ export async function calcCustos(
     }
 
     // 3. Cancelamentos
+    // bronze_contahub_avendas_cancelamentos usa `dt_gerencial`, nao `data`.
+    // Antes da migracao medallion havia coluna `data` que foi renomeada/dropada.
     const { data: cancelRows, error: cancelError } = await supabase
       .schema('bronze')
       .from('bronze_contahub_avendas_cancelamentos')
       .select('custototal')
       .eq('bar_id', barId)
-      .gte('data', startDate)
-      .lte('data', endDate);
+      .gte('dt_gerencial', startDate)
+      .lte('dt_gerencial', endDate);
 
     if (cancelError) {
       return {
@@ -131,14 +133,16 @@ export async function calcCustos(
       (sum: number, r: any) => sum + (parseFloat(r.custototal) || 0), 0
     );
 
-    // 4. Couvert e Comissao (vr_repique) - FONTE CANÔNICA: bronze_contahub_avendas_vendasperiodo
+    // 4. Couvert e Comissao - FONTE CANONICA: bronze_contahub_avendas_vendasperiodo
+    // Colunas reais: vd_vrcouvert, vd_vrrepique (com prefixo `vd_` que veio
+    // direto do payload do ContaHub e foi preservado na promocao raw->bronze).
     const { data: couvertComissaoRows, error: couvertError } = await supabase
       .schema('bronze')
       .from('bronze_contahub_avendas_vendasperiodo')
-      .select('vr_couvert, vr_repique')
+      .select('vd_vrcouvert, vd_vrrepique')
       .eq('bar_id', barId)
-      .gte('dt_gerencial', startDate)
-      .lte('dt_gerencial', endDate);
+      .gte('vd_dtgerencial', startDate)
+      .lte('vd_dtgerencial', endDate);
 
     if (couvertError) {
       return {
@@ -149,10 +153,10 @@ export async function calcCustos(
     }
 
     const couvertAtracoes = (couvertComissaoRows || []).reduce(
-      (sum: number, r: any) => sum + (parseFloat(r.vr_couvert) || 0), 0
+      (sum: number, r: any) => sum + (parseFloat(r.vd_vrcouvert) || 0), 0
     );
     const comissaoCartao = (couvertComissaoRows || []).reduce(
-      (sum: number, r: any) => sum + (parseFloat(r.vr_repique) || 0), 0
+      (sum: number, r: any) => sum + (parseFloat(r.vd_vrrepique) || 0), 0
     );
     console.log(`[DEBUG calc-custos] bar_id=${barId}, period=${startDate} to ${endDate}, rows=${couvertComissaoRows?.length || 0}, comissao=${comissaoCartao}, couvert=${couvertAtracoes}`);
 

--- a/backend/supabase/functions/_shared/calculators/calc-operacional.ts
+++ b/backend/supabase/functions/_shared/calculators/calc-operacional.ts
@@ -118,16 +118,19 @@ export async function calcOperacional(
     const tempoSaidaBar = (tempoSaidaResult && tempoSaidaResult[0] && tempoSaidaResult[0].tempo_bar_minutos) || 0;
     const tempoSaidaCozinha = (tempoSaidaResult && tempoSaidaResult[0] && tempoSaidaResult[0].tempo_cozinha_minutos) || 0;
 
-    // 4. Atrasinhos direto de bronze_contahub_produtos_temposproducao (filtrar outliers > 60 min)
+    // 4. Atrasinhos via silver.tempos_producao (categoria ja mapeada de loc_desc).
+    // Bronze nao tem coluna `categoria` nem `tempo_final` — sao calculadas/mapeadas
+    // na promocao bronze->silver. Usa t0_t3 (lancamento -> entrega) como tempo total
+    // que inclui producao + entrega. Filtra outliers > 60 min.
     const { data: atrasinhosData, error: atrasinhosError } = await supabase
-      .schema('bronze')
-      .from('bronze_contahub_produtos_temposproducao')
-      .select('categoria, tempo_final')
+      .schema('silver')
+      .from('tempos_producao')
+      .select('categoria, t0_t3')
       .eq('bar_id', barId)
-      .gte('data', startDate)
-      .lte('data', endDate)
-      .gt('tempo_final', 0)
-      .lte('tempo_final', 60);
+      .gte('data_producao', startDate)
+      .lte('data_producao', endDate)
+      .gt('t0_t3', 0)
+      .lte('t0_t3', 60);
 
     if (atrasinhosError) {
       return {
@@ -138,14 +141,15 @@ export async function calcOperacional(
     }
 
     // Atrasinhos: 5-10 min para bar, 15-20 min para cozinha
-    const atrasinhosBar = (atrasinhosData || []).filter((item: any) => 
-      (item.categoria === 'bebida' || item.categoria === 'drink') && 
-      item.tempo_final > 5 && item.tempo_final <= 10
+    // t0_t3 = tempo total do lançamento até entrega (em minutos)
+    const atrasinhosBar = (atrasinhosData || []).filter((item: any) =>
+      (item.categoria === 'bebida' || item.categoria === 'drink') &&
+      item.t0_t3 > 5 && item.t0_t3 <= 10
     ).length;
-    
-    const atrasinhosCozinha = (atrasinhosData || []).filter((item: any) => 
-      item.categoria === 'comida' && 
-      item.tempo_final > 15 && item.tempo_final <= 20
+
+    const atrasinhosCozinha = (atrasinhosData || []).filter((item: any) =>
+      item.categoria === 'comida' &&
+      item.t0_t3 > 15 && item.t0_t3 <= 20
     ).length;
     
     // Atraso (não usado no cálculo de atrasos_bar/cozinha, apenas para referência)

--- a/backend/supabase/functions/recalcular-desempenho-v2/index.ts
+++ b/backend/supabase/functions/recalcular-desempenho-v2/index.ts
@@ -110,7 +110,11 @@ interface V2Result {
   timestamp: string;
 }
 
-// Mapeamento dos campos dos calculators para colunas de gold.desempenho
+// Mapeamento calc_key -> db_column (gold.desempenho).
+// Auditado em 2026-04-28 contra schema real. Comentarios marcam ajustes:
+//  [DROP] = key existia no calc mas nao tem coluna correspondente em gold.desempenho
+//  [TYPO_DB] = coluna no banco tem typo (ex: cmvivel sem o)
+//  [RENAME] = code retornava com nome legado, mapear pra coluna real
 const FIELD_MAPPING: Record<string, string> = {
   // Faturamento
   faturamento_total: "faturamento_total",
@@ -120,7 +124,7 @@ const FIELD_MAPPING: Record<string, string> = {
   ticket_medio: "ticket_medio",
   tm_entrada: "tm_entrada",
   tm_bar: "tm_bar",
-  meta_semanal: "meta_semanal",
+  // [DROP] meta_semanal — nao existe em gold.desempenho
   mesas_totais: "mesas_totais",
   mesas_presentes: "mesas_presentes",
   reservas_totais: "reservas_totais",
@@ -132,32 +136,33 @@ const FIELD_MAPPING: Record<string, string> = {
   couvert_atracoes: "couvert_atracoes",
   comissao: "comissao",
   atracoes_eventos: "atracoes_eventos",
-  cancelamentos: "cancelamentos",
-  // Operacional
-  stockout_bar: "stockout_bar",
+  cancelamentos: "cancelamentos_total", // [RENAME] sum em R$ -> cancelamentos_total
+  // Operacional — Stockout (so o _perc existe; counts ficam apenas no calc, nao persistem)
+  // [DROP] stockout_bar (count)
   stockout_bar_perc: "stockout_bar_perc",
-  stockout_drinks: "stockout_drinks",
+  // [DROP] stockout_drinks (count)
   stockout_drinks_perc: "stockout_drinks_perc",
-  stockout_comidas: "stockout_comidas",
+  // [DROP] stockout_comidas (count)
   stockout_comidas_perc: "stockout_comidas_perc",
   perc_bebidas: "perc_bebidas",
   perc_drinks: "perc_drinks",
   perc_comida: "perc_comida",
   perc_happy_hour: "perc_happy_hour",
-  tempo_saida_bar: "tempo_saida_bar",
-  tempo_saida_cozinha: "tempo_saida_cozinha",
-  qtde_itens_bar: "qtde_itens_bar",
-  qtde_itens_cozinha: "qtde_itens_cozinha",
-  atrasinhos_bar: "atrasinhos_bar",
+  // [RENAME] tempo_saida_bar -> tempo_bebidas; tempo_drinks separado nao vem do calc
+  tempo_saida_bar: "tempo_bebidas",
+  tempo_saida_cozinha: "tempo_cozinha", // [RENAME]
+  // [DROP] qtde_itens_bar / qtde_itens_cozinha — usados apenas no calc dos %; gold guarda qtd_drinks_total e qtd_comida_total mas o calc atual nao retorna esses
+  // Atrasinhos (singular no banco)
+  atrasinhos_bar: "atrasinho_bar", // [RENAME] singular
   atrasinhos_bar_perc: "atrasinhos_bar_perc",
-  atrasinhos_cozinha: "atrasinhos_cozinha",
+  atrasinhos_cozinha: "atrasinho_cozinha", // [RENAME] singular
   atrasinhos_cozinha_perc: "atrasinhos_cozinha_perc",
-  atraso_bar: "atraso_bar",
-  atraso_cozinha: "atraso_cozinha",
-  atrasos_bar: "atrasos_bar",
-  atrasos_cozinha: "atrasos_cozinha",
+  // Atrasos: db usa ortografia "atrasao" (ao invez de "atraso") — preservar pra nao causar deriva
+  atraso_bar: "atrasao_bar", // [RENAME]
+  atraso_cozinha: "atrasao_cozinha", // [RENAME]
+  // [DROP] atrasos_bar / atrasos_cozinha sem _perc — duplicidade com atraso_bar/cozinha
   atrasos_bar_perc: "atrasos_bar_perc",
-  atrasos_cozinha_perc: "atrasos_cozinha_perc",
+  atrasos_cozinha_perc: "atrasos_comida_perc", // [RENAME] db usa "comida" no lugar de "cozinha"
   // Satisfacao
   avaliacoes_5_google_trip: "avaliacoes_5_google_trip",
   media_avaliacoes_google: "media_avaliacoes_google",
@@ -178,7 +183,7 @@ const FIELD_MAPPING: Record<string, string> = {
   clientes_ativos: "clientes_ativos",
   perc_clientes_novos: "perc_clientes_novos",
   // CMV (integrado de cmv_semanal)
-  faturamento_cmovivel: "faturamento_cmovivel",
+  faturamento_cmovivel: "faturamento_cmvivel", // [TYPO_DB] db: cmvivel sem o
   cmv_rs: "cmv_rs",
   cmv: "cmv",
 };
@@ -458,7 +463,7 @@ async function processBarWeek(
         updatePayload[dbKey] = calculatedValues[calcKey];
       }
     }
-    updatePayload["atualizado_em"] = new Date().toISOString() as any;
+    updatePayload["calculado_em"] = new Date().toISOString() as any;
 
     if (registroAtualEncontrado) {
       const { error: updateError } = await supabase
@@ -485,16 +490,15 @@ async function processBarWeek(
         ano,
         numero_semana: numeroSemana,
         granularidade: "semanal",
-        criado_em: new Date().toISOString(),
       };
 
       // Adicionar apenas campos calculados (não manuais)
       for (const [key, value] of Object.entries(updatePayload)) {
-        if (key !== "atualizado_em" && !MANUAL_FIELDS.includes(key as any)) {
+        if (key !== "calculado_em" && !MANUAL_FIELDS.includes(key as any)) {
           insertPayload[key] = value;
         }
       }
-      insertPayload["atualizado_em"] = updatePayload["atualizado_em"];
+      insertPayload["calculado_em"] = updatePayload["calculado_em"];
 
       const { error: insertError } = await supabase
         .schema("gold")


### PR DESCRIPTION
Resolve ~7 items da lista do socio relatada hoje. UPDATE em gold.desempenho voltou a funcionar apos meses de silent regression.

3 fixes em 1 PR:

1. **calc-custos.ts**: cancelamentos.`data` → `dt_gerencial`, vendasperiodo.`vr_couvert` → `vd_vrcouvert`, etc.
2. **calc-operacional.ts**: bronze.temposproducao (sem `categoria`) → silver.tempos_producao (tem categoria mapeada)
3. **FIELD_MAPPING**: 15+ mismatches calc keys vs colunas reais (cancelamentos→cancelamentos_total, atrasinhos→atrasinho singular, faturamento_cmovivel→cmvivel, etc.)

Backfill executado em prod: 20/20 semanas (S08-S17 × 2 bars) write OK. Stockout drinks, comidas, bar populados; cancelamentos, comissao, tempos, atrasinhos tudo persistindo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)