### PR TITLE
fix(cmv-mensal): salva cmv_teorico_percentual + override no GET

### DIFF
--- a/frontend/src/app/api/cmv-semanal/mensal/route.ts
+++ b/frontend/src/app/api/cmv-semanal/mensal/route.ts
@@ -308,6 +308,16 @@ export async function GET(request: NextRequest) {
     // Agregar dados CMV com proporção
     const dadosMensais = agregarCMVProportional(semanasComProporcao, cmvMap, estoqueFinalMesAnterior, ano, mes);
 
+    // Override pelo campo manual se cmv_mensal já tiver valor pra este mês
+    // (mesmo no mês atual). Permite sócio salvar cmv_teorico_percentual manual
+    // e ver imediatamente, sem esperar o mês fechar.
+    if (cmvMensal && !errMensal) {
+      const cmvTeoricoManual = parseFloat(String(cmvMensal.cmv_teorico_percentual || 0));
+      if (cmvTeoricoManual > 0) {
+        dadosMensais.cmv_teorico_percentual = cmvTeoricoManual;
+      }
+    }
+
     // Adicionar metadados
     const resultado = {
       ...dadosMensais,
@@ -527,4 +537,79 @@ function agregarCMVProportional(
     cmv_teorico_percentual: mediaProportional('cmv_teorico_percentual'),
     gap: mediaProportional('gap'),
   };
+}
+
+/**
+ * PUT - Salva campos manuais (cmv_teorico_percentual, etc) em
+ * financial.cmv_mensal via upsert (bar_id, ano, mes).
+ *
+ * Body: { bar_id, ano, mes, [campo]: valor }
+ *
+ * Bug anterior: o salvarMetrica do front chamava /api/cmv-semanal com
+ * id fictício "${ano}-${mes}" — update silenciosamente não bate em row
+ * nenhuma da cmv_semanal. Sócio relatou "não tá salvando".
+ */
+export async function PUT(request: NextRequest) {
+  try {
+    const supabase = await getAdminClient();
+    const body = await request.json();
+    const { bar_id, ano, mes, ...campos } = body;
+
+    if (!bar_id || !ano || !mes) {
+      return NextResponse.json(
+        { error: 'bar_id, ano e mes são obrigatórios' },
+        { status: 400 }
+      );
+    }
+
+    const camposPermitidos = [
+      'cmv_teorico_percentual',
+      'consumo_socios', 'consumo_beneficios', 'consumo_artista',
+      'consumo_rh_operacao', 'consumo_rh_escritorio',
+      'outros_ajustes', 'ajuste_bonificacoes',
+      'estoque_inicial', 'estoque_final', 'compras',
+      'estoque_inicial_funcionarios', 'estoque_final_funcionarios', 'compras_alimentacao',
+    ];
+
+    const upsertData: any = {
+      bar_id,
+      ano,
+      mes,
+      data_inicio: `${ano}-${String(mes).padStart(2, '0')}-01`,
+      data_fim: `${ano}-${String(mes).padStart(2, '0')}-${String(new Date(ano, mes, 0).getDate()).padStart(2, '0')}`,
+      fonte: 'manual',
+      updated_at: new Date().toISOString(),
+    };
+
+    for (const campo of camposPermitidos) {
+      if (campos[campo] !== undefined) {
+        upsertData[campo] = campos[campo];
+      }
+    }
+
+    const { data, error } = await tbl(supabase, 'cmv_mensal')
+      .upsert(upsertData, { onConflict: 'bar_id,ano,mes' })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Erro ao salvar CMV mensal:', error);
+      return NextResponse.json(
+        { error: 'Erro ao salvar CMV mensal', details: error.message },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      data,
+      message: 'CMV mensal atualizado com sucesso'
+    });
+  } catch (error) {
+    console.error('Erro interno PUT cmv-semanal/mensal:', error);
+    return NextResponse.json(
+      { error: 'Erro interno do servidor' },
+      { status: 500 }
+    );
+  }
 }

--- a/frontend/src/app/ferramentas/cmv-semanal/tabela/page.tsx
+++ b/frontend/src/app/ferramentas/cmv-semanal/tabela/page.tsx
@@ -631,22 +631,43 @@ export default function CMVSemanalTabelaPage() {
   // Salvar métrica editada
   const salvarMetrica = async (semanaId: string, campo: string) => {
     const numValue = parseFloat(valorEdit.replace(',', '.'));
-    
+
     if (isNaN(numValue)) {
       setEditando(null);
       toast({ title: 'Erro', description: 'Valor inválido', variant: 'destructive' });
       return;
     }
-    
+
     try {
-      const response = await fetch('/api/cmv-semanal', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: semanaId, [campo]: numValue })
-      });
+      let response: Response;
+
+      if (visao === 'mensal') {
+        // Visão mensal: salva em financial.cmv_mensal via upsert (bar_id, ano, mes).
+        // semanaId no modo mensal é "${ano}-${mes}" (ID fictício, não existe em cmv_semanal).
+        const semana = semanas.find(s => s.id === semanaId);
+        if (!semana || !selectedBar) throw new Error('Semana ou bar não encontrado');
+
+        response = await fetch('/api/cmv-semanal/mensal', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            bar_id: selectedBar.id,
+            ano: semana.ano,
+            mes: semana.semana, // no modo mensal, "semana" guarda o mês (ver carregarDados)
+            [campo]: numValue,
+          }),
+        });
+      } else {
+        // Visão semanal: salva em cmv_semanal por id real
+        response = await fetch('/api/cmv-semanal', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: semanaId, [campo]: numValue }),
+        });
+      }
 
       if (!response.ok) throw new Error('Erro ao salvar');
-      
+
       toast({ title: 'Salvo!', description: 'Valor atualizado' });
       setEditando(null);
       carregarDados();


### PR DESCRIPTION
## Bug

Socio reportou: na visao mensal de \`/ferramentas/cmv-semanal/tabela\`, preencher manualmente o CMV Teorico **não salvava**.

## Causa raiz

\`salvarMetrica\` no front chamava \`PUT /api/cmv-semanal\` passando \`id\` fictício \`\"\${ano}-\${mes}\"\` (ex: \`\"2026-4\"\`). Esse ID **não existe** em \`cmv_semanal\` — o update não batia em row nenhuma e falhava silenciosamente.

## Fix

### 1. \`PUT /api/cmv-semanal/mensal\` (novo)
Aceita body \`{ bar_id, ano, mes, [campo] }\` e faz **upsert** em \`financial.cmv_mensal\` (UNIQUE \`(bar_id, ano, mes)\` já existe).

Campos permitidos: \`cmv_teorico_percentual\`, consumos, estoques, compras (manuais).

### 2. \`GET\` aplica override
Se \`cmv_mensal.cmv_teorico_percentual > 0\`, sobrescreve o valor agregado vindo de \`cmv_semanal\`. Antes só usava \`cmv_mensal\` pra meses passados — agora também pro mês atual, permitindo o sócio ver o valor manual imediatamente.

### 3. \`salvarMetrica\` no front
Detecta \`visao === 'mensal'\` e chama o endpoint correto, passando \`bar_id/ano/mes\` extraídos do row.

## Validação

- Upsert em \`financial.cmv_mensal\` testado via SQL direto ✓
- Front pendente teste manual via dev server (preencher CMV Teórico → salvar → recarregar → ver valor)

## Arquivos

- \`frontend/src/app/api/cmv-semanal/mensal/route.ts\` (+85)
- \`frontend/src/app/ferramentas/cmv-semanal/tabela/page.tsx\` (+29 -8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)