### PR TITLE
fix(contaazul-sync): schema integrations + http() timeout 120s

### DIFF
--- a/backend/supabase/functions/contaazul-sync/index.ts
+++ b/backend/supabase/functions/contaazul-sync/index.ts
@@ -348,6 +348,7 @@ async function syncLancamentos(
           }
           
           const { error, data: upsertData } = await supabase
+            .schema('integrations')
             .from('contaazul_lancamentos')
             .upsert(lancamentos, { onConflict: 'contaazul_id,bar_id' })
             .select('id')
@@ -414,6 +415,7 @@ async function syncCategorias(
   }))
 
   const { error } = await supabase
+    .schema('integrations')
     .from('contaazul_categorias')
     .upsert(categorias, { onConflict: 'contaazul_id,bar_id', ignoreDuplicates: false })
 
@@ -464,6 +466,7 @@ async function syncCentrosCusto(
   }))
 
   const { error } = await supabase
+    .schema('integrations')
     .from('contaazul_centros_custo')
     .upsert(centros, { onConflict: 'contaazul_id,bar_id', ignoreDuplicates: false })
 
@@ -515,6 +518,7 @@ async function syncPessoas(
       }))
 
       const { error } = await supabase
+        .schema('integrations')
         .from('contaazul_pessoas')
         .upsert(pessoas, { onConflict: 'contaazul_id,bar_id', ignoreDuplicates: false })
 
@@ -555,6 +559,7 @@ async function syncPessoas(
       }))
 
       const { error } = await supabase
+        .schema('integrations')
         .from('contaazul_pessoas')
         .upsert(pessoas, { onConflict: 'contaazul_id,bar_id', ignoreDuplicates: false })
 
@@ -613,6 +618,7 @@ async function syncContasFinanceiras(
   }))
 
   const { error } = await supabase
+    .schema('integrations')
     .from('contaazul_contas_financeiras')
     .upsert(contas, { onConflict: 'contaazul_id,bar_id', ignoreDuplicates: false })
 
@@ -632,6 +638,7 @@ async function createSyncLog(
   tipoSincronizacao: string
 ): Promise<number | null> {
   const { data, error } = await supabase
+    .schema('integrations')
     .from('contaazul_logs_sincronizacao')
     .insert({
       bar_id: barId,
@@ -662,6 +669,7 @@ async function updateSyncLog(
   const totalRegistros = stats.lancamentos + stats.categorias + stats.centros_custo + stats.pessoas + stats.contas_financeiras
 
   const { error } = await supabase
+    .schema('integrations')
     .from('contaazul_logs_sincronizacao')
     .update({
       status,

--- a/database/migrations/2026-04-28-fix-sync-contaazul-daily-timeout.sql
+++ b/database/migrations/2026-04-28-fix-sync-contaazul-daily-timeout.sql
@@ -1,0 +1,87 @@
+-- 2026-04-28: Fix sync_contaazul_daily timeout silencioso
+--
+-- Contexto: cron 354 (contaazul-sync-8h) chama public.sync_contaazul_daily()
+-- que invoca a edge function via http(). Default da extensao http e' 5s,
+-- mas a edge function leva 12-30s. Resultado: timeout disparava
+-- "Operation timed out after 5002 ms with 0 bytes received", o
+-- EXCEPTION WHEN OTHERS engolia em silencio, e a edge function nunca era
+-- invocada (zero logs no edge-function service). Cron marcava "succeeded"
+-- de qualquer jeito (a SQL function retorna void sem erro).
+--
+-- Combinado com o bug de schema na edge function (`.from('contaazul_*')`
+-- sem `.schema('integrations')` apos a refatoracao medallion ~2026-04-16),
+-- isso paralisou o sync por 12 dias sem alerta visivel.
+--
+-- Fix: PERFORM http_set_curlopt('CURLOPT_TIMEOUT_MS', '120000') antes do
+-- loop. Setting e' session-level — o cron roda em sessao propria, nao
+-- impacta outras chamadas.
+
+CREATE OR REPLACE FUNCTION public.sync_contaazul_daily()
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  bar_record RECORD;
+  resultado JSONB;
+  v_service_key TEXT;
+  v_eventos_recalculados INTEGER;
+BEGIN
+  v_service_key := get_service_role_key();
+
+  -- Bump http() timeout: edge function leva 12-30s; default de 5s estava
+  -- estourando silenciosamente e impedindo a invocação da contaazul-sync.
+  PERFORM http_set_curlopt('CURLOPT_TIMEOUT_MS', '120000');
+
+  RAISE NOTICE 'Iniciando sincronizacao diaria do Conta Azul';
+
+  FOR bar_record IN
+    SELECT DISTINCT bar_id
+    FROM api_credentials
+    WHERE sistema = 'conta_azul'
+      AND access_token IS NOT NULL
+  LOOP
+    BEGIN
+      RAISE NOTICE 'Sincronizando Conta Azul para bar_id=%', bar_record.bar_id;
+
+      SELECT content::jsonb INTO resultado
+      FROM http((
+        'POST',
+        get_supabase_url() || '/functions/v1/contaazul-sync',
+        ARRAY[
+          http_header('Authorization', 'Bearer ' || v_service_key),
+          http_header('Content-Type', 'application/json')
+        ],
+        'application/json',
+        json_build_object(
+          'bar_id', bar_record.bar_id,
+          'sync_mode', 'daily_incremental'
+        )::text
+      ));
+
+      IF resultado->>'success' = 'true' THEN
+        RAISE NOTICE 'Bar % sincronizado: % lancamentos',
+          bar_record.bar_id,
+          COALESCE((resultado->'stats'->>'lancamentos')::text, '0');
+      ELSE
+        RAISE WARNING 'Erro na sincronizacao do bar %: %',
+          bar_record.bar_id, resultado;
+      END IF;
+
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'Erro ao sincronizar bar %: %',
+        bar_record.bar_id, SQLERRM;
+    END;
+  END LOOP;
+
+  -- Recalcular eventos dos ultimos 7 dias apos sincronizacao
+  RAISE NOTICE 'Recalculando eventos dos ultimos 7 dias...';
+  SELECT eventos_recalculados INTO v_eventos_recalculados
+  FROM recalcular_eventos_recentes(7);
+  RAISE NOTICE 'Eventos recalculados: %', v_eventos_recalculados;
+
+  RAISE NOTICE 'Sincronizacao diaria do Conta Azul concluida';
+
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'Erro na sincronizacao Conta Azul: %', SQLERRM;
+END;
+$function$;


### PR DESCRIPTION
## Bug raiz

Sync ContaAzul ficou paralisado de **2026-04-16 ate 2026-04-28** (12 dias) sem alerta visivel. Sócio reclamou que lançamentos manuais não apareciam no CMV — investigacao mostrou que **fonte estava vazia desde 16/04**, nao era problema do CMV.

Combinacao de **dois bugs** que se mascaravam:

### 1. Schema mismatch pos-medallion

A refatoracao medallion (~16/04) moveu \`contaazul_*\` de \`public\` pra \`integrations\`. Mas \`backend/supabase/functions/contaazul-sync/index.ts\` continuou usando \`supabase.from('contaazul_lancamentos')\` sem \`.schema('integrations')\`.

Resultado: cada upsert falhava com:
\`\`\`json
{\"code\":\"PGRST205\",\"message\":\"Could not find the table 'public.contaazul_lancamentos' in the schema cache\"}
\`\`\`

A funcao apenas \`console.error\` e seguia retornando \`success: true\` com \`stats.lancamentos: 0\` — ninguem reparou.

### 2. http() timeout 5s no SQL cron

\`public.sync_contaazul_daily()\` invoca a edge function via \`http()\`. Default da extensao e' 5s. Edge function leva 12-30s. Timeout disparava \`Operation timed out after 5002 ms with 0 bytes received\`, o \`EXCEPTION WHEN OTHERS\` engolia em silencio. **Edge function nem era invocada** (zero logs no edge-function service nas ultimas 24h), e cron 354 marcava \`succeeded\` de qualquer forma.

## Fix

### \`backend/supabase/functions/contaazul-sync/index.ts\`
\`.schema('integrations')\` em 8 chamadas:
- \`contaazul_lancamentos\` (upsert)
- \`contaazul_categorias\`
- \`contaazul_centros_custo\`
- \`contaazul_pessoas\` x2 (fornecedores + clientes)
- \`contaazul_contas_financeiras\`
- \`contaazul_logs_sincronizacao\` x2 (insert + update)

### \`database/migrations/2026-04-28-fix-sync-contaazul-daily-timeout.sql\`
\`PERFORM http_set_curlopt('CURLOPT_TIMEOUT_MS', '120000')\` antes do loop em \`sync_contaazul_daily\`. Setting e' session-level, nao afeta outras chamadas.

## Validacao

Apos deploy + migration, dispara manual de \`full_month\`:

| Bar | Lancamentos sincronizados | Duracao |
|-----|----------------------------|---------|
| 3 (Ord) | 8.679 | 34s |
| 4 (Deb) | 3.984 | 14s |

CMV semanal pos-recalculo:

| Semana | Bar | Antes | Depois |
|--------|-----|-------|--------|
| S15 Ord | 3 | R\$ 65.827 | R\$ 93.272 |
| S16 Ord | 3 | R\$ 531 | R\$ 104.510 |
| S17 Ord | 3 | **R\$ 0** | **R\$ 100.880** ✓ |
| S15 Deb | 4 | R\$ 9.918 | R\$ 14.520 |
| S16 Deb | 4 | R\$ 1.483 | R\$ 31.050 |
| S17 Deb | 4 | **R\$ 0** | **R\$ 16.570** ✓ |

## Risco / Followup

- Migration ja aplicada manualmente em prod (\`apply_migration\` via MCP). PR mantem o arquivo no repo pra rastreabilidade.
- Edge function ja deployed.
- Cron 354 sobe normal as 5h/13h/21h. Se vier sucesso com lancamentos > 0 amanha, sinal verde.

## Lessons learned

- Edge functions que fazem upsert deveriam falhar (status 500) quando upsert falha, nao retornar \`success: true\` com 0 registros. Sugere abrir issue separada pra adicionar guard.
- Cron silencioso e' inimigo. Vale considerar adicionar metric: alertar quando \`bronze_contaazul_sync_log\` nao recebe row em > 24h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)