### PR TITLE
fix(cmv-semanal): inclui Custo Outros + warning visual quando compras=0

### DIFF
--- a/backend/supabase/functions/cmv-semanal-auto/index.ts
+++ b/backend/supabase/functions/cmv-semanal-auto/index.ts
@@ -344,12 +344,14 @@ serve(async (req) => {
           .eq('bar_id', barId)
           .gte('data_competencia', dataInicio)
           .lte('data_competencia', dataFim)
-          .or('categoria_nome.ilike.%custo comida%,categoria_nome.ilike.%custo bebida%,categoria_nome.ilike.%custo drink%,categoria_nome.ilike.alimenta%');
+          .or('categoria_nome.ilike.%custo comida%,categoria_nome.ilike.%custo bebida%,categoria_nome.ilike.%custo drink%,categoria_nome.ilike.%custo outros%,categoria_nome.ilike.alimenta%');
 
         const comprasPorCategoria = {
           cozinha: 0,    // CUSTO COMIDA / CUSTO COMIDAS
           bebidas: 0,    // Custo Bebidas / CUSTO BEBIDAS
           drinks: 0,     // Custo Drinks / CUSTO DRINKS
+          outros: 0,     // Custo Outros — produtos/insumos que nao sao
+                         //                comida/bebida/drink (limpeza, descartavel, etc)
           alimentacao: 0 // ALIMENTAÇÃO (CMA - separado do CMV)
         };
 
@@ -358,18 +360,19 @@ serve(async (req) => {
           const valorBruto = parseFloat(String(c.valor_bruto)) || 0;
           const tipo = (c.tipo || '').toLowerCase();
           const cat = (c.categoria_nome || '').toLowerCase();
-          
+
           // Se for receita (crédito/devolução), subtrai; se for despesa, soma
           const valor = tipo === 'receita' ? -valorBruto : valorBruto;
-          
+
           if (cat.includes('custo comida')) comprasPorCategoria.cozinha += valor;
           else if (cat.includes('custo bebida')) comprasPorCategoria.bebidas += valor;
           else if (cat.includes('custo drink')) comprasPorCategoria.drinks += valor;
+          else if (cat.includes('custo outros')) comprasPorCategoria.outros += valor;
           else if (cat.includes('alimenta')) comprasPorCategoria.alimentacao += valor;
         });
 
-        // CMV Total = cozinha + bebidas + drinks (NÃO inclui alimentação)
-        const comprasCmvTotal = comprasPorCategoria.cozinha + comprasPorCategoria.bebidas + comprasPorCategoria.drinks;
+        // CMV Total = cozinha + bebidas + drinks + outros (NÃO inclui alimentação)
+        const comprasCmvTotal = comprasPorCategoria.cozinha + comprasPorCategoria.bebidas + comprasPorCategoria.drinks + comprasPorCategoria.outros;
         console.log(`⏱️ [${Date.now() - semanaStartTime}ms] Compras processadas: R$ ${comprasCmvTotal.toFixed(2)}`);
 
         // 4.2. Buscar CONSUMAÇÕES (4 categorias) - valores BRUTOS (sem multiplicador)

--- a/frontend/src/app/ferramentas/cmv-semanal/tabela/page.tsx
+++ b/frontend/src/app/ferramentas/cmv-semanal/tabela/page.tsx
@@ -19,9 +19,9 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { 
-  ChevronDown, 
-  ChevronRight, 
+import {
+  ChevronDown,
+  ChevronRight,
   Calendar,
   Eye,
   Pencil,
@@ -32,6 +32,7 @@ import {
   Calculator,
   BarChart3,
   Table2,
+  AlertTriangle,
 } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useBar } from '@/contexts/BarContext';
@@ -1388,7 +1389,31 @@ export default function CMVSemanalTabelaPage() {
                                         </span>
                                       );
                                     })()}
-                                    
+
+                                    {/* Aviso visual: Compras = R$ 0 sugere lançamentos faltando no ContaAzul */}
+                                    {!isEditandoCell && metrica.key === 'compras_periodo' && (valor || 0) === 0 && (
+                                      <TooltipProvider>
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <AlertTriangle
+                                              className="absolute left-1 h-3 w-3 text-amber-500 dark:text-amber-400"
+                                              onClick={(e) => e.stopPropagation()}
+                                            />
+                                          </TooltipTrigger>
+                                          <TooltipContent side="top" className="p-2 bg-white dark:bg-gray-800 shadow-lg border border-amber-300 dark:border-amber-600 z-50 max-w-[260px]">
+                                            <div className="space-y-1">
+                                              <div className="text-xs font-semibold text-amber-700 dark:text-amber-400">
+                                                ⚠️ Sem compras registradas
+                                              </div>
+                                              <div className="text-[11px] text-gray-700 dark:text-gray-300">
+                                                Nenhum lançamento de compra foi encontrado no ContaAzul para esta semana. Verifique se a equipe lançou as notas (categorias <em>Custo Comida / Bebida / Drink / Outros</em>).
+                                              </div>
+                                            </div>
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      </TooltipProvider>
+                                    )}
+
                                     {/* Botão editar - apenas no modo semanal */}
                                     {!isEditandoCell && metrica.editavel && visao === 'semanal' && (
                                       <Button


### PR DESCRIPTION
## Summary

Resolve dois itens da lista do socio sobre a aba CMV:

- **C.** Categoria \`Custo Outros\` (limpeza, descartaveis, etc) nao era contabilizada no CMV — itens de R\$ 459 (S15) e R\$ 20 (S16) eram dropados silenciosamente. Agora entra no CMV Total junto com Cozinha/Bebidas/Drinks (Alimentação continua separada para CMA).
- **D.** Quando \`compras_periodo = R\$ 0\` na tabela CMV, mostra \`AlertTriangle\` ambar com tooltip explicando que provavelmente faltam lançamentos no ContaAzul. Isso da um sinal visivel para o gap operacional sem precisar abrir cron logs.

## Changes

### `backend/supabase/functions/cmv-semanal-auto/index.ts`
- Filter \`.or(...)\` ganha \`%custo outros%\`
- Novo bucket \`comprasPorCategoria.outros\`
- \`comprasCmvTotal\` soma \`cozinha + bebidas + drinks + outros\` (alimentação continua excluida — vai pro CMA)

### `frontend/src/app/ferramentas/cmv-semanal/tabela/page.tsx`
- Import \`AlertTriangle\` do lucide
- Condicional inline na celula: quando \`metrica.key === 'compras_periodo' && (valor || 0) === 0\`, renderiza icone com tooltip ambar

## Test plan

- [ ] Deploy edge function (ja feito via \`supabase functions deploy cmv-semanal-auto\`)
- [ ] Aguardar proximo cron (jobid 354, 8h) ou disparar manual via \`POST /functions/v1/cmv-semanal-auto\` para semana com Custo Outros (S15 Ord)
- [ ] Verificar coluna \`compras_custo_outros\` populada na \`cmv_semanal\`
- [ ] Ver tabela \`/ferramentas/cmv-semanal/tabela\` em semana sem compras (S16+ Ord) — icone ambar deve aparecer com tooltip

## Related

Continua trabalho da serie de bugs do socio (PRs #37/#38/#39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)