### PR TITLE
fix(desempenho-v2): mensal — manual, ETL completo + mapeamento front

### DIFF
--- a/database/migrations/2026-04-29-desempenho-manual-mensal.sql
+++ b/database/migrations/2026-04-29-desempenho-manual-mensal.sql
@@ -1,0 +1,46 @@
+-- 2026-04-29: Suportar mensal em meta.desempenho_manual
+--
+-- Bug reportado: PUT /api/estrategico/desempenho-v2 retorna 500 ao salvar
+-- mensal (CMV Teorico, CMO%) com erro
+--   "null value in column \"numero_semana\" violates not-null constraint"
+--
+-- Causa: tabela criada apenas pra granularidade=semanal (UNIQUE em
+-- bar_id, ano, numero_semana) com numero_semana NOT NULL. No mensal, gold
+-- tem numero_semana=null e periodo='YYYY-MM'.
+--
+-- Fix:
+-- 1. Tornar numero_semana nullable
+-- 2. Adicionar colunas granularidade ('semanal'|'mensal') e mes
+-- 3. Substituir UNIQUE por 2 partial unique indexes (1 por granularidade)
+-- 4. Frontend route.ts (/api/estrategico/desempenho-v2 PUT) detecta
+--    mensal via gold.granularidade ou periodo regex e faz SELECT+INSERT/UPDATE
+--    manual (PostgREST não suporta partial index target em onConflict)
+
+ALTER TABLE meta.desempenho_manual
+  ADD COLUMN IF NOT EXISTS granularidade text NOT NULL DEFAULT 'semanal',
+  ADD COLUMN IF NOT EXISTS mes integer NULL,
+  ALTER COLUMN numero_semana DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='desempenho_manual_granularidade_chk'
+      AND conrelid='meta.desempenho_manual'::regclass
+  ) THEN
+    ALTER TABLE meta.desempenho_manual
+      ADD CONSTRAINT desempenho_manual_granularidade_chk
+      CHECK (granularidade IN ('semanal','mensal'));
+  END IF;
+END $$;
+
+ALTER TABLE meta.desempenho_manual
+  DROP CONSTRAINT IF EXISTS desempenho_semanal_bar_id_ano_numero_semana_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS desempenho_manual_semanal_uniq
+  ON meta.desempenho_manual(bar_id, ano, numero_semana)
+  WHERE granularidade='semanal';
+
+CREATE UNIQUE INDEX IF NOT EXISTS desempenho_manual_mensal_uniq
+  ON meta.desempenho_manual(bar_id, ano, mes)
+  WHERE granularidade='mensal';

--- a/database/migrations/2026-04-29-etl-mensal-reservas-getin.sql
+++ b/database/migrations/2026-04-29-etl-mensal-reservas-getin.sql
@@ -1,0 +1,449 @@
+-- 2026-04-29: Adicionar fase_reservas_getin no etl_gold_desempenho_mensal
+--
+-- Bug reportado pelo socio em /estrategico/desempenho?visao=mensal:
+-- "as reservas continuam zeradas .. mar 2026 ta 0/17015 e 0/3499"
+--
+-- Causa raiz: o display do front e "mesas/pessoas" (mesas_totais /
+-- reservas_totais). O ETL mensal NAO populava mesas_totais/mesas_presentes
+-- nem reservas_totais_quantidade/_pessoas (quatro colunas vinham NULL ou 0).
+--
+-- gold.planejamento.num_mesas_tot esta NULL pra mar/2026 Ord (todos 31 dias),
+-- entao a tentativa de somar dali nao funciona. O ETL semanal le direto de
+-- bronze.bronze_getin_reservations e popula essas colunas — fix replica a
+-- mesma fase_reservas_getin no mensal.
+--
+-- Mantem reservas_totais e reservas_presentes vindo de gold.planejamento
+-- (res_tot/res_p — comportamento atual que o socio ja aceita: 17015/3499).
+-- Acrescenta:
+--   reservas_totais_quantidade = COUNT(*) Getin no mes (= mesas_totais)
+--   reservas_presentes_quantidade = COUNT(*) Getin presentes (= mesas_presentes)
+--   reservas_totais_pessoas = SUM(people) Getin
+--   reservas_presentes_pessoas = SUM(people) presentes
+--   reservas_quebra_pct = (1 - presentes/totais) * 100
+--
+-- Filtro presentes (igual semanal): status NOT IN ('canceled-user',
+--   'canceled-restaurant','canceled-agent','no-show') AND no_show != true.
+--
+-- Validacao Ord mar/2026 antes/depois:
+--   mesas_totais 0 -> 327, mesas_presentes 0 -> 220
+--   reservas_quebra_pct null -> 22.95
+--   reservas_totais 17015 (preservado), reservas_presentes 3499 (preservado)
+--
+-- Display front passa de "0/17015" e "0/3499" pra "327/17015" e "220/3499".
+--
+-- Deb (bar_id=4) nao tem dados em bronze_getin_reservations — mesas continuam
+-- 0 (mesmo comportamento do semanal Deb, sem regressao).
+--
+-- versao_etl 6 -> 7.
+
+CREATE OR REPLACE FUNCTION public.etl_gold_desempenho_mensal(
+  p_bar_id integer,
+  p_ano integer,
+  p_mes integer
+)
+RETURNS TABLE(bar_processado integer, periodo_processado text, linhas_inseridas integer, duracao_ms integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+
+DECLARE
+  v_start timestamptz := clock_timestamp();
+  v_data_inicio date;
+  v_data_fim date;
+  v_periodo text;
+  v_inseridos integer := 0;
+  v_locs_drinks text[];
+  v_locs_cozinha text[];
+  v_uses_t0t2_cozinha boolean;
+BEGIN
+  IF p_bar_id IS NULL OR p_ano IS NULL OR p_mes IS NULL THEN
+    RAISE EXCEPTION 'Parametros obrigatorios';
+  END IF;
+
+  IF p_bar_id = 3 THEN
+    v_locs_drinks := ARRAY['Preshh','Montados','Mexido','Drinks','Drinks Autorais','Shot e Dose','Batidos'];
+    v_locs_cozinha := ARRAY['Cozinha','Cozinha 1','Cozinha 2'];
+    v_uses_t0t2_cozinha := true;
+  ELSIF p_bar_id = 4 THEN
+    v_locs_drinks := ARRAY['Bar'];
+    v_locs_cozinha := ARRAY['Cozinha','Cozinha 2'];
+    v_uses_t0t2_cozinha := false;
+  ELSE
+    v_locs_drinks := NULL;
+    v_locs_cozinha := NULL;
+    v_uses_t0t2_cozinha := false;
+  END IF;
+
+  v_data_inicio := make_date(p_ano, p_mes, 1);
+  v_data_fim := (v_data_inicio + INTERVAL '1 month' - INTERVAL '1 day')::date;
+  v_periodo := p_ano::text || '-' || LPAD(p_mes::text, 2, '0');
+
+  WITH fase_planejamento AS (
+    SELECT
+      COALESCE(SUM(faturamento_total_consolidado), 0) as faturamento_total,
+      COALESCE(SUM(faturamento_entrada_yuzer), 0) as faturamento_entrada,
+      COALESCE(SUM(real_r), 0) as faturamento_bar,
+      COALESCE(SUM(res_tot), 0) as reservas_totais,
+      COALESCE(SUM(res_p), 0) as reservas_presentes,
+      COALESCE(SUM(faturamento_couvert), 0) as couvert_atracoes,
+      COALESCE(SUM(publico_real_consolidado), 0) as clientes_atendidos,
+      (COALESCE(SUM(faturamento_total_consolidado), 0)::numeric / NULLIF(SUM(publico_real_consolidado), 0))::numeric(10,2) as ticket_medio,
+      (COALESCE(SUM(faturamento_couvert), 0)::numeric / NULLIF(SUM(publico_real_consolidado), 0))::numeric(10,2) as tm_entrada,
+      ((COALESCE(SUM(faturamento_total_consolidado), 0) - COALESCE(SUM(faturamento_couvert), 0))::numeric / NULLIF(SUM(publico_real_consolidado), 0))::numeric(10,2) as tm_bar,
+      COALESCE(SUM(descontos), 0)::numeric(14,2) as desconto_total,
+      CASE WHEN SUM(faturamento_total_consolidado) > 0
+        THEN (SUM(descontos)::numeric / SUM(faturamento_total_consolidado) * 100)::numeric(5,2)
+        ELSE 0 END as desconto_percentual,
+      AVG(fat_19h_percent) FILTER (WHERE fat_19h_percent > 0)::numeric(5,2) as perc_fat_ate_19h,
+      AVG(fat_apos_22h_percent) FILTER (WHERE fat_apos_22h_percent > 0)::numeric(5,2) as perc_fat_apos_22h,
+      COALESCE(SUM(faturamento_total_consolidado) FILTER (WHERE EXTRACT(dow FROM data_evento) IN (4, 6, 0)), 0) as qui_sab_dom,
+      COALESCE(SUM(faturamento_total_consolidado) FILTER (WHERE EXTRACT(dow FROM data_evento) IN (2, 3, 4)), 0) as ter_qua_qui,
+      COALESCE(SUM(faturamento_total_consolidado) FILTER (WHERE EXTRACT(dow FROM data_evento) IN (5, 6)), 0) as sex_sab
+    FROM gold.planejamento
+    WHERE planejamento.bar_id = p_bar_id
+      AND data_evento BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_reservas_getin AS (
+    SELECT
+      COUNT(*)::integer as reservas_totais_qtd,
+      COUNT(*) FILTER (WHERE status NOT IN ('canceled-user','canceled-restaurant','canceled-agent','no-show') AND (no_show IS NULL OR no_show = false))::integer as reservas_presentes_qtd,
+      COALESCE(SUM(people), 0)::integer as reservas_totais_pes,
+      COALESCE(SUM(people) FILTER (WHERE status NOT IN ('canceled-user','canceled-restaurant','canceled-agent','no-show') AND (no_show IS NULL OR no_show = false)), 0)::integer as reservas_presentes_pes,
+      CASE WHEN SUM(people) > 0 THEN
+        ROUND(((SUM(people) - SUM(people) FILTER (WHERE status NOT IN ('canceled-user','canceled-restaurant','canceled-agent','no-show') AND (no_show IS NULL OR no_show = false)))::numeric / SUM(people) * 100), 2)
+      END as reservas_quebra
+    FROM bronze.bronze_getin_reservations
+    WHERE bar_id = p_bar_id AND reservation_date BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_clientes AS (
+    SELECT
+      COALESCE((SELECT total_ativos FROM gold.clientes_diario cd
+        WHERE cd.bar_id = p_bar_id AND cd.data_referencia <= v_data_fim
+        ORDER BY cd.data_referencia DESC LIMIT 1), 0) as clientes_ativos,
+      (SELECT CASE WHEN SUM(total_clientes_unicos_dia) > 0
+        THEN (SUM(novos_clientes_dia)::numeric / SUM(total_clientes_unicos_dia) * 100)::numeric(5,2)
+        END
+        FROM gold.clientes_diario cd2
+        WHERE cd2.bar_id = p_bar_id AND cd2.data_referencia BETWEEN v_data_inicio AND v_data_fim
+      ) as perc_clientes_novos
+  ),
+  fase_cmv AS (
+    SELECT SUM(compras_periodo) as compras_periodo, SUM(faturamento_cmvivel) as faturamento_cmvivel,
+      SUM(COALESCE(compras_periodo, 0) - COALESCE(vr_repique, 0)) as cmv_limpo_calc,
+      CASE WHEN SUM(faturamento_cmvivel) > 0 THEN ((SUM(COALESCE(compras_periodo, 0) - COALESCE(vr_repique, 0)) / SUM(faturamento_cmvivel)) * 100)::numeric(6,2) END as cmv_percentual_calc
+    FROM gold.cmv WHERE cmv.bar_id = p_bar_id AND cmv.data_inicio >= v_data_inicio AND cmv.data_fim <= v_data_fim
+  ),
+  fase_nps_geral AS (
+    SELECT CASE WHEN COUNT(*) > 0 THEN ((COUNT(*) FILTER (WHERE nps >= 9) - COUNT(*) FILTER (WHERE nps <= 6)) * 100.0 / COUNT(*))::numeric(6,2) END as nps_geral,
+      COUNT(*)::integer as nps_respostas
+    FROM bronze.bronze_falae_respostas
+    WHERE bar_id = p_bar_id AND (created_at AT TIME ZONE 'America/Sao_Paulo')::date BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_nps_digital AS (
+    SELECT CASE WHEN COUNT(*) > 0 THEN ((COUNT(*) FILTER (WHERE nps >= 9) - COUNT(*) FILTER (WHERE nps <= 6)) * 100.0 / COUNT(*))::numeric(6,2) END as nps_digital,
+      COUNT(*)::integer as nps_digital_respostas
+    FROM bronze.bronze_falae_respostas
+    WHERE bar_id = p_bar_id AND (created_at AT TIME ZONE 'America/Sao_Paulo')::date BETWEEN v_data_inicio AND v_data_fim AND search_name = 'NPS Digital'
+  ),
+  fase_nps_salao AS (
+    SELECT CASE WHEN COUNT(*) > 0 THEN ((COUNT(*) FILTER (WHERE nps >= 9) - COUNT(*) FILTER (WHERE nps <= 6)) * 100.0 / COUNT(*))::numeric(6,2) END as nps_salao,
+      COUNT(*)::integer as nps_salao_respostas
+    FROM bronze.bronze_falae_respostas
+    WHERE bar_id = p_bar_id AND (created_at AT TIME ZONE 'America/Sao_Paulo')::date BETWEEN v_data_inicio AND v_data_fim AND search_name = 'Salão'
+  ),
+  fase_nps_reservas AS (
+    SELECT
+      CASE WHEN SUM((respostas_por_pesquisa->'(reserva getin)'->>'total')::integer) > 0
+        THEN (SUM((respostas_por_pesquisa->'(reserva getin)'->>'total')::integer * (respostas_por_pesquisa->'(reserva getin)'->>'nps_medio')::numeric)
+             / SUM((respostas_por_pesquisa->'(reserva getin)'->>'total')::integer))::numeric(5,2)
+      END as nps_reservas,
+      COALESCE(SUM((respostas_por_pesquisa->'(reserva getin)'->>'total')::integer), 0) as nps_reservas_respostas
+    FROM silver.nps_diario
+    WHERE bar_id = p_bar_id AND data_referencia BETWEEN v_data_inicio AND v_data_fim AND respostas_por_pesquisa ? '(reserva getin)'
+  ),
+  fase_nps_criterios AS (
+    SELECT
+      AVG((criterios_medios->>'Atendimento')::numeric)::numeric(5,2) as nps_atendimento,
+      AVG((criterios_medios->>'Ambiente')::numeric)::numeric(5,2) as nps_ambiente,
+      AVG((criterios_medios->>'Drinks')::numeric)::numeric(5,2) as nps_drink,
+      AVG((criterios_medios->>'Qualidade do Produto')::numeric)::numeric(5,2) as nps_comida,
+      AVG((criterios_medios->>'Limpeza')::numeric)::numeric(5,2) as nps_limpeza,
+      AVG((criterios_medios->>'Custo benefício')::numeric)::numeric(5,2) as nps_preco,
+      AVG((criterios_medios->>'MÚSICA')::numeric)::numeric(5,2) as nps_musica
+    FROM silver.nps_diario nps
+    WHERE nps.bar_id = p_bar_id AND nps.data_referencia BETWEEN v_data_inicio AND v_data_fim AND nps.criterios_medios IS NOT NULL
+  ),
+  fase_tempos_agg AS (
+    SELECT
+      CASE WHEN COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_drinks) AND t0_t3 BETWEEN 1 AND 3600) > 0
+        THEN AVG(t0_t3) FILTER (WHERE local_desc = ANY(v_locs_drinks) AND t0_t3 BETWEEN 1 AND 3600)::numeric(8,2)
+      END as tempo_drinks,
+      CASE WHEN COUNT(*) FILTER (WHERE categoria = 'bebida' AND t0_t3 > 0) > 0
+        THEN AVG(t0_t3) FILTER (WHERE categoria = 'bebida' AND t0_t3 > 0)::numeric(8,2)
+      END as tempo_bebidas,
+      CASE WHEN v_uses_t0t2_cozinha THEN
+        CASE WHEN COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t2 BETWEEN 1 AND 3600) > 0
+          THEN AVG(t0_t2) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t2 BETWEEN 1 AND 3600)::numeric(8,2) END
+      ELSE
+        CASE WHEN COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t3 BETWEEN 1 AND 3600) > 0
+          THEN AVG(t0_t3) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t3 BETWEEN 1 AND 3600)::numeric(8,2) END
+      END as tempo_cozinha,
+      COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_drinks) AND t0_t3 BETWEEN 1 AND 3600)::integer as qtd_drinks_total,
+      CASE WHEN v_uses_t0t2_cozinha THEN
+        COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t2 BETWEEN 1 AND 3600)::integer
+      ELSE
+        COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t3 BETWEEN 1 AND 3600)::integer
+      END as qtd_comida_total,
+      COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_drinks) AND t0_t3 BETWEEN 300 AND 600)::integer as atrasinho_drinks,
+      COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_drinks) AND t0_t3 > 600)::integer as atrasao_drinks,
+      CASE WHEN v_uses_t0t2_cozinha THEN
+        COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t2 BETWEEN 900 AND 1200)::integer
+      ELSE
+        COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t3 BETWEEN 900 AND 1200)::integer
+      END as atrasinho_cozinha,
+      CASE WHEN v_uses_t0t2_cozinha THEN
+        COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t2 > 1200)::integer
+      ELSE
+        COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t3 > 1200)::integer
+      END as atrasao_cozinha,
+      COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_drinks) AND t0_t3 > 600)::integer as atrasao_bar
+    FROM silver.tempos_producao WHERE bar_id = p_bar_id AND data_producao BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_mix AS (
+    SELECT SUM(valor) as total,
+      SUM(valor) FILTER (WHERE categoria_mix = 'BEBIDA') as fat_bebida,
+      SUM(valor) FILTER (WHERE categoria_mix = 'DRINK') as fat_drink,
+      SUM(valor) FILTER (WHERE categoria_mix = 'COMIDA') as fat_comida
+    FROM silver.vendas_item WHERE bar_id = p_bar_id AND data_venda BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_stockout_dia AS (
+    SELECT data_consulta, categoria_local,
+      COUNT(DISTINCT prd) as total,
+      COUNT(DISTINCT prd) FILTER (WHERE prd_venda = 'N') as stockout
+    FROM silver.silver_contahub_operacional_stockout_processado
+    WHERE bar_id = p_bar_id AND data_consulta BETWEEN v_data_inicio AND v_data_fim AND incluido = true
+    GROUP BY data_consulta, categoria_local
+  ),
+  fase_stockout AS (
+    SELECT
+      AVG(stockout::numeric / NULLIF(total, 0) * 100) FILTER (WHERE categoria_local = 'Drinks')::numeric(5,2) as stockout_drinks_perc,
+      AVG(stockout::numeric / NULLIF(total, 0) * 100) FILTER (WHERE categoria_local = 'Bar')::numeric(5,2) as stockout_bar_perc,
+      AVG(stockout::numeric / NULLIF(total, 0) * 100) FILTER (WHERE categoria_local = 'Comidas')::numeric(5,2) as stockout_comidas_perc,
+      AVG(stockout::numeric / NULLIF(total, 0) * 100)::numeric(5,2) as stockout_total_perc
+    FROM fase_stockout_dia
+  ),
+  fase_google AS (
+    SELECT
+      COALESCE(SUM(qtd_5_estrelas), 0)::integer as avaliacoes_5_google_trip,
+      AVG(stars_medio) FILTER (WHERE total_reviews > 0)::numeric(4,2) as media_avaliacoes_google,
+      COALESCE(SUM(total_reviews), 0)::integer as google_reviews_total
+    FROM silver.google_reviews_diario WHERE bar_id = p_bar_id AND data_referencia BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_custos AS (
+    SELECT
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%atra%' OR categoria_nome ILIKE '%produ%evento%'), 0)::numeric(14,2) as atracoes_eventos,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%freela%'), 0)::numeric(14,2) as freelas,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%material%' OR categoria_nome ILIKE '%limpeza%'), 0)::numeric(14,2) as materiais,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%comiss%'), 0)::numeric(14,2) as comissao,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%sal%rio%' OR categoria_nome ILIKE '%vale%transp%'), 0)::numeric(14,2) as cmo,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%pro%labore%'), 0)::numeric(14,2) as pro_labore,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%aluguel%' OR categoria_nome ILIKE '%iptu%' OR categoria_nome ILIKE '%condom%' OR categoria_nome ILIKE '%%gua%' OR categoria_nome ILIKE '%luz%'), 0)::numeric(14,2) as ocupacao_custo,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%imposto%'), 0)::numeric(14,2) as imposto,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%escrit%central%'), 0)::numeric(14,2) as escritorio_central,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%marketing%'), 0)::numeric(14,2) as marketing_fixo,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%taxa%maquin%'), 0)::numeric(14,2) as adm_fixo,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%manuten%'), 0)::numeric(14,2) as manutencao,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%utens%'), 0)::numeric(14,2) as utensilios,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%alimenta%'), 0)::numeric(14,2) as alimentacao
+    FROM silver.contaazul_lancamentos_diarios
+    WHERE bar_id = p_bar_id AND data_competencia BETWEEN v_data_inicio AND v_data_fim AND tipo = 'DESPESA'
+  ),
+  fase_cancelamentos AS (
+    SELECT COALESCE(SUM(custototal), 0)::numeric(14,2) as cancelamentos_total, COUNT(*)::integer as cancelamentos_qtd
+    FROM bronze.bronze_contahub_avendas_cancelamentos
+    WHERE bar_id = p_bar_id AND dt_gerencial BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_pagamentos AS (
+    SELECT COALESCE(SUM(valor_liquido) FILTER (WHERE meio ILIKE '%conta assinada%'), 0)::numeric(14,2) as conta_assinada_valor
+    FROM operations.faturamento_pagamentos
+    WHERE bar_id = p_bar_id AND data_pagamento BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_marketing_mensal AS (
+    SELECT
+      SUM(o_num_posts)::integer as o_num_posts,
+      SUM(o_num_stories)::integer as o_num_stories,
+      SUM(o_alcance)::integer as o_alcance,
+      SUM(o_interacao)::integer as o_interacao,
+      SUM(o_compartilhamento)::integer as o_compartilhamento,
+      AVG(o_engajamento)::numeric(8,4) as o_engajamento,
+      SUM(o_visu_stories)::integer as o_visu_stories,
+      SUM(m_valor_investido)::numeric(14,2) as m_valor_investido,
+      SUM(m_alcance)::integer as m_alcance,
+      AVG(m_frequencia)::numeric(8,4) as m_frequencia,
+      AVG(m_cpm)::numeric(10,2) as m_cpm,
+      SUM(m_cliques)::integer as m_cliques,
+      AVG(m_ctr)::numeric(8,4) as m_ctr,
+      AVG(m_cpc)::numeric(10,2) as m_cpc,
+      SUM(m_conversas_iniciadas)::integer as m_conversas_iniciadas
+    FROM meta.marketing_semanal
+    WHERE bar_id = p_bar_id
+      AND EXTRACT(month FROM (date_trunc('week', make_date(ano, 1, 4)) + ((semana - 1) * INTERVAL '1 week') + INTERVAL '3 days')::date) = p_mes
+      AND EXTRACT(year FROM (date_trunc('week', make_date(ano, 1, 4)) + ((semana - 1) * INTERVAL '1 week') + INTERVAL '3 days')::date) = p_ano
+  )
+  INSERT INTO gold.desempenho (
+    bar_id, granularidade, periodo, ano, numero_semana, data_inicio, data_fim,
+    faturamento_total, faturamento_entrada, faturamento_bar, couvert_atracoes,
+    clientes_atendidos, ticket_medio, tm_entrada, tm_bar,
+    reservas_totais, reservas_presentes,
+    reservas_totais_quantidade, reservas_presentes_quantidade,
+    reservas_totais_pessoas, reservas_presentes_pessoas,
+    mesas_totais, mesas_presentes, reservas_quebra_pct,
+    desconto_total, desconto_percentual, conta_assinada_valor, conta_assinada_perc,
+    qui_sab_dom, ter_qua_qui, sex_sab,
+    perc_faturamento_ate_19h, perc_faturamento_apos_22h,
+    clientes_ativos, perc_clientes_novos,
+    cmv, cmv_limpo, cmv_percentual, faturamento_cmvivel,
+    nps_geral, nps_respostas, nps_digital, nps_digital_respostas,
+    nps_salao, nps_salao_respostas, nps_reservas, nps_reservas_respostas,
+    nps_atendimento, nps_ambiente, nps_drink, nps_comida, nps_limpeza, nps_preco, nps_musica,
+    tempo_drinks, tempo_bebidas, tempo_cozinha,
+    qtd_drinks_total, qtd_comida_total,
+    atrasinho_drinks, atrasao_drinks, atrasinho_cozinha, atrasao_cozinha, atrasao_bar,
+    atrasos_drinks_perc, atrasos_comida_perc,
+    perc_bebidas, perc_drinks, perc_comida,
+    stockout_drinks_perc, stockout_bar_perc, stockout_comidas_perc, stockout_total_perc,
+    avaliacoes_5_google_trip, media_avaliacoes_google, google_reviews_total,
+    atracoes_eventos, freelas, materiais, comissao, cmo, pro_labore,
+    ocupacao_custo, imposto, escritorio_central, marketing_fixo, adm_fixo,
+    manutencao, utensilios, alimentacao,
+    custos_variaveis, custos_fixos, custos_total, custo_atracao_faturamento,
+    cancelamentos_total, cancelamentos_qtd,
+    o_num_posts, o_num_stories, o_alcance, o_interacao, o_compartilhamento, o_engajamento, o_visu_stories,
+    m_valor_investido, m_alcance, m_frequencia, m_cpm, m_cliques, m_ctr, m_custo_por_clique, m_conversas_iniciadas,
+    calculado_em, versao_etl
+  )
+  SELECT
+    p_bar_id, 'mensal', v_periodo, p_ano, NULL, v_data_inicio, v_data_fim,
+    p.faturamento_total, p.faturamento_entrada, p.faturamento_bar, p.couvert_atracoes,
+    p.clientes_atendidos, p.ticket_medio, p.tm_entrada, p.tm_bar,
+    p.reservas_totais, p.reservas_presentes,
+    rg.reservas_totais_qtd, rg.reservas_presentes_qtd,
+    p.reservas_totais, p.reservas_presentes,
+    rg.reservas_totais_qtd, rg.reservas_presentes_qtd,
+    rg.reservas_quebra,
+    p.desconto_total, p.desconto_percentual,
+    pg.conta_assinada_valor,
+    CASE WHEN p.faturamento_total > 0 THEN (pg.conta_assinada_valor / p.faturamento_total * 100)::numeric(5,2) ELSE 0 END,
+    p.qui_sab_dom, p.ter_qua_qui, p.sex_sab,
+    p.perc_fat_ate_19h, p.perc_fat_apos_22h,
+    COALESCE(c.clientes_ativos, 0), c.perc_clientes_novos,
+    cmv.compras_periodo, cmv.cmv_limpo_calc, cmv.cmv_percentual_calc, cmv.faturamento_cmvivel,
+    ng.nps_geral, COALESCE(ng.nps_respostas, 0),
+    nd.nps_digital, COALESCE(nd.nps_digital_respostas, 0),
+    ns.nps_salao, COALESCE(ns.nps_salao_respostas, 0),
+    nr.nps_reservas, COALESCE(nr.nps_reservas_respostas, 0),
+    nc.nps_atendimento, nc.nps_ambiente, nc.nps_drink, nc.nps_comida,
+    nc.nps_limpeza, nc.nps_preco, nc.nps_musica,
+    t.tempo_drinks, t.tempo_bebidas, t.tempo_cozinha,
+    t.qtd_drinks_total, t.qtd_comida_total,
+    t.atrasinho_drinks, t.atrasao_drinks, t.atrasinho_cozinha, t.atrasao_cozinha, t.atrasao_bar,
+    CASE WHEN t.qtd_drinks_total > 0 THEN (t.atrasao_drinks::numeric / t.qtd_drinks_total * 100)::numeric(5,2) END,
+    CASE WHEN t.qtd_comida_total > 0 THEN (t.atrasao_cozinha::numeric / t.qtd_comida_total * 100)::numeric(5,2) END,
+    CASE WHEN mx.total > 0 THEN (mx.fat_bebida / mx.total * 100)::numeric(5,2) END,
+    CASE WHEN mx.total > 0 THEN (mx.fat_drink / mx.total * 100)::numeric(5,2) END,
+    CASE WHEN mx.total > 0 THEN (mx.fat_comida / mx.total * 100)::numeric(5,2) END,
+    stk.stockout_drinks_perc, stk.stockout_bar_perc, stk.stockout_comidas_perc, stk.stockout_total_perc,
+    g.avaliacoes_5_google_trip, g.media_avaliacoes_google, g.google_reviews_total,
+    ca.atracoes_eventos, ca.freelas, ca.materiais, ca.comissao, ca.cmo, ca.pro_labore,
+    ca.ocupacao_custo, ca.imposto, ca.escritorio_central, ca.marketing_fixo, ca.adm_fixo,
+    ca.manutencao, ca.utensilios, ca.alimentacao,
+    (ca.atracoes_eventos + ca.freelas + ca.materiais + ca.manutencao + ca.utensilios + ca.alimentacao),
+    (ca.comissao + ca.cmo + ca.pro_labore + ca.ocupacao_custo + ca.imposto + ca.escritorio_central + ca.marketing_fixo + ca.adm_fixo),
+    (ca.atracoes_eventos + ca.freelas + ca.materiais + ca.manutencao + ca.utensilios + ca.alimentacao
+      + ca.comissao + ca.cmo + ca.pro_labore + ca.ocupacao_custo + ca.imposto + ca.escritorio_central + ca.marketing_fixo + ca.adm_fixo),
+    CASE WHEN p.faturamento_total > 0 THEN (ca.atracoes_eventos / p.faturamento_total * 100)::numeric(6,2) END,
+    canc.cancelamentos_total, canc.cancelamentos_qtd,
+    mk.o_num_posts, mk.o_num_stories, mk.o_alcance, mk.o_interacao, mk.o_compartilhamento, mk.o_engajamento, mk.o_visu_stories,
+    mk.m_valor_investido, mk.m_alcance, mk.m_frequencia, mk.m_cpm, mk.m_cliques, mk.m_ctr, mk.m_cpc, mk.m_conversas_iniciadas,
+    NOW(), 7
+  FROM fase_planejamento p
+  CROSS JOIN fase_reservas_getin rg
+  CROSS JOIN fase_clientes c
+  LEFT JOIN fase_cmv cmv ON true
+  CROSS JOIN fase_nps_geral ng
+  LEFT JOIN fase_nps_digital nd ON true
+  LEFT JOIN fase_nps_salao ns ON true
+  LEFT JOIN fase_nps_reservas nr ON true
+  CROSS JOIN fase_nps_criterios nc
+  CROSS JOIN fase_tempos_agg t
+  CROSS JOIN fase_mix mx
+  CROSS JOIN fase_stockout stk
+  CROSS JOIN fase_google g
+  CROSS JOIN fase_custos ca
+  CROSS JOIN fase_cancelamentos canc
+  CROSS JOIN fase_pagamentos pg
+  LEFT JOIN fase_marketing_mensal mk ON true
+  ON CONFLICT (bar_id, granularidade, periodo) DO UPDATE SET
+    faturamento_total = EXCLUDED.faturamento_total, faturamento_entrada = EXCLUDED.faturamento_entrada,
+    faturamento_bar = EXCLUDED.faturamento_bar, couvert_atracoes = EXCLUDED.couvert_atracoes,
+    clientes_atendidos = EXCLUDED.clientes_atendidos, ticket_medio = EXCLUDED.ticket_medio,
+    tm_entrada = EXCLUDED.tm_entrada, tm_bar = EXCLUDED.tm_bar,
+    reservas_totais = EXCLUDED.reservas_totais, reservas_presentes = EXCLUDED.reservas_presentes,
+    reservas_totais_quantidade = EXCLUDED.reservas_totais_quantidade,
+    reservas_presentes_quantidade = EXCLUDED.reservas_presentes_quantidade,
+    reservas_totais_pessoas = EXCLUDED.reservas_totais_pessoas,
+    reservas_presentes_pessoas = EXCLUDED.reservas_presentes_pessoas,
+    mesas_totais = EXCLUDED.mesas_totais, mesas_presentes = EXCLUDED.mesas_presentes,
+    reservas_quebra_pct = EXCLUDED.reservas_quebra_pct,
+    desconto_total = EXCLUDED.desconto_total, desconto_percentual = EXCLUDED.desconto_percentual,
+    conta_assinada_valor = EXCLUDED.conta_assinada_valor, conta_assinada_perc = EXCLUDED.conta_assinada_perc,
+    qui_sab_dom = EXCLUDED.qui_sab_dom, ter_qua_qui = EXCLUDED.ter_qua_qui, sex_sab = EXCLUDED.sex_sab,
+    perc_faturamento_ate_19h = EXCLUDED.perc_faturamento_ate_19h,
+    perc_faturamento_apos_22h = EXCLUDED.perc_faturamento_apos_22h,
+    clientes_ativos = EXCLUDED.clientes_ativos, perc_clientes_novos = EXCLUDED.perc_clientes_novos,
+    cmv = EXCLUDED.cmv, cmv_limpo = EXCLUDED.cmv_limpo,
+    cmv_percentual = EXCLUDED.cmv_percentual, faturamento_cmvivel = EXCLUDED.faturamento_cmvivel,
+    nps_geral = EXCLUDED.nps_geral, nps_respostas = EXCLUDED.nps_respostas,
+    nps_digital = EXCLUDED.nps_digital, nps_digital_respostas = EXCLUDED.nps_digital_respostas,
+    nps_salao = EXCLUDED.nps_salao, nps_salao_respostas = EXCLUDED.nps_salao_respostas,
+    nps_reservas = EXCLUDED.nps_reservas, nps_reservas_respostas = EXCLUDED.nps_reservas_respostas,
+    nps_atendimento = EXCLUDED.nps_atendimento, nps_ambiente = EXCLUDED.nps_ambiente,
+    nps_drink = EXCLUDED.nps_drink, nps_comida = EXCLUDED.nps_comida,
+    nps_limpeza = EXCLUDED.nps_limpeza, nps_preco = EXCLUDED.nps_preco, nps_musica = EXCLUDED.nps_musica,
+    tempo_drinks = EXCLUDED.tempo_drinks, tempo_bebidas = EXCLUDED.tempo_bebidas, tempo_cozinha = EXCLUDED.tempo_cozinha,
+    qtd_drinks_total = EXCLUDED.qtd_drinks_total, qtd_comida_total = EXCLUDED.qtd_comida_total,
+    atrasinho_drinks = EXCLUDED.atrasinho_drinks, atrasao_drinks = EXCLUDED.atrasao_drinks,
+    atrasinho_cozinha = EXCLUDED.atrasinho_cozinha, atrasao_cozinha = EXCLUDED.atrasao_cozinha,
+    atrasao_bar = EXCLUDED.atrasao_bar,
+    atrasos_drinks_perc = EXCLUDED.atrasos_drinks_perc, atrasos_comida_perc = EXCLUDED.atrasos_comida_perc,
+    perc_bebidas = EXCLUDED.perc_bebidas, perc_drinks = EXCLUDED.perc_drinks, perc_comida = EXCLUDED.perc_comida,
+    stockout_drinks_perc = EXCLUDED.stockout_drinks_perc, stockout_bar_perc = EXCLUDED.stockout_bar_perc,
+    stockout_comidas_perc = EXCLUDED.stockout_comidas_perc, stockout_total_perc = EXCLUDED.stockout_total_perc,
+    avaliacoes_5_google_trip = EXCLUDED.avaliacoes_5_google_trip,
+    media_avaliacoes_google = EXCLUDED.media_avaliacoes_google,
+    google_reviews_total = EXCLUDED.google_reviews_total,
+    atracoes_eventos = EXCLUDED.atracoes_eventos, freelas = EXCLUDED.freelas, materiais = EXCLUDED.materiais,
+    comissao = EXCLUDED.comissao, cmo = EXCLUDED.cmo, pro_labore = EXCLUDED.pro_labore,
+    ocupacao_custo = EXCLUDED.ocupacao_custo, imposto = EXCLUDED.imposto,
+    escritorio_central = EXCLUDED.escritorio_central, marketing_fixo = EXCLUDED.marketing_fixo,
+    adm_fixo = EXCLUDED.adm_fixo, manutencao = EXCLUDED.manutencao,
+    utensilios = EXCLUDED.utensilios, alimentacao = EXCLUDED.alimentacao,
+    custos_variaveis = EXCLUDED.custos_variaveis, custos_fixos = EXCLUDED.custos_fixos,
+    custos_total = EXCLUDED.custos_total, custo_atracao_faturamento = EXCLUDED.custo_atracao_faturamento,
+    cancelamentos_total = EXCLUDED.cancelamentos_total, cancelamentos_qtd = EXCLUDED.cancelamentos_qtd,
+    o_num_posts = EXCLUDED.o_num_posts, o_num_stories = EXCLUDED.o_num_stories,
+    o_alcance = EXCLUDED.o_alcance, o_interacao = EXCLUDED.o_interacao,
+    o_compartilhamento = EXCLUDED.o_compartilhamento, o_engajamento = EXCLUDED.o_engajamento,
+    o_visu_stories = EXCLUDED.o_visu_stories,
+    m_valor_investido = EXCLUDED.m_valor_investido, m_alcance = EXCLUDED.m_alcance,
+    m_frequencia = EXCLUDED.m_frequencia, m_cpm = EXCLUDED.m_cpm, m_cliques = EXCLUDED.m_cliques,
+    m_ctr = EXCLUDED.m_ctr, m_custo_por_clique = EXCLUDED.m_custo_por_clique,
+    m_conversas_iniciadas = EXCLUDED.m_conversas_iniciadas,
+    calculado_em = NOW(), versao_etl = 7;
+
+  GET DIAGNOSTICS v_inseridos = ROW_COUNT;
+
+  RETURN QUERY SELECT p_bar_id, v_periodo, v_inseridos, ((EXTRACT(EPOCH FROM (clock_timestamp() - v_start)) * 1000))::int;
+END;
+
+$function$;

--- a/database/migrations/2026-04-29-etl-mensal-tempos-bar-marketing-semanal.sql
+++ b/database/migrations/2026-04-29-etl-mensal-tempos-bar-marketing-semanal.sql
@@ -1,0 +1,529 @@
+-- 2026-04-29: Fix etl_gold_desempenho_mensal pra ficar 100% automatico
+--
+-- Sintomas reportados pelo socio em /estrategico/desempenho?visao=mensal:
+--   * Tempos drinks/cozinha errados — Deb mostrava 9999 (cap) em dez/2025,
+--     jan, fev/2026 porque mensal usava categoria='drink'/'comida' do silver
+--     em vez das regras por bar (loc_desc + t0_t2 vs t0_t3) que o semanal
+--     aplica desde PR #44.
+--   * Marketing manual (m_valor_investido, o_num_posts etc) sempre NULL
+--     porque mensal lia de meta.marketing_mensal (vazia) em vez de
+--     somar de meta.marketing_semanal (populada toda semana).
+--
+-- Correcoes:
+--   1. Variaveis v_locs_drinks / v_locs_cozinha / v_uses_t0t2_cozinha por
+--      bar (espelha etl_gold_desempenho_semanal exatamente):
+--        Ord (3): drinks em [Preshh,Montados,Mexido,Drinks,Drinks Autorais,
+--                  Shot e Dose,Batidos]; cozinha em [Cozinha,Cozinha 1,
+--                  Cozinha 2] usando t0_t2.
+--        Deb (4): drinks em [Bar]; cozinha em [Cozinha,Cozinha 2] usando t0_t3.
+--   2. fase_marketing_mensal le de meta.marketing_semanal somando todas as
+--      semanas cuja quinta-feira ISO (data_inicio + 3 dias) cai no mes
+--      target. Quinta eh dia central da semana ISO, garante que cada
+--      semana cai em exatamente UM mes (sem double counting).
+--
+-- Validacao pos-deploy (mar/2026):
+--   Ord: tempo_drinks 162.97 -> 151.85 (bate semanal S09-S13: 133-170)
+--        m_valor_investido NULL -> R$ 15.011,49
+--        o_num_posts NULL -> 22, m_cliques NULL -> 16.820
+--   Deb: tempo_drinks 9999 (cap) -> 486.98
+--        m_valor_investido NULL -> R$ 2.663,76
+--
+-- Cobertura cron: jobid 462 "gold-desempenho" 12:00 BRT diario ja chama
+-- etl_gold_desempenho_mensal_range — recalculo automatico todo dia.
+--
+-- versao_etl 5 -> 6.
+
+CREATE OR REPLACE FUNCTION public.etl_gold_desempenho_mensal(
+  p_bar_id integer,
+  p_ano integer,
+  p_mes integer
+)
+RETURNS TABLE(bar_processado integer, periodo_processado text, linhas_inseridas integer, duracao_ms integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+
+DECLARE
+  v_start timestamptz := clock_timestamp();
+  v_data_inicio date;
+  v_data_fim date;
+  v_periodo text;
+  v_inseridos integer := 0;
+  v_locs_drinks text[];
+  v_locs_cozinha text[];
+  v_uses_t0t2_cozinha boolean;
+BEGIN
+  IF p_bar_id IS NULL OR p_ano IS NULL OR p_mes IS NULL THEN
+    RAISE EXCEPTION 'Parametros obrigatorios';
+  END IF;
+
+  IF p_bar_id = 3 THEN
+    v_locs_drinks := ARRAY['Preshh','Montados','Mexido','Drinks','Drinks Autorais','Shot e Dose','Batidos'];
+    v_locs_cozinha := ARRAY['Cozinha','Cozinha 1','Cozinha 2'];
+    v_uses_t0t2_cozinha := true;
+  ELSIF p_bar_id = 4 THEN
+    v_locs_drinks := ARRAY['Bar'];
+    v_locs_cozinha := ARRAY['Cozinha','Cozinha 2'];
+    v_uses_t0t2_cozinha := false;
+  ELSE
+    v_locs_drinks := NULL;
+    v_locs_cozinha := NULL;
+    v_uses_t0t2_cozinha := false;
+  END IF;
+
+  v_data_inicio := make_date(p_ano, p_mes, 1);
+  v_data_fim := (v_data_inicio + INTERVAL '1 month' - INTERVAL '1 day')::date;
+  v_periodo := p_ano::text || '-' || LPAD(p_mes::text, 2, '0');
+
+  WITH fase_planejamento AS (
+    SELECT
+      COALESCE(SUM(faturamento_total_consolidado), 0) as faturamento_total,
+      COALESCE(SUM(faturamento_entrada_yuzer), 0) as faturamento_entrada,
+      COALESCE(SUM(real_r), 0) as faturamento_bar,
+      COALESCE(SUM(faturamento_couvert), 0) as couvert_atracoes,
+      COALESCE(SUM(publico_real_consolidado), 0) as clientes_atendidos,
+      (COALESCE(SUM(faturamento_total_consolidado), 0)::numeric / NULLIF(SUM(publico_real_consolidado), 0))::numeric(10,2) as ticket_medio,
+      (COALESCE(SUM(faturamento_couvert), 0)::numeric / NULLIF(SUM(publico_real_consolidado), 0))::numeric(10,2) as tm_entrada,
+      ((COALESCE(SUM(faturamento_total_consolidado), 0) - COALESCE(SUM(faturamento_couvert), 0))::numeric / NULLIF(SUM(publico_real_consolidado), 0))::numeric(10,2) as tm_bar,
+      COALESCE(SUM(res_tot), 0) as reservas_totais,
+      COALESCE(SUM(res_p), 0) as reservas_presentes,
+      COALESCE(SUM(num_mesas_tot), 0) as mesas_totais,
+      COALESCE(SUM(num_mesas_presentes), 0) as mesas_presentes,
+      CASE WHEN SUM(res_tot) > 0
+        THEN ((1 - SUM(res_p)::numeric / SUM(res_tot)) * 100)::numeric(5,2)
+        ELSE 0 END as reservas_quebra_pct,
+      COALESCE(SUM(descontos), 0)::numeric(14,2) as desconto_total,
+      CASE WHEN SUM(faturamento_total_consolidado) > 0
+        THEN (SUM(descontos)::numeric / SUM(faturamento_total_consolidado) * 100)::numeric(5,2)
+        ELSE 0 END as desconto_percentual,
+      AVG(fat_19h_percent) FILTER (WHERE fat_19h_percent > 0)::numeric(5,2) as perc_fat_ate_19h,
+      AVG(fat_apos_22h_percent) FILTER (WHERE fat_apos_22h_percent > 0)::numeric(5,2) as perc_fat_apos_22h,
+      COALESCE(SUM(faturamento_total_consolidado) FILTER (WHERE EXTRACT(dow FROM data_evento) IN (4, 6, 0)), 0) as qui_sab_dom,
+      COALESCE(SUM(faturamento_total_consolidado) FILTER (WHERE EXTRACT(dow FROM data_evento) IN (2, 3, 4)), 0) as ter_qua_qui,
+      COALESCE(SUM(faturamento_total_consolidado) FILTER (WHERE EXTRACT(dow FROM data_evento) IN (5, 6)), 0) as sex_sab
+    FROM gold.planejamento
+    WHERE planejamento.bar_id = p_bar_id
+      AND data_evento BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_clientes AS (
+    SELECT
+      COALESCE((SELECT total_ativos FROM gold.clientes_diario cd
+        WHERE cd.bar_id = p_bar_id AND cd.data_referencia <= v_data_fim
+        ORDER BY cd.data_referencia DESC LIMIT 1), 0) as clientes_ativos,
+      (SELECT CASE WHEN SUM(total_clientes_unicos_dia) > 0
+        THEN (SUM(novos_clientes_dia)::numeric / SUM(total_clientes_unicos_dia) * 100)::numeric(5,2)
+        END
+        FROM gold.clientes_diario cd2
+        WHERE cd2.bar_id = p_bar_id AND cd2.data_referencia BETWEEN v_data_inicio AND v_data_fim
+      ) as perc_clientes_novos
+  ),
+  fase_cmv AS (
+    SELECT
+      SUM(compras_periodo) as compras_periodo,
+      SUM(faturamento_cmvivel) as faturamento_cmvivel,
+      SUM(COALESCE(compras_periodo, 0) - COALESCE(vr_repique, 0)) as cmv_limpo_calc,
+      CASE WHEN SUM(faturamento_cmvivel) > 0
+        THEN ((SUM(COALESCE(compras_periodo, 0) - COALESCE(vr_repique, 0)) / SUM(faturamento_cmvivel)) * 100)::numeric(6,2)
+      END as cmv_percentual_calc
+    FROM gold.cmv
+    WHERE cmv.bar_id = p_bar_id
+      AND cmv.data_inicio >= v_data_inicio
+      AND cmv.data_fim <= v_data_fim
+  ),
+  fase_nps_geral AS (
+    SELECT
+      CASE WHEN COUNT(*) > 0
+        THEN ((COUNT(*) FILTER (WHERE nps >= 9) - COUNT(*) FILTER (WHERE nps <= 6)) * 100.0 / COUNT(*))::numeric(6,2)
+      END as nps_geral,
+      COUNT(*)::integer as nps_respostas
+    FROM bronze.bronze_falae_respostas
+    WHERE bar_id = p_bar_id
+      AND (created_at AT TIME ZONE 'America/Sao_Paulo')::date BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_nps_digital AS (
+    SELECT
+      CASE WHEN COUNT(*) > 0
+        THEN ((COUNT(*) FILTER (WHERE nps >= 9) - COUNT(*) FILTER (WHERE nps <= 6)) * 100.0 / COUNT(*))::numeric(6,2)
+      END as nps_digital,
+      COUNT(*)::integer as nps_digital_respostas
+    FROM bronze.bronze_falae_respostas
+    WHERE bar_id = p_bar_id
+      AND (created_at AT TIME ZONE 'America/Sao_Paulo')::date BETWEEN v_data_inicio AND v_data_fim
+      AND search_name = 'NPS Digital'
+  ),
+  fase_nps_salao AS (
+    SELECT
+      CASE WHEN COUNT(*) > 0
+        THEN ((COUNT(*) FILTER (WHERE nps >= 9) - COUNT(*) FILTER (WHERE nps <= 6)) * 100.0 / COUNT(*))::numeric(6,2)
+      END as nps_salao,
+      COUNT(*)::integer as nps_salao_respostas
+    FROM bronze.bronze_falae_respostas
+    WHERE bar_id = p_bar_id
+      AND (created_at AT TIME ZONE 'America/Sao_Paulo')::date BETWEEN v_data_inicio AND v_data_fim
+      AND search_name = 'Salão'
+  ),
+  fase_nps_reservas AS (
+    SELECT
+      CASE WHEN SUM((respostas_por_pesquisa->'(reserva getin)'->>'total')::integer) > 0
+        THEN (SUM((respostas_por_pesquisa->'(reserva getin)'->>'total')::integer * (respostas_por_pesquisa->'(reserva getin)'->>'nps_medio')::numeric)
+             / SUM((respostas_por_pesquisa->'(reserva getin)'->>'total')::integer))::numeric(5,2)
+      END as nps_reservas,
+      COALESCE(SUM((respostas_por_pesquisa->'(reserva getin)'->>'total')::integer), 0) as nps_reservas_respostas
+    FROM silver.nps_diario
+    WHERE bar_id = p_bar_id
+      AND data_referencia BETWEEN v_data_inicio AND v_data_fim
+      AND respostas_por_pesquisa ? '(reserva getin)'
+  ),
+  fase_nps_criterios AS (
+    SELECT
+      AVG((criterios_medios->>'Atendimento')::numeric)::numeric(5,2) as nps_atendimento,
+      AVG((criterios_medios->>'Ambiente')::numeric)::numeric(5,2) as nps_ambiente,
+      AVG((criterios_medios->>'Drinks')::numeric)::numeric(5,2) as nps_drink,
+      AVG((criterios_medios->>'Qualidade do Produto')::numeric)::numeric(5,2) as nps_comida,
+      AVG((criterios_medios->>'Limpeza')::numeric)::numeric(5,2) as nps_limpeza,
+      AVG((criterios_medios->>'Custo benefício')::numeric)::numeric(5,2) as nps_preco,
+      AVG((criterios_medios->>'MÚSICA')::numeric)::numeric(5,2) as nps_musica
+    FROM silver.nps_diario nps
+    WHERE nps.bar_id = p_bar_id
+      AND nps.data_referencia BETWEEN v_data_inicio AND v_data_fim
+      AND nps.criterios_medios IS NOT NULL
+  ),
+  -- Tempos com regras por bar (espelha ETL semanal PR #44)
+  fase_tempos_agg AS (
+    SELECT
+      CASE WHEN COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_drinks) AND t0_t3 BETWEEN 1 AND 3600) > 0
+        THEN AVG(t0_t3) FILTER (WHERE local_desc = ANY(v_locs_drinks) AND t0_t3 BETWEEN 1 AND 3600)::numeric(8,2)
+      END as tempo_drinks,
+      CASE WHEN COUNT(*) FILTER (WHERE categoria = 'bebida' AND t0_t3 > 0) > 0
+        THEN AVG(t0_t3) FILTER (WHERE categoria = 'bebida' AND t0_t3 > 0)::numeric(8,2)
+      END as tempo_bebidas,
+      CASE WHEN v_uses_t0t2_cozinha THEN
+        CASE WHEN COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t2 BETWEEN 1 AND 3600) > 0
+          THEN AVG(t0_t2) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t2 BETWEEN 1 AND 3600)::numeric(8,2) END
+      ELSE
+        CASE WHEN COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t3 BETWEEN 1 AND 3600) > 0
+          THEN AVG(t0_t3) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t3 BETWEEN 1 AND 3600)::numeric(8,2) END
+      END as tempo_cozinha,
+      COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_drinks) AND t0_t3 BETWEEN 1 AND 3600)::integer as qtd_drinks_total,
+      CASE WHEN v_uses_t0t2_cozinha THEN
+        COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t2 BETWEEN 1 AND 3600)::integer
+      ELSE
+        COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t3 BETWEEN 1 AND 3600)::integer
+      END as qtd_comida_total,
+      COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_drinks) AND t0_t3 BETWEEN 300 AND 600)::integer as atrasinho_drinks,
+      COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_drinks) AND t0_t3 > 600)::integer as atrasao_drinks,
+      CASE WHEN v_uses_t0t2_cozinha THEN
+        COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t2 BETWEEN 900 AND 1200)::integer
+      ELSE
+        COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t3 BETWEEN 900 AND 1200)::integer
+      END as atrasinho_cozinha,
+      CASE WHEN v_uses_t0t2_cozinha THEN
+        COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t2 > 1200)::integer
+      ELSE
+        COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_cozinha) AND t0_t3 > 1200)::integer
+      END as atrasao_cozinha,
+      COUNT(*) FILTER (WHERE local_desc = ANY(v_locs_drinks) AND t0_t3 > 600)::integer as atrasao_bar
+    FROM silver.tempos_producao
+    WHERE bar_id = p_bar_id
+      AND data_producao BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_mix AS (
+    SELECT SUM(valor) as total,
+      SUM(valor) FILTER (WHERE categoria_mix = 'BEBIDA') as fat_bebida,
+      SUM(valor) FILTER (WHERE categoria_mix = 'DRINK') as fat_drink,
+      SUM(valor) FILTER (WHERE categoria_mix = 'COMIDA') as fat_comida
+    FROM silver.vendas_item
+    WHERE bar_id = p_bar_id AND data_venda BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_stockout_dia AS (
+    SELECT data_consulta, categoria_local,
+      COUNT(DISTINCT prd) as total,
+      COUNT(DISTINCT prd) FILTER (WHERE prd_venda = 'N') as stockout
+    FROM silver.silver_contahub_operacional_stockout_processado
+    WHERE bar_id = p_bar_id
+      AND data_consulta BETWEEN v_data_inicio AND v_data_fim
+      AND incluido = true
+    GROUP BY data_consulta, categoria_local
+  ),
+  fase_stockout AS (
+    SELECT
+      AVG(stockout::numeric / NULLIF(total, 0) * 100) FILTER (WHERE categoria_local = 'Drinks')::numeric(5,2) as stockout_drinks_perc,
+      AVG(stockout::numeric / NULLIF(total, 0) * 100) FILTER (WHERE categoria_local = 'Bar')::numeric(5,2) as stockout_bar_perc,
+      AVG(stockout::numeric / NULLIF(total, 0) * 100) FILTER (WHERE categoria_local = 'Comidas')::numeric(5,2) as stockout_comidas_perc,
+      AVG(stockout::numeric / NULLIF(total, 0) * 100)::numeric(5,2) as stockout_total_perc
+    FROM fase_stockout_dia
+  ),
+  fase_google AS (
+    SELECT
+      COALESCE(SUM(qtd_5_estrelas), 0)::integer as avaliacoes_5_google_trip,
+      AVG(stars_medio) FILTER (WHERE total_reviews > 0)::numeric(4,2) as media_avaliacoes_google,
+      COALESCE(SUM(total_reviews), 0)::integer as google_reviews_total
+    FROM silver.google_reviews_diario
+    WHERE bar_id = p_bar_id AND data_referencia BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_custos AS (
+    SELECT
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%atra%' OR categoria_nome ILIKE '%produ%evento%'), 0)::numeric(14,2) as atracoes_eventos,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%freela%'), 0)::numeric(14,2) as freelas,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%material%' OR categoria_nome ILIKE '%limpeza%'), 0)::numeric(14,2) as materiais,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%comiss%'), 0)::numeric(14,2) as comissao,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%sal%rio%' OR categoria_nome ILIKE '%vale%transp%'), 0)::numeric(14,2) as cmo,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%pro%labore%'), 0)::numeric(14,2) as pro_labore,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%aluguel%' OR categoria_nome ILIKE '%iptu%' OR categoria_nome ILIKE '%condom%' OR categoria_nome ILIKE '%%gua%' OR categoria_nome ILIKE '%luz%'), 0)::numeric(14,2) as ocupacao_custo,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%imposto%'), 0)::numeric(14,2) as imposto,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%escrit%central%'), 0)::numeric(14,2) as escritorio_central,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%marketing%'), 0)::numeric(14,2) as marketing_fixo,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%taxa%maquin%'), 0)::numeric(14,2) as adm_fixo,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%manuten%'), 0)::numeric(14,2) as manutencao,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%utens%'), 0)::numeric(14,2) as utensilios,
+      COALESCE(SUM(valor_liquido) FILTER (WHERE categoria_nome ILIKE '%alimenta%'), 0)::numeric(14,2) as alimentacao
+    FROM silver.contaazul_lancamentos_diarios
+    WHERE bar_id = p_bar_id
+      AND data_competencia BETWEEN v_data_inicio AND v_data_fim
+      AND tipo = 'DESPESA'
+  ),
+  fase_cancelamentos AS (
+    SELECT
+      COALESCE(SUM(custototal), 0)::numeric(14,2) as cancelamentos_total,
+      COUNT(*)::integer as cancelamentos_qtd
+    FROM bronze.bronze_contahub_avendas_cancelamentos
+    WHERE bar_id = p_bar_id AND dt_gerencial BETWEEN v_data_inicio AND v_data_fim
+  ),
+  fase_pagamentos AS (
+    SELECT
+      COALESCE(SUM(valor_liquido) FILTER (WHERE meio ILIKE '%conta assinada%'), 0)::numeric(14,2) as conta_assinada_valor
+    FROM operations.faturamento_pagamentos
+    WHERE bar_id = p_bar_id
+      AND data_pagamento BETWEEN v_data_inicio AND v_data_fim
+  ),
+  -- Marketing: somar de meta.marketing_semanal todas as semanas cuja
+  -- quinta-feira ISO (dia central) cai no mes target. Sem double counting.
+  fase_marketing_mensal AS (
+    SELECT
+      SUM(o_num_posts)::integer as o_num_posts,
+      SUM(o_num_stories)::integer as o_num_stories,
+      SUM(o_alcance)::integer as o_alcance,
+      SUM(o_interacao)::integer as o_interacao,
+      SUM(o_compartilhamento)::integer as o_compartilhamento,
+      AVG(o_engajamento)::numeric(8,4) as o_engajamento,
+      SUM(o_visu_stories)::integer as o_visu_stories,
+      SUM(m_valor_investido)::numeric(14,2) as m_valor_investido,
+      SUM(m_alcance)::integer as m_alcance,
+      AVG(m_frequencia)::numeric(8,4) as m_frequencia,
+      AVG(m_cpm)::numeric(10,2) as m_cpm,
+      SUM(m_cliques)::integer as m_cliques,
+      AVG(m_ctr)::numeric(8,4) as m_ctr,
+      AVG(m_cpc)::numeric(10,2) as m_cpc,
+      SUM(m_conversas_iniciadas)::integer as m_conversas_iniciadas
+    FROM meta.marketing_semanal
+    WHERE bar_id = p_bar_id
+      AND EXTRACT(month FROM
+        (date_trunc('week', make_date(ano, 1, 4)) + ((semana - 1) * INTERVAL '1 week') + INTERVAL '3 days')::date
+      ) = p_mes
+      AND EXTRACT(year FROM
+        (date_trunc('week', make_date(ano, 1, 4)) + ((semana - 1) * INTERVAL '1 week') + INTERVAL '3 days')::date
+      ) = p_ano
+  )
+  INSERT INTO gold.desempenho (
+    bar_id, granularidade, periodo, ano, numero_semana, data_inicio, data_fim,
+    faturamento_total, faturamento_entrada, faturamento_bar, couvert_atracoes,
+    clientes_atendidos, ticket_medio, tm_entrada, tm_bar,
+    reservas_totais, reservas_presentes,
+    mesas_totais, mesas_presentes, reservas_quebra_pct,
+    desconto_total, desconto_percentual, conta_assinada_valor, conta_assinada_perc,
+    qui_sab_dom, ter_qua_qui, sex_sab,
+    perc_faturamento_ate_19h, perc_faturamento_apos_22h,
+    clientes_ativos, perc_clientes_novos,
+    cmv, cmv_limpo, cmv_percentual, faturamento_cmvivel,
+    nps_geral, nps_respostas, nps_digital, nps_digital_respostas,
+    nps_salao, nps_salao_respostas, nps_reservas, nps_reservas_respostas,
+    nps_atendimento, nps_ambiente, nps_drink, nps_comida, nps_limpeza, nps_preco, nps_musica,
+    tempo_drinks, tempo_bebidas, tempo_cozinha,
+    qtd_drinks_total, qtd_comida_total,
+    atrasinho_drinks, atrasao_drinks, atrasinho_cozinha, atrasao_cozinha, atrasao_bar,
+    atrasos_drinks_perc, atrasos_comida_perc,
+    perc_bebidas, perc_drinks, perc_comida,
+    stockout_drinks_perc, stockout_bar_perc, stockout_comidas_perc, stockout_total_perc,
+    avaliacoes_5_google_trip, media_avaliacoes_google, google_reviews_total,
+    atracoes_eventos, freelas, materiais, comissao, cmo, pro_labore,
+    ocupacao_custo, imposto, escritorio_central, marketing_fixo, adm_fixo,
+    manutencao, utensilios, alimentacao,
+    custos_variaveis, custos_fixos, custos_total, custo_atracao_faturamento,
+    cancelamentos_total, cancelamentos_qtd,
+    o_num_posts, o_num_stories, o_alcance, o_interacao, o_compartilhamento, o_engajamento, o_visu_stories,
+    m_valor_investido, m_alcance, m_frequencia, m_cpm, m_cliques, m_ctr, m_custo_por_clique, m_conversas_iniciadas,
+    calculado_em, versao_etl
+  )
+  SELECT
+    p_bar_id, 'mensal', v_periodo, p_ano, NULL, v_data_inicio, v_data_fim,
+    p.faturamento_total, p.faturamento_entrada, p.faturamento_bar, p.couvert_atracoes,
+    p.clientes_atendidos, p.ticket_medio, p.tm_entrada, p.tm_bar,
+    p.reservas_totais, p.reservas_presentes,
+    p.mesas_totais, p.mesas_presentes, p.reservas_quebra_pct,
+    p.desconto_total, p.desconto_percentual,
+    pg.conta_assinada_valor,
+    CASE WHEN p.faturamento_total > 0
+      THEN (pg.conta_assinada_valor / p.faturamento_total * 100)::numeric(5,2)
+      ELSE 0 END,
+    p.qui_sab_dom, p.ter_qua_qui, p.sex_sab,
+    p.perc_fat_ate_19h, p.perc_fat_apos_22h,
+    COALESCE(c.clientes_ativos, 0), c.perc_clientes_novos,
+    cmv.compras_periodo, cmv.cmv_limpo_calc, cmv.cmv_percentual_calc, cmv.faturamento_cmvivel,
+    ng.nps_geral, COALESCE(ng.nps_respostas, 0),
+    nd.nps_digital, COALESCE(nd.nps_digital_respostas, 0),
+    ns.nps_salao, COALESCE(ns.nps_salao_respostas, 0),
+    nr.nps_reservas, COALESCE(nr.nps_reservas_respostas, 0),
+    nc.nps_atendimento, nc.nps_ambiente, nc.nps_drink, nc.nps_comida,
+    nc.nps_limpeza, nc.nps_preco, nc.nps_musica,
+    t.tempo_drinks, t.tempo_bebidas, t.tempo_cozinha,
+    t.qtd_drinks_total, t.qtd_comida_total,
+    t.atrasinho_drinks, t.atrasao_drinks, t.atrasinho_cozinha, t.atrasao_cozinha, t.atrasao_bar,
+    CASE WHEN t.qtd_drinks_total > 0 THEN (t.atrasao_drinks::numeric / t.qtd_drinks_total * 100)::numeric(5,2) END,
+    CASE WHEN t.qtd_comida_total > 0 THEN (t.atrasao_cozinha::numeric / t.qtd_comida_total * 100)::numeric(5,2) END,
+    CASE WHEN mx.total > 0 THEN (mx.fat_bebida / mx.total * 100)::numeric(5,2) END,
+    CASE WHEN mx.total > 0 THEN (mx.fat_drink / mx.total * 100)::numeric(5,2) END,
+    CASE WHEN mx.total > 0 THEN (mx.fat_comida / mx.total * 100)::numeric(5,2) END,
+    stk.stockout_drinks_perc, stk.stockout_bar_perc, stk.stockout_comidas_perc, stk.stockout_total_perc,
+    g.avaliacoes_5_google_trip, g.media_avaliacoes_google, g.google_reviews_total,
+    ca.atracoes_eventos, ca.freelas, ca.materiais, ca.comissao, ca.cmo, ca.pro_labore,
+    ca.ocupacao_custo, ca.imposto, ca.escritorio_central, ca.marketing_fixo, ca.adm_fixo,
+    ca.manutencao, ca.utensilios, ca.alimentacao,
+    (ca.atracoes_eventos + ca.freelas + ca.materiais + ca.manutencao + ca.utensilios + ca.alimentacao),
+    (ca.comissao + ca.cmo + ca.pro_labore + ca.ocupacao_custo + ca.imposto + ca.escritorio_central + ca.marketing_fixo + ca.adm_fixo),
+    (ca.atracoes_eventos + ca.freelas + ca.materiais + ca.manutencao + ca.utensilios + ca.alimentacao
+      + ca.comissao + ca.cmo + ca.pro_labore + ca.ocupacao_custo + ca.imposto + ca.escritorio_central + ca.marketing_fixo + ca.adm_fixo),
+    CASE WHEN p.faturamento_total > 0 THEN (ca.atracoes_eventos / p.faturamento_total * 100)::numeric(6,2) END,
+    canc.cancelamentos_total, canc.cancelamentos_qtd,
+    mk.o_num_posts, mk.o_num_stories, mk.o_alcance, mk.o_interacao, mk.o_compartilhamento, mk.o_engajamento, mk.o_visu_stories,
+    mk.m_valor_investido, mk.m_alcance, mk.m_frequencia, mk.m_cpm, mk.m_cliques, mk.m_ctr, mk.m_cpc, mk.m_conversas_iniciadas,
+    NOW(), 6
+  FROM fase_planejamento p
+  CROSS JOIN fase_clientes c
+  LEFT JOIN fase_cmv cmv ON true
+  CROSS JOIN fase_nps_geral ng
+  LEFT JOIN fase_nps_digital nd ON true
+  LEFT JOIN fase_nps_salao ns ON true
+  LEFT JOIN fase_nps_reservas nr ON true
+  CROSS JOIN fase_nps_criterios nc
+  CROSS JOIN fase_tempos_agg t
+  CROSS JOIN fase_mix mx
+  CROSS JOIN fase_stockout stk
+  CROSS JOIN fase_google g
+  CROSS JOIN fase_custos ca
+  CROSS JOIN fase_cancelamentos canc
+  CROSS JOIN fase_pagamentos pg
+  LEFT JOIN fase_marketing_mensal mk ON true
+  ON CONFLICT (bar_id, granularidade, periodo) DO UPDATE SET
+    faturamento_total = EXCLUDED.faturamento_total,
+    faturamento_entrada = EXCLUDED.faturamento_entrada,
+    faturamento_bar = EXCLUDED.faturamento_bar,
+    couvert_atracoes = EXCLUDED.couvert_atracoes,
+    clientes_atendidos = EXCLUDED.clientes_atendidos,
+    ticket_medio = EXCLUDED.ticket_medio,
+    tm_entrada = EXCLUDED.tm_entrada,
+    tm_bar = EXCLUDED.tm_bar,
+    reservas_totais = EXCLUDED.reservas_totais,
+    reservas_presentes = EXCLUDED.reservas_presentes,
+    mesas_totais = EXCLUDED.mesas_totais,
+    mesas_presentes = EXCLUDED.mesas_presentes,
+    reservas_quebra_pct = EXCLUDED.reservas_quebra_pct,
+    desconto_total = EXCLUDED.desconto_total,
+    desconto_percentual = EXCLUDED.desconto_percentual,
+    conta_assinada_valor = EXCLUDED.conta_assinada_valor,
+    conta_assinada_perc = EXCLUDED.conta_assinada_perc,
+    qui_sab_dom = EXCLUDED.qui_sab_dom,
+    ter_qua_qui = EXCLUDED.ter_qua_qui,
+    sex_sab = EXCLUDED.sex_sab,
+    perc_faturamento_ate_19h = EXCLUDED.perc_faturamento_ate_19h,
+    perc_faturamento_apos_22h = EXCLUDED.perc_faturamento_apos_22h,
+    clientes_ativos = EXCLUDED.clientes_ativos,
+    perc_clientes_novos = EXCLUDED.perc_clientes_novos,
+    cmv = EXCLUDED.cmv,
+    cmv_limpo = EXCLUDED.cmv_limpo,
+    cmv_percentual = EXCLUDED.cmv_percentual,
+    faturamento_cmvivel = EXCLUDED.faturamento_cmvivel,
+    nps_geral = EXCLUDED.nps_geral,
+    nps_respostas = EXCLUDED.nps_respostas,
+    nps_digital = EXCLUDED.nps_digital,
+    nps_digital_respostas = EXCLUDED.nps_digital_respostas,
+    nps_salao = EXCLUDED.nps_salao,
+    nps_salao_respostas = EXCLUDED.nps_salao_respostas,
+    nps_reservas = EXCLUDED.nps_reservas,
+    nps_reservas_respostas = EXCLUDED.nps_reservas_respostas,
+    nps_atendimento = EXCLUDED.nps_atendimento,
+    nps_ambiente = EXCLUDED.nps_ambiente,
+    nps_drink = EXCLUDED.nps_drink,
+    nps_comida = EXCLUDED.nps_comida,
+    nps_limpeza = EXCLUDED.nps_limpeza,
+    nps_preco = EXCLUDED.nps_preco,
+    nps_musica = EXCLUDED.nps_musica,
+    tempo_drinks = EXCLUDED.tempo_drinks,
+    tempo_bebidas = EXCLUDED.tempo_bebidas,
+    tempo_cozinha = EXCLUDED.tempo_cozinha,
+    qtd_drinks_total = EXCLUDED.qtd_drinks_total,
+    qtd_comida_total = EXCLUDED.qtd_comida_total,
+    atrasinho_drinks = EXCLUDED.atrasinho_drinks,
+    atrasao_drinks = EXCLUDED.atrasao_drinks,
+    atrasinho_cozinha = EXCLUDED.atrasinho_cozinha,
+    atrasao_cozinha = EXCLUDED.atrasao_cozinha,
+    atrasao_bar = EXCLUDED.atrasao_bar,
+    atrasos_drinks_perc = EXCLUDED.atrasos_drinks_perc,
+    atrasos_comida_perc = EXCLUDED.atrasos_comida_perc,
+    perc_bebidas = EXCLUDED.perc_bebidas,
+    perc_drinks = EXCLUDED.perc_drinks,
+    perc_comida = EXCLUDED.perc_comida,
+    stockout_drinks_perc = EXCLUDED.stockout_drinks_perc,
+    stockout_bar_perc = EXCLUDED.stockout_bar_perc,
+    stockout_comidas_perc = EXCLUDED.stockout_comidas_perc,
+    stockout_total_perc = EXCLUDED.stockout_total_perc,
+    avaliacoes_5_google_trip = EXCLUDED.avaliacoes_5_google_trip,
+    media_avaliacoes_google = EXCLUDED.media_avaliacoes_google,
+    google_reviews_total = EXCLUDED.google_reviews_total,
+    atracoes_eventos = EXCLUDED.atracoes_eventos,
+    freelas = EXCLUDED.freelas,
+    materiais = EXCLUDED.materiais,
+    comissao = EXCLUDED.comissao,
+    cmo = EXCLUDED.cmo,
+    pro_labore = EXCLUDED.pro_labore,
+    ocupacao_custo = EXCLUDED.ocupacao_custo,
+    imposto = EXCLUDED.imposto,
+    escritorio_central = EXCLUDED.escritorio_central,
+    marketing_fixo = EXCLUDED.marketing_fixo,
+    adm_fixo = EXCLUDED.adm_fixo,
+    manutencao = EXCLUDED.manutencao,
+    utensilios = EXCLUDED.utensilios,
+    alimentacao = EXCLUDED.alimentacao,
+    custos_variaveis = EXCLUDED.custos_variaveis,
+    custos_fixos = EXCLUDED.custos_fixos,
+    custos_total = EXCLUDED.custos_total,
+    custo_atracao_faturamento = EXCLUDED.custo_atracao_faturamento,
+    cancelamentos_total = EXCLUDED.cancelamentos_total,
+    cancelamentos_qtd = EXCLUDED.cancelamentos_qtd,
+    o_num_posts = EXCLUDED.o_num_posts,
+    o_num_stories = EXCLUDED.o_num_stories,
+    o_alcance = EXCLUDED.o_alcance,
+    o_interacao = EXCLUDED.o_interacao,
+    o_compartilhamento = EXCLUDED.o_compartilhamento,
+    o_engajamento = EXCLUDED.o_engajamento,
+    o_visu_stories = EXCLUDED.o_visu_stories,
+    m_valor_investido = EXCLUDED.m_valor_investido,
+    m_alcance = EXCLUDED.m_alcance,
+    m_frequencia = EXCLUDED.m_frequencia,
+    m_cpm = EXCLUDED.m_cpm,
+    m_cliques = EXCLUDED.m_cliques,
+    m_ctr = EXCLUDED.m_ctr,
+    m_custo_por_clique = EXCLUDED.m_custo_por_clique,
+    m_conversas_iniciadas = EXCLUDED.m_conversas_iniciadas,
+    calculado_em = NOW(),
+    versao_etl = 6;
+
+  GET DIAGNOSTICS v_inseridos = ROW_COUNT;
+
+  RETURN QUERY SELECT
+    p_bar_id,
+    v_periodo,
+    v_inseridos,
+    ((EXTRACT(EPOCH FROM (clock_timestamp() - v_start)) * 1000))::int;
+END;
+
+$function$;

--- a/frontend/src/app/api/estrategico/desempenho-v2/route.ts
+++ b/frontend/src/app/api/estrategico/desempenho-v2/route.ts
@@ -289,7 +289,7 @@ export async function PUT(request: NextRequest) {
     const { data: goldRow, error: goldError } = await supabase
       .schema('gold' as any)
       .from('desempenho')
-      .select('bar_id, ano, numero_semana, data_inicio, data_fim')
+      .select('bar_id, ano, numero_semana, data_inicio, data_fim, granularidade, periodo')
       .eq('id', id)
       .single();
 
@@ -353,38 +353,81 @@ export async function PUT(request: NextRequest) {
       }
     }
 
-    console.log(`🟢 PUT Desempenho V2: bar=${goldRow.bar_id}, S${goldRow.numero_semana}/${goldRow.ano}, desempenho=[${Object.keys(camposDesempenho).join(',')}], marketing=[${Object.keys(camposMarketing).join(',')}]`);
+    // Detectar granularidade (semanal vs mensal). Mensal tem numero_semana=null
+    // e periodo no formato YYYY-MM (ex: '2026-04').
+    const isMensal = goldRow.granularidade === 'mensal'
+      || (goldRow.numero_semana == null && /^\d{4}-\d{2}$/.test(String(goldRow.periodo || '')));
+    const mes = isMensal && goldRow.periodo
+      ? parseInt(String(goldRow.periodo).split('-')[1], 10)
+      : null;
+
+    console.log(`🟢 PUT Desempenho V2: bar=${goldRow.bar_id}, ${isMensal ? `M${mes}/${goldRow.ano}` : `S${goldRow.numero_semana}/${goldRow.ano}`}, desempenho=[${Object.keys(camposDesempenho).join(',')}], marketing=[${Object.keys(camposMarketing).join(',')}]`);
 
     let resultado: any = null;
 
-    // Upsert campos desempenho em meta.desempenho_manual
+    // Salvar campos em meta.desempenho_manual
+    // Como temos partial unique indexes (não constraints nominais), o upsert
+    // do PostgREST não funciona — fazemos SELECT + UPDATE/INSERT manual.
     if (Object.keys(camposDesempenho).length > 0) {
-      const { data, error: upsertError } = await supabase
+      const granularidade = isMensal ? 'mensal' : 'semanal';
+      const dadosBase: any = {
+        bar_id: goldRow.bar_id,
+        ano: goldRow.ano,
+        granularidade,
+        numero_semana: isMensal ? null : goldRow.numero_semana,
+        mes: isMensal ? mes : null,
+        data_inicio: goldRow.data_inicio,
+        data_fim: goldRow.data_fim,
+      };
+
+      // Buscar registro existente
+      let queryExist = supabase
         .schema('meta' as any)
         .from('desempenho_manual')
-        .upsert(
-          {
-            bar_id: goldRow.bar_id,
-            ano: goldRow.ano,
-            numero_semana: goldRow.numero_semana,
-            data_inicio: goldRow.data_inicio,
-            data_fim: goldRow.data_fim,
-            ...camposDesempenho,
-            atualizado_em: new Date().toISOString(),
-          },
-          { onConflict: 'bar_id,ano,numero_semana' }
-        )
-        .select()
-        .single();
+        .select('id')
+        .eq('bar_id', goldRow.bar_id)
+        .eq('ano', goldRow.ano)
+        .eq('granularidade', granularidade);
+      queryExist = isMensal
+        ? queryExist.eq('mes', mes!)
+        : queryExist.eq('numero_semana', goldRow.numero_semana);
 
-      if (upsertError) {
-        console.error('❌ PUT: erro upsert meta.desempenho_manual:', upsertError);
-        return NextResponse.json(
-          { error: 'Erro ao salvar desempenho', details: upsertError.message },
-          { status: 500 }
-        );
+      const { data: existing } = await queryExist.maybeSingle();
+
+      if (existing?.id) {
+        // UPDATE
+        const { data, error: updErr } = await supabase
+          .schema('meta' as any)
+          .from('desempenho_manual')
+          .update({ ...camposDesempenho, atualizado_em: new Date().toISOString() })
+          .eq('id', existing.id)
+          .select()
+          .single();
+        if (updErr) {
+          console.error('❌ PUT: erro update meta.desempenho_manual:', updErr);
+          return NextResponse.json(
+            { error: 'Erro ao salvar desempenho', details: updErr.message },
+            { status: 500 }
+          );
+        }
+        resultado = data;
+      } else {
+        // INSERT
+        const { data, error: insErr } = await supabase
+          .schema('meta' as any)
+          .from('desempenho_manual')
+          .insert({ ...dadosBase, ...camposDesempenho, atualizado_em: new Date().toISOString() })
+          .select()
+          .single();
+        if (insErr) {
+          console.error('❌ PUT: erro insert meta.desempenho_manual:', insErr);
+          return NextResponse.json(
+            { error: 'Erro ao salvar desempenho', details: insErr.message },
+            { status: 500 }
+          );
+        }
+        resultado = data;
       }
-      resultado = data;
     }
 
     // Upsert campos marketing em meta.marketing_semanal

--- a/frontend/src/app/estrategico/desempenho/services/desempenho-mensal-service.ts
+++ b/frontend/src/app/estrategico/desempenho/services/desempenho-mensal-service.ts
@@ -42,13 +42,47 @@ export async function getMeses(
     return [];
   }
 
-  // Gold mensal retorna todos os campos necessários
-  return mesesGold.map(g => ({
-    ...g,
-    numero_semana: parseInt(g.periodo.split('-')[1]), // Extrair mês do periodo
-    atualizado_em: g.calculado_em,
-    atualizado_por_nome: 'Sistema ETL',
-  })) as DadosSemana[];
+  // Mapeamento gold.desempenho -> nomes esperados pelo front
+  // Espelha o mapeamento que desempenho-service.ts (semanal) faz
+  const toNum = (v: unknown): number | null => {
+    if (v === null || v === undefined) return null;
+    if (typeof v === 'number' && !isNaN(v)) return v;
+    if (typeof v === 'string') { const n = parseFloat(v); return isNaN(n) ? null : n; }
+    return null;
+  };
+
+  return mesesGold.map((g: any) => {
+    const tempoDrinks = toNum(g.tempo_drinks);
+    const tempoCozinha = toNum(g.tempo_cozinha);
+    const faturamentoTotal = toNum(g.faturamento_total) ?? 0;
+    const descontoTotal = toNum(g.desconto_total) ?? 0;
+
+    return {
+      ...g,
+      numero_semana: parseInt(g.periodo.split('-')[1]),
+      atualizado_em: g.calculado_em,
+      atualizado_por_nome: 'Sistema ETL',
+
+      // Tempos: gold em SEGUNDOS -> front em MINUTOS. Filtra clamp 9999 (outliers).
+      tempo_saida_bar: tempoDrinks !== null && tempoDrinks < 9999 ? Math.round(tempoDrinks / 60 * 100) / 100 : null,
+      tempo_saida_cozinha: tempoCozinha !== null && tempoCozinha < 9999 ? Math.round(tempoCozinha / 60 * 100) / 100 : null,
+
+      // Atrasos: rename gold -> front
+      atrasinhos_bar: toNum(g.atrasinho_drinks),
+      atrasos_bar: toNum(g.atrasao_drinks),
+      atrasos_bar_perc: toNum(g.atrasos_drinks_perc),
+      atrasinhos_cozinha: toNum(g.atrasinho_cozinha),
+      atrasos_cozinha: toNum(g.atrasao_cozinha),
+      atrasos_cozinha_perc: toNum(g.atrasos_comida_perc),
+
+      // Descontos: gold tem desconto_total/desconto_percentual; front espera descontos_valor/descontos_perc
+      descontos_valor: descontoTotal,
+      descontos_perc: faturamentoTotal > 0 ? (descontoTotal / faturamentoTotal) * 100 : 0,
+
+      // Cancelamentos: gold cancelamentos_total -> front cancelamentos
+      cancelamentos: toNum(g.cancelamentos_total) ?? toNum(g.cancelamentos),
+    };
+  }) as DadosSemana[];
 }
 
 // REMOVIDO: getDadosMensais e helpers de agregação JS


### PR DESCRIPTION
## Summary

Bateria de fixes pra /estrategico/desempenho?visao=mensal ficar 100% automático e bater com o semanal. Cron jobid 462 (12:00 BRT) ja recalcula `etl_gold_desempenho_mensal_range` todo dia — depois desse merge, mensal continua atualizando sozinho sem intervencao.

### 4 commits

* **a0fd73ec** — Suporte mensal em meta.desempenho_manual + PUT /api/estrategico/desempenho-v2 detecta mensal e faz SELECT+INSERT/UPDATE manual (PostgREST nao suporta partial unique index em onConflict). Resolve erro 500 ao salvar CMV Teorico/CMO% no mensal.

* **357af52f** — etl_gold_desempenho_mensal: tempos drinks/cozinha por bar (espelha PR #44 do semanal — Ord usa t0_t2 cozinha, Deb t0_t3) + marketing somando de meta.marketing_semanal por quinta-feira ISO. Deb saiu do cap 9999s pra valor real.

* **dd38414c** — etl_gold_desempenho_mensal: fase_reservas_getin lendo direto de bronze.bronze_getin_reservations. Antes mostrava \"0/17015\" e \"0/3499\" no front — agora popula mesas_totais, mesas_presentes, reservas_quebra_pct corretamente.

* **91a67380** — desempenho-mensal-service.ts mapeia campos gold->front: tempo_drinks (segs) -> tempo_saida_bar (min, /60), atrasao_drinks -> atrasos_bar, desconto_total -> descontos_valor, cancelamentos_total -> cancelamentos. Bug: dados no banco ja existiam, mas service retornava {...g} cru e UI nao achava os campos.

## Validacao Mar/2026 (Ord)

| Campo | Antes | Depois |
|---|---|---|
| Tempo Drinks | NULL/9999 | 2,53 min |
| Tempo Comida | NULL/9999 | 11,87 min |
| Atrasao Drinks | 0/0 | 116/9.811 (1,18%) |
| Atrasao Comida | 0/0 | 433/3.606 (12,01%) |
| Descontos | NULL | R\$ 97.207,88 (5,80%) |
| Cancelamentos | NULL | R\$ 14.291,67 (1.971) |
| Mesas Realizadas | 0/17.015 | 327/17.015 |
| Mesas Presentes | 0/3.499 | 220/3.499 |
| Marketing | NULL | R\$ 15.011 / 22 posts / 16.820 cliques |

## Test plan

- [ ] Vercel build verde
- [ ] /estrategico/desempenho?visao=mensal Ord mar/2026 mostra todos campos
- [ ] /estrategico/desempenho?visao=mensal Deb mar/2026 mostra tempos/atrasos (Deb sem Getin segue 0 nas mesas, igual semanal)
- [ ] PUT manual de CMV Teorico/CMO% no mensal nao da mais erro 500
- [ ] Cron 462 (12:00 BRT amanha) recalcula automatico

🤖 Generated with [Claude Code](https://claude.com/claude-code)