### PR TITLE
fix(desempenho-v2): suporte mensal em desempenho_manual

### DIFF
--- a/database/migrations/2026-04-29-desempenho-manual-mensal.sql
+++ b/database/migrations/2026-04-29-desempenho-manual-mensal.sql
@@ -1,0 +1,46 @@
+-- 2026-04-29: Suportar mensal em meta.desempenho_manual
+--
+-- Bug reportado: PUT /api/estrategico/desempenho-v2 retorna 500 ao salvar
+-- mensal (CMV Teorico, CMO%) com erro
+--   "null value in column \"numero_semana\" violates not-null constraint"
+--
+-- Causa: tabela criada apenas pra granularidade=semanal (UNIQUE em
+-- bar_id, ano, numero_semana) com numero_semana NOT NULL. No mensal, gold
+-- tem numero_semana=null e periodo='YYYY-MM'.
+--
+-- Fix:
+-- 1. Tornar numero_semana nullable
+-- 2. Adicionar colunas granularidade ('semanal'|'mensal') e mes
+-- 3. Substituir UNIQUE por 2 partial unique indexes (1 por granularidade)
+-- 4. Frontend route.ts (/api/estrategico/desempenho-v2 PUT) detecta
+--    mensal via gold.granularidade ou periodo regex e faz SELECT+INSERT/UPDATE
+--    manual (PostgREST não suporta partial index target em onConflict)
+
+ALTER TABLE meta.desempenho_manual
+  ADD COLUMN IF NOT EXISTS granularidade text NOT NULL DEFAULT 'semanal',
+  ADD COLUMN IF NOT EXISTS mes integer NULL,
+  ALTER COLUMN numero_semana DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='desempenho_manual_granularidade_chk'
+      AND conrelid='meta.desempenho_manual'::regclass
+  ) THEN
+    ALTER TABLE meta.desempenho_manual
+      ADD CONSTRAINT desempenho_manual_granularidade_chk
+      CHECK (granularidade IN ('semanal','mensal'));
+  END IF;
+END $$;
+
+ALTER TABLE meta.desempenho_manual
+  DROP CONSTRAINT IF EXISTS desempenho_semanal_bar_id_ano_numero_semana_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS desempenho_manual_semanal_uniq
+  ON meta.desempenho_manual(bar_id, ano, numero_semana)
+  WHERE granularidade='semanal';
+
+CREATE UNIQUE INDEX IF NOT EXISTS desempenho_manual_mensal_uniq
+  ON meta.desempenho_manual(bar_id, ano, mes)
+  WHERE granularidade='mensal';

--- a/frontend/src/app/api/estrategico/desempenho-v2/route.ts
+++ b/frontend/src/app/api/estrategico/desempenho-v2/route.ts
@@ -289,7 +289,7 @@ export async function PUT(request: NextRequest) {
     const { data: goldRow, error: goldError } = await supabase
       .schema('gold' as any)
       .from('desempenho')
-      .select('bar_id, ano, numero_semana, data_inicio, data_fim')
+      .select('bar_id, ano, numero_semana, data_inicio, data_fim, granularidade, periodo')
       .eq('id', id)
       .single();
 
@@ -353,38 +353,81 @@ export async function PUT(request: NextRequest) {
       }
     }
 
-    console.log(`🟢 PUT Desempenho V2: bar=${goldRow.bar_id}, S${goldRow.numero_semana}/${goldRow.ano}, desempenho=[${Object.keys(camposDesempenho).join(',')}], marketing=[${Object.keys(camposMarketing).join(',')}]`);
+    // Detectar granularidade (semanal vs mensal). Mensal tem numero_semana=null
+    // e periodo no formato YYYY-MM (ex: '2026-04').
+    const isMensal = goldRow.granularidade === 'mensal'
+      || (goldRow.numero_semana == null && /^\d{4}-\d{2}$/.test(String(goldRow.periodo || '')));
+    const mes = isMensal && goldRow.periodo
+      ? parseInt(String(goldRow.periodo).split('-')[1], 10)
+      : null;
+
+    console.log(`🟢 PUT Desempenho V2: bar=${goldRow.bar_id}, ${isMensal ? `M${mes}/${goldRow.ano}` : `S${goldRow.numero_semana}/${goldRow.ano}`}, desempenho=[${Object.keys(camposDesempenho).join(',')}], marketing=[${Object.keys(camposMarketing).join(',')}]`);
 
     let resultado: any = null;
 
-    // Upsert campos desempenho em meta.desempenho_manual
+    // Salvar campos em meta.desempenho_manual
+    // Como temos partial unique indexes (não constraints nominais), o upsert
+    // do PostgREST não funciona — fazemos SELECT + UPDATE/INSERT manual.
     if (Object.keys(camposDesempenho).length > 0) {
-      const { data, error: upsertError } = await supabase
+      const granularidade = isMensal ? 'mensal' : 'semanal';
+      const dadosBase: any = {
+        bar_id: goldRow.bar_id,
+        ano: goldRow.ano,
+        granularidade,
+        numero_semana: isMensal ? null : goldRow.numero_semana,
+        mes: isMensal ? mes : null,
+        data_inicio: goldRow.data_inicio,
+        data_fim: goldRow.data_fim,
+      };
+
+      // Buscar registro existente
+      let queryExist = supabase
         .schema('meta' as any)
         .from('desempenho_manual')
-        .upsert(
-          {
-            bar_id: goldRow.bar_id,
-            ano: goldRow.ano,
-            numero_semana: goldRow.numero_semana,
-            data_inicio: goldRow.data_inicio,
-            data_fim: goldRow.data_fim,
-            ...camposDesempenho,
-            atualizado_em: new Date().toISOString(),
-          },
-          { onConflict: 'bar_id,ano,numero_semana' }
-        )
-        .select()
-        .single();
+        .select('id')
+        .eq('bar_id', goldRow.bar_id)
+        .eq('ano', goldRow.ano)
+        .eq('granularidade', granularidade);
+      queryExist = isMensal
+        ? queryExist.eq('mes', mes!)
+        : queryExist.eq('numero_semana', goldRow.numero_semana);
 
-      if (upsertError) {
-        console.error('❌ PUT: erro upsert meta.desempenho_manual:', upsertError);
-        return NextResponse.json(
-          { error: 'Erro ao salvar desempenho', details: upsertError.message },
-          { status: 500 }
-        );
+      const { data: existing } = await queryExist.maybeSingle();
+
+      if (existing?.id) {
+        // UPDATE
+        const { data, error: updErr } = await supabase
+          .schema('meta' as any)
+          .from('desempenho_manual')
+          .update({ ...camposDesempenho, atualizado_em: new Date().toISOString() })
+          .eq('id', existing.id)
+          .select()
+          .single();
+        if (updErr) {
+          console.error('❌ PUT: erro update meta.desempenho_manual:', updErr);
+          return NextResponse.json(
+            { error: 'Erro ao salvar desempenho', details: updErr.message },
+            { status: 500 }
+          );
+        }
+        resultado = data;
+      } else {
+        // INSERT
+        const { data, error: insErr } = await supabase
+          .schema('meta' as any)
+          .from('desempenho_manual')
+          .insert({ ...dadosBase, ...camposDesempenho, atualizado_em: new Date().toISOString() })
+          .select()
+          .single();
+        if (insErr) {
+          console.error('❌ PUT: erro insert meta.desempenho_manual:', insErr);
+          return NextResponse.json(
+            { error: 'Erro ao salvar desempenho', details: insErr.message },
+            { status: 500 }
+          );
+        }
+        resultado = data;
       }
-      resultado = data;
     }
 
     // Upsert campos marketing em meta.marketing_semanal


### PR DESCRIPTION
## Bug

PUT /api/estrategico/desempenho-v2 retorna 500 ao salvar manualmente CMV Teórico ou CMO% na visão **mensal**.

\`\`\`
{"error":"Erro ao salvar desempenho","details":"null value in column \"numero_semana\" of relation \"desempenho_manual\" violates not-null constraint"}
\`\`\`

## Causa

\`meta.desempenho_manual\` foi criada só pra granularidade=semanal:
- UNIQUE em (bar_id, ano, numero_semana)
- numero_semana NOT NULL

No mensal, \`gold.desempenho.numero_semana\` é null (tem \`periodo='YYYY-MM'\`).

## Fix em 3 partes

### 1. Migration
- numero_semana → nullable
- Novas colunas: \`granularidade\` (semanal|mensal) e \`mes\`
- Substituir UNIQUE por 2 partial indexes (1 por granularidade)

### 2. PUT detecta mensal
- via \`goldRow.granularidade==='mensal'\` ou regex \`/^\d{4}-\d{2}$/\` em \`periodo\`
- Extrai mes de \`'2026-04'.split('-')[1]\`

### 3. SELECT + INSERT/UPDATE manual
PostgREST não suporta partial unique index target em \`onConflict\`. Refator pra fazer SELECT existing → UPDATE ou INSERT manual.

## Status

- Migration aplicada em prod
- Frontend route.ts atualizado

🤖 Generated with [Claude Code](https://claude.com/claude-code)