### PR TITLE
fix(planejamento+stockout): KPIs de producao + couvert Deb + auto-heal stockout loud

### DIFF
--- a/database/migrations/2026-04-29-etl-gold-planejamento-kpis-producao.sql
+++ b/database/migrations/2026-04-29-etl-gold-planejamento-kpis-producao.sql
@@ -1,0 +1,85 @@
+-- 2026-04-29: Adicionar 14 KPIs de producao em etl_gold_planejamento_full
+--
+-- Bug reportado pelo socio em /estrategico/planejamento-comercial:
+--   Mix bebidas (%b/%d/%c) ZERADO, atrasao cozinha/bar ZERADO,
+--   stockout drinks/comidas ZERADO. Tela praticamente inutil.
+--
+-- Causa: operations.eventos_base esta populado corretamente (pelo
+-- calculate_evento_metrics), mas o ETL etl_gold_planejamento_full NAO
+-- copiava esses 14 campos pro gold.planejamento — INSERT cols e
+-- ON CONFLICT omitiam tudo.
+--
+-- Patch: 4 REPLACEs cirurgicos via DO block (idempotente):
+--   1. fase_eb: ler 14 colunas de operations.eventos_base
+--   2. INSERT cols: adicionar percent_b/d/c, percent_happy_hour,
+--      t_coz/t_bar, atrasinho_cozinha/bar, atrasao_cozinha/bar,
+--      percent_stockout, stockout_bebidas/comidas/drinks_perc
+--   3. SELECT VALUES: bind eb.eb_* nos novos campos
+--   4. ON CONFLICT DO UPDATE: incluir os 14 campos
+--
+-- versao_etl 5 -> 6.
+--
+-- Validacao Ord 24/04 (semana cheia):
+--   pb 67,85% / pd 21,09% / pc 11,06%
+--   atrasao cozinha 226, bar 1.738
+--   stockout drinks 9,5%, comidas 0%
+--
+-- Cron 'gold-desempenho' (jobid 462, 12:00 BRT) ja chama
+-- etl_gold_planejamento_all_bars — recalculo automatico todo dia.
+
+DO $$
+DECLARE
+  v_def text;
+  v_new text;
+BEGIN
+  SELECT pg_get_functiondef(p.oid) INTO v_def
+  FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+  WHERE p.proname='etl_gold_planejamento_full' AND n.nspname='public';
+
+  v_new := v_def;
+
+  -- Patch 1: 14 KPIs em fase_eb (lendo de operations.eventos_base)
+  v_new := REPLACE(v_new,
+    E'      eb.cl_real AS eb_cl_real,\n      eb.real_r AS eb_real_r',
+    E'      eb.cl_real AS eb_cl_real,\n      eb.real_r AS eb_real_r,\n      COALESCE(eb.percent_b, 0)::numeric AS eb_percent_b,\n      COALESCE(eb.percent_d, 0)::numeric AS eb_percent_d,\n      COALESCE(eb.percent_c, 0)::numeric AS eb_percent_c,\n      COALESCE(eb.percent_happy_hour, 0)::numeric AS eb_percent_happy_hour,\n      COALESCE(eb.t_coz, 0)::numeric AS eb_t_coz,\n      COALESCE(eb.t_bar, 0)::numeric AS eb_t_bar,\n      COALESCE(eb.atrasinho_cozinha, 0)::integer AS eb_atrasinho_cozinha,\n      COALESCE(eb.atrasinho_bar, 0)::integer AS eb_atrasinho_bar,\n      COALESCE(eb.atrasao_cozinha, 0)::integer AS eb_atrasao_cozinha,\n      COALESCE(eb.atrasao_bar, 0)::integer AS eb_atrasao_bar,\n      COALESCE(eb.percent_stockout, 0)::numeric AS eb_percent_stockout,\n      COALESCE(eb.stockout_bebidas_perc, 0)::numeric AS eb_stockout_bebidas_perc,\n      COALESCE(eb.stockout_comidas_perc, 0)::numeric AS eb_stockout_comidas_perc,\n      COALESCE(eb.stockout_drinks_perc, 0)::numeric AS eb_stockout_drinks_perc'
+  );
+
+  -- Patch 2: INSERT cols
+  v_new := REPLACE(v_new,
+    E'    fat_apos_22h, fat_apos_22h_percent,\n    calculado_em, versao_etl',
+    E'    fat_apos_22h, fat_apos_22h_percent,\n    percent_b, percent_d, percent_c, percent_happy_hour,\n    t_coz, t_bar,\n    atrasinho_cozinha, atrasinho_bar, atrasao_cozinha, atrasao_bar,\n    percent_stockout, stockout_bebidas_perc, stockout_comidas_perc, stockout_drinks_perc,\n    calculado_em, versao_etl'
+  );
+
+  -- Patch 3: SELECT VALUES
+  v_new := REPLACE(v_new,
+    E'    CASE WHEN fh.fat_total > 0 THEN (fh.fat_apos_22h / fh.fat_total * 100)::numeric(5,2) ELSE NULL END,\n    NOW(), 5',
+    E'    CASE WHEN fh.fat_total > 0 THEN (fh.fat_apos_22h / fh.fat_total * 100)::numeric(5,2) ELSE NULL END,\n    eb.eb_percent_b, eb.eb_percent_d, eb.eb_percent_c, eb.eb_percent_happy_hour,\n    eb.eb_t_coz, eb.eb_t_bar,\n    eb.eb_atrasinho_cozinha, eb.eb_atrasinho_bar, eb.eb_atrasao_cozinha, eb.eb_atrasao_bar,\n    eb.eb_percent_stockout, eb.eb_stockout_bebidas_perc, eb.eb_stockout_comidas_perc, eb.eb_stockout_drinks_perc,\n    NOW(), 6'
+  );
+
+  -- Patch 4: ON CONFLICT
+  v_new := REPLACE(v_new,
+    E'    fat_apos_22h_percent=EXCLUDED.fat_apos_22h_percent,\n    calculado_em=NOW(),\n    versao_etl=5',
+    E'    fat_apos_22h_percent=EXCLUDED.fat_apos_22h_percent,\n    percent_b=EXCLUDED.percent_b,\n    percent_d=EXCLUDED.percent_d,\n    percent_c=EXCLUDED.percent_c,\n    percent_happy_hour=EXCLUDED.percent_happy_hour,\n    t_coz=EXCLUDED.t_coz,\n    t_bar=EXCLUDED.t_bar,\n    atrasinho_cozinha=EXCLUDED.atrasinho_cozinha,\n    atrasinho_bar=EXCLUDED.atrasinho_bar,\n    atrasao_cozinha=EXCLUDED.atrasao_cozinha,\n    atrasao_bar=EXCLUDED.atrasao_bar,\n    percent_stockout=EXCLUDED.percent_stockout,\n    stockout_bebidas_perc=EXCLUDED.stockout_bebidas_perc,\n    stockout_comidas_perc=EXCLUDED.stockout_comidas_perc,\n    stockout_drinks_perc=EXCLUDED.stockout_drinks_perc,\n    calculado_em=NOW(),\n    versao_etl=6'
+  );
+
+  -- Idempotente: se ja foi aplicado (v_new == v_def), nao executa
+  IF v_new <> v_def THEN
+    EXECUTE v_new;
+    RAISE NOTICE 'etl_gold_planejamento_full atualizado: 14 KPIs adicionados';
+  ELSE
+    RAISE NOTICE 'etl_gold_planejamento_full ja esta atualizado (no-op)';
+  END IF;
+END $$;
+
+-- Re-rodar todos os bares pros ultimos 60 dias pra recalcular gold.planejamento
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN SELECT id FROM operations.bares WHERE ativo=true ORDER BY id LOOP
+    BEGIN
+      PERFORM public.etl_gold_planejamento_full(r.id, (CURRENT_DATE - INTERVAL '60 days')::date, CURRENT_DATE);
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'Falha bar=%: %', r.id, SQLERRM;
+    END;
+  END LOOP;
+END $$;

--- a/database/migrations/2026-04-29-etl-planejamento-couvert-vr-contahub.sql
+++ b/database/migrations/2026-04-29-etl-planejamento-couvert-vr-contahub.sql
@@ -1,0 +1,83 @@
+-- 2026-04-29: Popular couvert_vr_contahub em gold.planejamento
+--
+-- Bug reportado pelo socio: em /estrategico/planejamento-comercial bar
+-- Deboche, a coluna $couvert vem zerada. Tem que pegar o vr_couvert do
+-- relatorio de periodo do ContaHub pra aquele dia.
+--
+-- Fonte: bronze.bronze_contahub_avendas_vendasperiodo.vd_vrcouvert
+-- (mesma fonte que ja popula faturamento_couvert).
+--
+-- Causa: gold.planejamento.couvert_vr_contahub existia mas o ETL
+-- etl_gold_planejamento_full nunca populava (ficava 0 sempre).
+--
+-- Patch: 5 REPLACEs cirurgicos via DO block (idempotente):
+--   1. Adicionar fase_couvert (SUM vd_vrcouvert por dia)
+--   2. INSERT cols: incluir couvert_vr_contahub
+--   3. SELECT VALUES: bind fc.couvert_vr
+--   4. FROM/JOIN: LEFT JOIN fase_couvert fc USING (data_evento)
+--   5. ON CONFLICT: incluir couvert_vr_contahub
+--
+-- Validacao Ord 24/04: 22.425,00; Deb 24/04: 2.568,00.
+--
+-- Bonus: front PlanejamentoClient.tsx inverte calculo da coluna couv/art
+-- de (couvert/c_art*100) para (c_art/couvert*100) — % do couvert que paga
+-- o c_art. couvertCArtGreen agora exige cArt/couvert <= meta (1.0).
+
+DO $$
+DECLARE v_def text; v_new text;
+BEGIN
+  SELECT pg_get_functiondef(p.oid) INTO v_def FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+  WHERE p.proname='etl_gold_planejamento_full' AND n.nspname='public';
+
+  v_new := v_def;
+
+  -- Patch 1: fase_couvert (somar vd_vrcouvert do bronze por dia)
+  v_new := REPLACE(v_new,
+    E'  fase_eb AS (',
+    E'  fase_couvert AS (\n    SELECT vd_dtgerencial::date AS data_evento, SUM(COALESCE(vd_vrcouvert, 0))::numeric(14,2) AS couvert_vr\n    FROM bronze.bronze_contahub_avendas_vendasperiodo\n    WHERE bar_id = p_bar_id\n      AND vd_dtgerencial::date BETWEEN p_data_inicio AND p_data_fim\n    GROUP BY vd_dtgerencial::date\n  ),\n  fase_eb AS ('
+  );
+
+  -- Patch 2: INSERT cols
+  v_new := REPLACE(v_new,
+    E'    fat_apos_22h, fat_apos_22h_percent,\n    percent_b,',
+    E'    fat_apos_22h, fat_apos_22h_percent,\n    couvert_vr_contahub,\n    percent_b,'
+  );
+
+  -- Patch 3: SELECT VALUES
+  v_new := REPLACE(v_new,
+    E'    CASE WHEN fh.fat_total > 0 THEN (fh.fat_apos_22h / fh.fat_total * 100)::numeric(5,2) ELSE NULL END,\n    eb.eb_percent_b,',
+    E'    CASE WHEN fh.fat_total > 0 THEN (fh.fat_apos_22h / fh.fat_total * 100)::numeric(5,2) ELSE NULL END,\n    COALESCE(fc.couvert_vr, 0),\n    eb.eb_percent_b,'
+  );
+
+  -- Patch 4: FROM/JOIN
+  v_new := REPLACE(v_new,
+    E'  LEFT JOIN fase_eb eb USING (data_evento)',
+    E'  LEFT JOIN fase_eb eb USING (data_evento)\n  LEFT JOIN fase_couvert fc USING (data_evento)'
+  );
+
+  -- Patch 5: ON CONFLICT
+  v_new := REPLACE(v_new,
+    E'    fat_apos_22h_percent=EXCLUDED.fat_apos_22h_percent,\n    percent_b=EXCLUDED.percent_b,',
+    E'    fat_apos_22h_percent=EXCLUDED.fat_apos_22h_percent,\n    couvert_vr_contahub=EXCLUDED.couvert_vr_contahub,\n    percent_b=EXCLUDED.percent_b,'
+  );
+
+  IF v_new <> v_def THEN
+    EXECUTE v_new;
+    RAISE NOTICE 'etl_gold_planejamento_full atualizado: couvert_vr_contahub';
+  ELSE
+    RAISE NOTICE 'etl_gold_planejamento_full ja esta atualizado (no-op)';
+  END IF;
+END $$;
+
+-- Re-rodar ultimos 60 dias
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN SELECT id FROM operations.bares WHERE ativo=true ORDER BY id LOOP
+    BEGIN
+      PERFORM public.etl_gold_planejamento_full(r.id, (CURRENT_DATE - INTERVAL '60 days')::date, CURRENT_DATE);
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'Falha bar=%: %', r.id, SQLERRM;
+    END;
+  END LOOP;
+END $$;

--- a/database/migrations/2026-04-29-fix-revalidar-stockout-d1-schemas.sql
+++ b/database/migrations/2026-04-29-fix-revalidar-stockout-d1-schemas.sql
@@ -1,0 +1,156 @@
+-- 2026-04-29: Fix revalidar_stockout_dia_anterior_ambos_bares_v2 + alerta loud
+--
+-- Bug detectado em 28/04:
+--   * Silver vazio o dia inteiro (Ord+Deb).
+--   * Bronze raw populado (641 + 212 linhas) pelas 19h.
+--   * Crons 402/403 (stockout-processar 22:30/22:45 UTC) dispararam mas
+--     edge function falhou silenciosamente.
+--   * Cron 312 (alerta-stockout-faltante 10:40 BRT) so alerta D-1, mas
+--     dependia do retry (cron 352) ja ter rodado e funcionado.
+--   * Cron 352 (07:20 BRT) revalidar_stockout... estava QUEBRADO ha tempo:
+--     referencia 'contahub_stockout' e 'contahub_stockout_processado' que
+--     nao existem mais (renomeadas pra schema bronze/silver). Erro ia pro
+--     EXCEPTION e era silenciosamente swallowed.
+--
+-- Caso real: socio descobriu manual em 29/04 14h que stockout 28/04
+-- estava zerado. Tive que re-disparar stockout-processar manual.
+--
+-- Fix:
+--   1. DROP+CREATE com return type novo (mais clareza pro caller)
+--   2. Apontar pras tabelas corretas:
+--      bronze.bronze_contahub_operacional_stockout_raw
+--      silver.silver_contahub_operacional_stockout_processado
+--   3. Auto-heal: se silver vazio, dispara sync (se bronze tambem vazio)
+--      + processar (sempre).
+--   4. Apos auto-heal, se silver continuar vazio: dispara alerta Discord
+--      via enviar_alerta_discord_sistema_dedup (loud).
+--   5. Se erro SQL inesperado: tambem dispara alerta.
+--
+-- Cron 352 (jobid 352, 07:20 BRT diario) ja chama essa funcao — sem
+-- mudanca no schedule.
+
+DROP FUNCTION IF EXISTS public.revalidar_stockout_dia_anterior_ambos_bares_v2();
+
+CREATE OR REPLACE FUNCTION public.revalidar_stockout_dia_anterior_ambos_bares_v2()
+RETURNS TABLE(
+  bar_id integer, data_ref date,
+  tinha_silver boolean, tinha_bronze boolean,
+  coleta_executada boolean, processamento_executado boolean,
+  silver_apos_heal integer,
+  alerta_disparado boolean,
+  error_msg text
+)
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_bar integer;
+  v_data date := (current_date - interval '1 day')::date;
+  v_dia_semana integer := EXTRACT(DOW FROM (current_date - interval '1 day')::date)::integer;
+  v_count_silver integer;
+  v_count_bronze integer;
+  v_count_silver_apos integer;
+  v_req_id_coleta bigint;
+  v_req_id_proc bigint;
+  v_coleta boolean;
+  v_proc boolean;
+  v_alerta boolean;
+  v_error text;
+  v_bar_opera boolean;
+BEGIN
+  FOREACH v_bar IN ARRAY ARRAY[3,4]
+  LOOP
+    v_count_silver := 0; v_count_bronze := 0; v_count_silver_apos := 0;
+    v_req_id_coleta := NULL; v_req_id_proc := NULL;
+    v_coleta := false; v_proc := false; v_alerta := false;
+    v_error := NULL; v_bar_opera := true;
+
+    BEGIN
+      SELECT CASE v_dia_semana
+        WHEN 0 THEN bc.opera_domingo WHEN 1 THEN bc.opera_segunda
+        WHEN 2 THEN bc.opera_terca WHEN 3 THEN bc.opera_quarta
+        WHEN 4 THEN bc.opera_quinta WHEN 5 THEN bc.opera_sexta
+        WHEN 6 THEN bc.opera_sabado
+      END INTO v_bar_opera
+      FROM operations.bares_config bc WHERE bc.bar_id = v_bar;
+
+      IF NOT COALESCE(v_bar_opera, true) THEN
+        RAISE NOTICE 'Bar % nao opera no DOW=%, pulando', v_bar, v_dia_semana;
+      ELSE
+        SELECT COUNT(*) INTO v_count_silver
+        FROM silver.silver_contahub_operacional_stockout_processado s
+        WHERE s.bar_id = v_bar AND s.data_consulta = v_data;
+
+        SELECT COUNT(*) INTO v_count_bronze
+        FROM bronze.bronze_contahub_operacional_stockout_raw b
+        WHERE b.bar_id = v_bar AND b.data_consulta = v_data;
+
+        IF v_count_silver = 0 THEN
+          RAISE NOTICE 'Bar % - silver vazio em %, bronze=% — auto-heal', v_bar, v_data, v_count_bronze;
+
+          IF v_count_bronze = 0 THEN
+            SELECT net.http_post(
+              url := get_supabase_url() || '/functions/v1/contahub-stockout-sync',
+              body := jsonb_build_object('bar_id', v_bar, 'data_date', v_data::text, 'source', 'pgcron-retry-d-1'),
+              headers := jsonb_build_object('Content-Type', 'application/json', 'Authorization', 'Bearer ' || get_service_role_key()),
+              timeout_milliseconds := 60000
+            ) INTO v_req_id_coleta;
+            v_coleta := true;
+            PERFORM pg_sleep(8);
+          END IF;
+
+          SELECT net.http_post(
+            url := get_supabase_url() || '/functions/v1/stockout-processar',
+            body := jsonb_build_object('bar_id', v_bar, 'data_date', v_data::text),
+            headers := jsonb_build_object('Content-Type', 'application/json', 'Authorization', 'Bearer ' || get_service_role_key()),
+            timeout_milliseconds := 60000
+          ) INTO v_req_id_proc;
+          v_proc := true;
+          PERFORM pg_sleep(5);
+
+          SELECT COUNT(*) INTO v_count_silver_apos
+          FROM silver.silver_contahub_operacional_stockout_processado s2
+          WHERE s2.bar_id = v_bar AND s2.data_consulta = v_data;
+
+          IF v_count_silver_apos = 0 THEN
+            v_alerta := true;
+            PERFORM public.enviar_alerta_discord_sistema_dedup(
+              v_bar, 'erro', 'pipeline_saude',
+              '🚨 Stockout D-1 sem dados (auto-heal falhou)',
+              'Bar ' || v_bar::text || ' silver vazio em ' || v_data::text || ' apos retry. Bronze=' || v_count_bronze::text || '. Verificar edge function stockout-processar.',
+              15158332,
+              'stockout_silencioso_d1_' || v_data::text || '_' || v_bar::text
+            );
+          END IF;
+        ELSE
+          RAISE NOTICE 'Bar % - silver ja tem % linhas em %, skip', v_bar, v_count_silver, v_data;
+        END IF;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      v_error := SQLERRM;
+      RAISE NOTICE 'Bar % - Erro: %', v_bar, v_error;
+      BEGIN
+        PERFORM public.enviar_alerta_discord_sistema_dedup(
+          v_bar, 'erro', 'pipeline_saude',
+          '🚨 Stockout D-1 retry com erro SQL',
+          'Bar ' || v_bar::text || ' data ' || v_data::text || ': ' || v_error,
+          15158332,
+          'stockout_retry_erro_' || v_data::text || '_' || v_bar::text
+        );
+        v_alerta := true;
+      EXCEPTION WHEN OTHERS THEN NULL;
+      END;
+    END;
+
+    bar_id := v_bar;
+    data_ref := v_data;
+    tinha_silver := (v_count_silver > 0);
+    tinha_bronze := (v_count_bronze > 0);
+    coleta_executada := v_coleta;
+    processamento_executado := v_proc;
+    silver_apos_heal := v_count_silver_apos;
+    alerta_disparado := v_alerta;
+    error_msg := v_error;
+    RETURN NEXT;
+  END LOOP;
+END;
+$function$;

--- a/frontend/src/app/estrategico/desempenho/services/desempenho-mensal-service.ts
+++ b/frontend/src/app/estrategico/desempenho/services/desempenho-mensal-service.ts
@@ -42,8 +42,77 @@ export async function getMeses(
     return [];
   }
 
+  // Buscar meta.marketing_semanal pra agregar campos g_* e gmn_*
+  // (gold.desempenho so tem m_*, mas o front exibe Google Ads e Google Meu Negocio)
+  const { data: marketingData } = await supabase
+    .schema('meta' as never)
+    .from('marketing_semanal')
+    .select('*')
+    .eq('bar_id', barId)
+    .gte('ano', anoInicio)
+    .lte('ano', anoFim);
+
+  // Agrupa marketing_semanal por (ano, mes) — quinta-feira ISO determina o mes
+  // (mesma logica do ETL etl_gold_desempenho_mensal pra evitar double counting)
+  const isoWeekStart = (ano: number, semana: number): Date => {
+    // ISO: semana 1 contém o 4 de janeiro; week start = monday
+    const jan4 = new Date(Date.UTC(ano, 0, 4));
+    const jan4Day = jan4.getUTCDay() || 7; // domingo=0 -> 7
+    const week1Monday = new Date(jan4);
+    week1Monday.setUTCDate(jan4.getUTCDate() - jan4Day + 1);
+    const start = new Date(week1Monday);
+    start.setUTCDate(week1Monday.getUTCDate() + (semana - 1) * 7);
+    return start;
+  };
+
+  type MktAgg = {
+    g_valor_investido: number;
+    g_impressoes: number;
+    g_cliques: number;
+    g_ctr_sum: number; g_ctr_n: number;
+    g_solicitacoes_rotas: number;
+    gmn_total_visualizacoes: number;
+    gmn_total_acoes: number;
+    gmn_solicitacoes_rotas: number;
+    gmn_visu_pesquisa: number;
+    gmn_visu_maps: number;
+    gmn_cliques_website: number;
+    gmn_ligacoes: number;
+    gmn_menu_views: number;
+  };
+  const marketingMensalMap = new Map<string, MktAgg>();
+
+  (marketingData || []).forEach((m: any) => {
+    const start = isoWeekStart(m.ano, m.semana);
+    const thursday = new Date(start);
+    thursday.setUTCDate(start.getUTCDate() + 3);
+    const mesAno = thursday.getUTCFullYear();
+    const mesMes = thursday.getUTCMonth() + 1;
+    const key = `${mesAno}-${String(mesMes).padStart(2, '0')}`;
+    const agg = marketingMensalMap.get(key) ?? {
+      g_valor_investido: 0, g_impressoes: 0, g_cliques: 0,
+      g_ctr_sum: 0, g_ctr_n: 0, g_solicitacoes_rotas: 0,
+      gmn_total_visualizacoes: 0, gmn_total_acoes: 0, gmn_solicitacoes_rotas: 0,
+      gmn_visu_pesquisa: 0, gmn_visu_maps: 0, gmn_cliques_website: 0,
+      gmn_ligacoes: 0, gmn_menu_views: 0,
+    };
+    agg.g_valor_investido += Number(m.g_valor_investido) || 0;
+    agg.g_impressoes += Number(m.g_impressoes) || 0;
+    agg.g_cliques += Number(m.g_cliques) || 0;
+    if (m.g_ctr != null) { agg.g_ctr_sum += Number(m.g_ctr); agg.g_ctr_n += 1; }
+    agg.g_solicitacoes_rotas += Number(m.g_solicitacoes_rotas) || 0;
+    agg.gmn_total_visualizacoes += Number(m.gmn_total_visualizacoes) || 0;
+    agg.gmn_total_acoes += Number(m.gmn_total_acoes) || 0;
+    agg.gmn_solicitacoes_rotas += Number(m.gmn_solicitacoes_rotas) || 0;
+    agg.gmn_visu_pesquisa += Number(m.gmn_visu_pesquisa) || 0;
+    agg.gmn_visu_maps += Number(m.gmn_visu_maps) || 0;
+    agg.gmn_cliques_website += Number(m.gmn_cliques_website) || 0;
+    agg.gmn_ligacoes += Number(m.gmn_ligacoes) || 0;
+    agg.gmn_menu_views += Number(m.gmn_menu_views) || 0;
+    marketingMensalMap.set(key, agg);
+  });
+
   // Mapeamento gold.desempenho -> nomes esperados pelo front
-  // Espelha o mapeamento que desempenho-service.ts (semanal) faz
   const toNum = (v: unknown): number | null => {
     if (v === null || v === undefined) return null;
     if (typeof v === 'number' && !isNaN(v)) return v;
@@ -56,6 +125,7 @@ export async function getMeses(
     const tempoCozinha = toNum(g.tempo_cozinha);
     const faturamentoTotal = toNum(g.faturamento_total) ?? 0;
     const descontoTotal = toNum(g.desconto_total) ?? 0;
+    const mkt = marketingMensalMap.get(g.periodo);
 
     return {
       ...g,
@@ -81,6 +151,24 @@ export async function getMeses(
 
       // Cancelamentos: gold cancelamentos_total -> front cancelamentos
       cancelamentos: toNum(g.cancelamentos_total) ?? toNum(g.cancelamentos),
+
+      // Meta Ads: front exibe key 'm_cpc', gold tem coluna 'm_custo_por_clique'
+      m_cpc: toNum(g.m_custo_por_clique),
+
+      // Google Ads e Google Meu Negocio: gold nao tem essas colunas — agrega de meta.marketing_semanal
+      g_valor_investido: mkt?.g_valor_investido ?? 0,
+      g_impressoes: mkt?.g_impressoes ?? 0,
+      g_cliques: mkt?.g_cliques ?? 0,
+      g_ctr: mkt && mkt.g_ctr_n > 0 ? mkt.g_ctr_sum / mkt.g_ctr_n : 0,
+      g_solicitacoes_rotas: mkt?.g_solicitacoes_rotas ?? 0,
+      gmn_total_visualizacoes: mkt?.gmn_total_visualizacoes ?? 0,
+      gmn_total_acoes: mkt?.gmn_total_acoes ?? 0,
+      gmn_solicitacoes_rotas: mkt?.gmn_solicitacoes_rotas ?? 0,
+      gmn_visu_pesquisa: mkt?.gmn_visu_pesquisa ?? 0,
+      gmn_visu_maps: mkt?.gmn_visu_maps ?? 0,
+      gmn_cliques_website: mkt?.gmn_cliques_website ?? 0,
+      gmn_ligacoes: mkt?.gmn_ligacoes ?? 0,
+      gmn_menu_views: mkt?.gmn_menu_views ?? 0,
     };
   }) as DadosSemana[];
 }

--- a/frontend/src/app/estrategico/planejamento-comercial/components/PlanejamentoClient.tsx
+++ b/frontend/src/app/estrategico/planejamento-comercial/components/PlanejamentoClient.tsx
@@ -986,15 +986,16 @@ export function PlanejamentoClient({ initialData, serverMes, serverAno }: Planej
                                   className={`px-2 py-1.5 text-center text-[11px] border-r-2 border-[hsl(var(--border))] cursor-pointer transition-colors ${colunaHighlight === 'percent_art_fat' ? 'bg-blue-50 dark:bg-blue-900/20 ring-1 ring-inset ring-blue-300 dark:ring-blue-700' : 'hover:bg-blue-100/70 dark:hover:bg-blue-900/30'}`} 
                                   style={{width: '90px', minWidth: '90px', maxWidth: '90px'}}>
                                     {selectedBar?.id === 4 ? (
+                                      // Etapa 6: couvert_c_art_green vem do service (threshold em operations.config_metas_planejamento)
                                       <span className={`font-semibold ${
-                                        evento.c_art > 0 && evento.couvert_vr_contahub && (evento.couvert_vr_contahub / evento.c_art) >= 1
+                                        evento.couvert_c_art_green
                                           ? 'text-green-600 dark:text-green-400'
                                           : evento.c_art > 0
                                             ? 'text-red-600 dark:text-red-400'
                                             : 'text-[hsl(var(--muted-foreground))]'
                                       }`}>
-                                        {evento.c_art > 0 && evento.couvert_vr_contahub
-                                          ? formatarPercentual((evento.couvert_vr_contahub / evento.c_art) * 100)
+                                        {evento.c_art > 0 && evento.couvert_vr_contahub && evento.couvert_vr_contahub > 0
+                                          ? formatarPercentual((evento.c_art / evento.couvert_vr_contahub) * 100)
                                           : evento.c_art > 0 ? '0,0%' : '-'}
                                       </span>
                                     ) : (
@@ -1042,7 +1043,7 @@ export function PlanejamentoClient({ initialData, serverMes, serverAno }: Planej
                                     setColunaHighlight(prev => prev === 'atrasao_cozinha' ? null : 'atrasao_cozinha');
                                   }}
                                   className={`px-2 py-1.5 text-center text-[11px] border-r border-[hsl(var(--border))] cursor-pointer transition-colors ${colunaHighlight === 'atrasao_cozinha' ? 'bg-blue-50 dark:bg-blue-900/20 ring-1 ring-inset ring-blue-300 dark:ring-blue-700' : 'hover:bg-blue-100/70 dark:hover:bg-blue-900/30'}`} 
-                                  style={{width: '105px', minWidth: '105px', maxWidth: '105px'}}><span className={`font-semibold ${evento.atrasao_cozinha <= 10 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>{evento.atrasao_cozinha > 0 ? formatarContagem(evento.atrasao_cozinha) : '-'}</span></td>
+                                  style={{width: '105px', minWidth: '105px', maxWidth: '105px'}}><span className={`font-semibold ${evento.atrasao_cozinha_green ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>{evento.atrasao_cozinha > 0 ? formatarContagem(evento.atrasao_cozinha) : '-'}</span></td>
                                 <td 
                                   onClick={(e) => { 
                                     e.stopPropagation(); 
@@ -1050,7 +1051,7 @@ export function PlanejamentoClient({ initialData, serverMes, serverAno }: Planej
                                     setColunaHighlight(prev => prev === 'atrasao_bar' ? null : 'atrasao_bar');
                                   }}
                                   className={`px-2 py-1.5 text-center text-[11px] border-r border-[hsl(var(--border))] cursor-pointer transition-colors ${colunaHighlight === 'atrasao_bar' ? 'bg-blue-50 dark:bg-blue-900/20 ring-1 ring-inset ring-blue-300 dark:ring-blue-700' : 'hover:bg-blue-100/70 dark:hover:bg-blue-900/30'}`} 
-                                  style={{width: '105px', minWidth: '105px', maxWidth: '105px'}}><span className={`font-semibold ${evento.atrasao_bar <= 50 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>{evento.atrasao_bar > 0 ? formatarContagem(evento.atrasao_bar) : '-'}</span></td>
+                                  style={{width: '105px', minWidth: '105px', maxWidth: '105px'}}><span className={`font-semibold ${evento.atrasao_bar_green ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>{evento.atrasao_bar > 0 ? formatarContagem(evento.atrasao_bar) : '-'}</span></td>
                                 <td 
                                   onClick={(e) => { 
                                     e.stopPropagation(); 
@@ -1058,7 +1059,7 @@ export function PlanejamentoClient({ initialData, serverMes, serverAno }: Planej
                                     setColunaHighlight(prev => prev === 'stockout_drinks' ? null : 'stockout_drinks');
                                   }}
                                   className={`px-2 py-1.5 text-center text-[11px] border-r border-[hsl(var(--border))] cursor-pointer transition-colors ${colunaHighlight === 'stockout_drinks' ? 'bg-blue-50 dark:bg-blue-900/20 ring-1 ring-inset ring-blue-300 dark:ring-blue-700' : 'hover:bg-blue-100/70 dark:hover:bg-blue-900/30'}`} 
-                                  style={{width: '100px', minWidth: '100px', maxWidth: '100px'}}><span className={`font-semibold ${evento.stockout_drinks_perc <= 10 ? 'text-green-600 dark:text-green-400' : evento.stockout_drinks_perc <= 25 ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-600 dark:text-red-400'}`}>{evento.stockout_drinks_perc > 0 ? formatarPercentual(evento.stockout_drinks_perc) : '-'}</span></td>
+                                  style={{width: '100px', minWidth: '100px', maxWidth: '100px'}}><span className={`font-semibold ${evento.stockout_drinks_status === 'green' ? 'text-green-600 dark:text-green-400' : evento.stockout_drinks_status === 'yellow' ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-600 dark:text-red-400'}`}>{evento.stockout_drinks_perc > 0 ? formatarPercentual(evento.stockout_drinks_perc) : '-'}</span></td>
                                 <td 
                                   onClick={(e) => { 
                                     e.stopPropagation(); 
@@ -1066,7 +1067,7 @@ export function PlanejamentoClient({ initialData, serverMes, serverAno }: Planej
                                     setColunaHighlight(prev => prev === 'stockout_comidas' ? null : 'stockout_comidas');
                                   }}
                                   className={`px-2 py-1.5 text-center text-[11px] border-r-2 border-[hsl(var(--border))] cursor-pointer transition-colors ${colunaHighlight === 'stockout_comidas' ? 'bg-blue-50 dark:bg-blue-900/20 ring-1 ring-inset ring-blue-300 dark:ring-blue-700' : 'hover:bg-blue-100/70 dark:hover:bg-blue-900/30'}`} 
-                                  style={{width: '100px', minWidth: '100px', maxWidth: '100px'}}><span className={`font-semibold ${evento.stockout_comidas_perc <= 10 ? 'text-green-600 dark:text-green-400' : evento.stockout_comidas_perc <= 25 ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-600 dark:text-red-400'}`}>{evento.stockout_comidas_perc > 0 ? formatarPercentual(evento.stockout_comidas_perc) : '-'}</span></td>
+                                  style={{width: '100px', minWidth: '100px', maxWidth: '100px'}}><span className={`font-semibold ${evento.stockout_comidas_status === 'green' ? 'text-green-600 dark:text-green-400' : evento.stockout_comidas_status === 'yellow' ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-600 dark:text-red-400'}`}>{evento.stockout_comidas_perc > 0 ? formatarPercentual(evento.stockout_comidas_perc) : '-'}</span></td>
                               </>
                             ) : (
                               <td className="px-2 py-1.5 text-center text-[11px] text-[hsl(var(--muted-foreground))] border-r-2 border-[hsl(var(--border))]" style={{width: '80px', minWidth: '80px', maxWidth: '80px'}}>•••</td>
@@ -1167,17 +1168,21 @@ export function PlanejamentoClient({ initialData, serverMes, serverAno }: Planej
                             <div className="flex justify-between">
                               <Tooltip>
                                 <TooltipTrigger asChild>
-                                  <span className="text-[hsl(var(--muted-foreground))] cursor-help underline decoration-dotted">Eventos:</span>
+                                  <span className="text-[hsl(var(--muted-foreground))] cursor-help underline decoration-dotted">Dias (faturado / com evento):</span>
                                 </TooltipTrigger>
                                 <TooltipContent side="top" className="max-w-xs bg-[hsl(var(--popover))] border-[hsl(var(--border))] z-[9999]">
                                   <div className="text-xs space-y-1">
-                                    <p><span className="font-semibold">Dias com eventos realizados:</span> {totaisAgregados.totalDiasRealizados}</p>
-                                    <p><span className="font-semibold">Total de dias com eventos:</span> {totaisAgregados.totalDiasComEvento}</p>
-                                    <p className="pt-1 border-t border-[hsl(var(--border))]"><span className="font-semibold">Total de eventos (incluindo múltiplos no mesmo dia):</span> {totaisAgregados.totalEventosRealizados} / {totaisAgregados.totalEventos}</p>
+                                    <p><span className="font-semibold">Dias com faturamento (real &gt; 0):</span> {totaisAgregados.totalDiasRealizados}</p>
+                                    <p><span className="font-semibold">Dias com pelo menos um evento na lista:</span> {totaisAgregados.totalDiasComEvento}</p>
+                                    <p className="pt-1 border-t border-[hsl(var(--border))]"><span className="font-semibold">Linhas (incl. 2+ no mesmo dia):</span> {totaisAgregados.totalEventosRealizados} com faturamento / {totaisAgregados.totalEventos} no mês</p>
                                   </div>
                                 </TooltipContent>
                               </Tooltip>
                               <span className="font-medium text-[hsl(var(--foreground))]">{totaisAgregados.totalDiasRealizados} / {totaisAgregados.totalDiasComEvento}</span>
+                            </div>
+                            <div className="flex justify-between">
+                              <span className="text-[hsl(var(--muted-foreground))]">Eventos (linhas):</span>
+                              <span className="font-medium text-[hsl(var(--foreground))]">{totaisAgregados.totalEventosRealizados} / {totaisAgregados.totalEventos}</span>
                             </div>
                          </div>
                       </div>

--- a/frontend/src/app/estrategico/planejamento-comercial/services/planejamento-service.ts
+++ b/frontend/src/app/estrategico/planejamento-comercial/services/planejamento-service.ts
@@ -179,7 +179,7 @@ export async function getPlanejamentoComercial(
         id, data_evento, nome, dia_semana, bar_id,
         m1_r, cl_plan, te_plan, tb_plan, c_artistico_plan, lot_max,
         real_r, faturamento_total_consolidado, cl_real, publico_real_consolidado,
-        te_real_calculado, tb_real_calculado, t_medio,
+        te_real_calculado, tb_real_calculado, t_medio, percent_art_fat,
         percent_b, percent_d, percent_c, percent_happy_hour,
         percent_stockout, stockout_drinks_perc, stockout_comidas_perc,
         faturamento_couvert, couvert_vr_contahub,

--- a/frontend/src/app/estrategico/planejamento-comercial/services/planejamento-service.ts
+++ b/frontend/src/app/estrategico/planejamento-comercial/services/planejamento-service.ts
@@ -1,9 +1,53 @@
 import { SupabaseClient } from '@supabase/supabase-js';
 
 const DIAS_SEMANA = [
-  'DOMINGO', 'SEGUNDA', 'TERÇA', 'QUARTA', 
+  'DOMINGO', 'SEGUNDA', 'TERÇA', 'QUARTA',
   'QUINTA', 'SEXTA', 'SÁBADO'
 ];
+
+/**
+ * Metas / thresholds vindos de operations.config_metas_planejamento.
+ * Substituem os números hardcoded que estavam neste service (linhas 198–202)
+ * e em PlanejamentoClient.tsx (linhas 990, 1045, 1053, 1061, 1069).
+ * Ver docs/planning/06-auditoria-planejamento.md.
+ */
+export interface MetasPlanejamento {
+  t_medio_meta: number;
+  percent_art_fat_meta: number;
+  t_coz_meta: number;
+  t_bar_meta: number;
+  fat_19h_meta: number;
+  couvert_c_art_ratio_meta: number;
+  atrasao_cozinha_meta: number;
+  atrasao_bar_meta: number;
+  stockout_drinks_green: number;
+  stockout_drinks_yellow: number;
+  stockout_comidas_green: number;
+  stockout_comidas_yellow: number;
+}
+
+/**
+ * Fallback defensivo — usado APENAS quando a row da config ainda não existe
+ * (ex: migração 2026-04-23-config-metas-planejamento.sql não rodou no ambiente).
+ * Emite console.warn para que o gap fique visível em observabilidade.
+ * Remover após 2 sprints de migração em produção.
+ */
+const METAS_FALLBACK: MetasPlanejamento = {
+  t_medio_meta: 93,
+  percent_art_fat_meta: 15,
+  t_coz_meta: 720,
+  t_bar_meta: 240,
+  fat_19h_meta: 40,
+  couvert_c_art_ratio_meta: 1.0,
+  atrasao_cozinha_meta: 10,
+  atrasao_bar_meta: 50,
+  stockout_drinks_green: 10,
+  stockout_drinks_yellow: 25,
+  stockout_comidas_green: 10,
+  stockout_comidas_yellow: 25,
+};
+
+export type StockoutStatus = 'green' | 'yellow' | 'red';
 
 export interface PlanejamentoData {
   evento_id: number;
@@ -91,6 +135,14 @@ export interface PlanejamentoData {
   t_coz_green: boolean;
   t_bar_green: boolean;
   fat_19h_green: boolean;
+
+  // Flags vindas da config (Etapa 6 — ver docs/planning/06-auditoria-planejamento.md)
+  /** Couvert >= ratio * c_art (usado apenas no Deboche, bar_id=4) */
+  couvert_c_art_green: boolean;
+  atrasao_cozinha_green: boolean;
+  atrasao_bar_green: boolean;
+  stockout_drinks_status: StockoutStatus;
+  stockout_comidas_status: StockoutStatus;
 }
 
 export async function getPlanejamentoComercial(
@@ -117,7 +169,9 @@ export async function getPlanejamentoComercial(
   // REFACTOR 2026-04-20: Migrado para gold.planejamento
   // Gold ja tem consolidacao de ContaHub + Yuzer + Sympla, eliminando
   // bug de double-counting (L268 subtraia quando real_r ja era consolidado)
-  const [{ data: eventosGold, error }, { data: eventosManuais }] = await Promise.all([
+  // REFACTOR 2026-04-23 (Etapa 6): lê também operations.config_metas_planejamento
+  // para eliminar thresholds hardcoded. Ver docs/planning/06-auditoria-planejamento.md
+  const [{ data: eventosGold, error }, { data: eventosManuais }, { data: configMetas }] = await Promise.all([
     supabase
       .schema('gold' as never)
       .from('planejamento')
@@ -140,7 +194,7 @@ export async function getPlanejamentoComercial(
       .lt('data_evento', dataFinalConsulta)
       .eq('ativo', true)
       .order('data_evento', { ascending: true }),
-    
+
     // LEFT JOIN eventos_base SOMENTE para campos manuais editaveis
     supabase
       .schema('operations' as never)
@@ -148,8 +202,27 @@ export async function getPlanejamentoComercial(
       .select('data_evento, observacoes, c_art, c_prod, faturamento_couvert_manual, faturamento_bar_manual, precisa_recalculo, versao_calculo')
       .eq('bar_id', barId)
       .gte('data_evento', dataInicio)
-      .lt('data_evento', dataFinalConsulta)
+      .lt('data_evento', dataFinalConsulta),
+
+    // Config de thresholds por (bar, ano) — fallback defensivo se row não existir
+    supabase
+      .schema('operations' as never)
+      .from('config_metas_planejamento')
+      .select('t_medio_meta, percent_art_fat_meta, t_coz_meta, t_bar_meta, fat_19h_meta, couvert_c_art_ratio_meta, atrasao_cozinha_meta, atrasao_bar_meta, stockout_drinks_green, stockout_drinks_yellow, stockout_comidas_green, stockout_comidas_yellow')
+      .eq('bar_id', barId)
+      .eq('ano', ano)
+      .maybeSingle()
   ]);
+
+  // Resolve metas — usa fallback SOMENTE quando config não existe ainda (migration pendente)
+  const metas: MetasPlanejamento = (configMetas as MetasPlanejamento | null) ?? (() => {
+    console.warn(
+      '[planejamento-service] config_metas_planejamento ausente para bar_id=%s ano=%s. Usando fallback. Rode a migration 2026-04-23-config-metas-planejamento.sql.',
+      barId,
+      ano
+    );
+    return METAS_FALLBACK;
+  })();
 
   if (error) {
     console.error('❌ Erro ao buscar Gold planejamento:', {
@@ -195,11 +268,36 @@ export async function getPlanejamentoComercial(
     const ciRealVsPlanGreen = (evento.publico_real_consolidado || 0) >= (evento.cl_plan || 0);
     const teRealVsPlanGreen = (evento.te_real_calculado || 0) >= (evento.te_plan || 0);
     const tbRealVsPlanGreen = (evento.tb_real_calculado || 0) >= (evento.tb_plan || 0);
-    const tMedioGreen = (evento.t_medio || 0) >= 93;
-    const percentArtFatGreen = (evento.percent_art_fat || 0) <= 15;
-    const tCozGreen = (evento.t_coz || 0) <= 720;
-    const tBarGreen = (evento.t_bar || 0) <= 240;
-    const fat19hGreen = (evento.fat_19h_percent || 0) >= 40;
+    // Etapa 6: thresholds vêm de metas (config_metas_planejamento), não mais hardcoded
+    const tMedioGreen = (evento.t_medio || 0) >= metas.t_medio_meta;
+    const percentArtFatGreen = (evento.percent_art_fat || 0) <= metas.percent_art_fat_meta;
+    const tCozGreen = (evento.t_coz || 0) <= metas.t_coz_meta;
+    const tBarGreen = (evento.t_bar || 0) <= metas.t_bar_meta;
+    const fat19hGreen = (evento.fat_19h_percent || 0) >= metas.fat_19h_meta;
+
+    // Flags extras migradas de PlanejamentoClient.tsx (Etapa 6)
+    const cArt = Number(manual?.c_art) || 0;
+    const couvertContahub = evento.couvert_vr_contahub !== null && evento.couvert_vr_contahub !== undefined
+      ? Number(evento.couvert_vr_contahub)
+      : 0;
+    // c_art / couvert <= 1.0 = green (couvert cobre o custo artistico)
+    const couvertCArtGreen = cArt > 0 && couvertContahub > 0
+      && (cArt / couvertContahub) <= metas.couvert_c_art_ratio_meta;
+
+    const atrasaoCozinhaGreen = (evento.atrasao_cozinha || 0) <= metas.atrasao_cozinha_meta;
+    const atrasaoBarGreen = (evento.atrasao_bar || 0) <= metas.atrasao_bar_meta;
+
+    const stockoutDrinksPerc = evento.stockout_drinks_perc || 0;
+    const stockoutDrinksStatus: StockoutStatus =
+      stockoutDrinksPerc <= metas.stockout_drinks_green ? 'green'
+      : stockoutDrinksPerc <= metas.stockout_drinks_yellow ? 'yellow'
+      : 'red';
+
+    const stockoutComidasPerc = evento.stockout_comidas_perc || 0;
+    const stockoutComidasStatus: StockoutStatus =
+      stockoutComidasPerc <= metas.stockout_comidas_green ? 'green'
+      : stockoutComidasPerc <= metas.stockout_comidas_yellow ? 'yellow'
+      : 'red';
 
     const percClientesNovos: number | null = null;
     const clientesAtivos: number | null = null;
@@ -289,6 +387,13 @@ export async function getPlanejamentoComercial(
       t_coz_green: tCozGreen,
       t_bar_green: tBarGreen,
       fat_19h_green: fat19hGreen,
+
+      // Flags vindas de operations.config_metas_planejamento (Etapa 6)
+      couvert_c_art_green: couvertCArtGreen,
+      atrasao_cozinha_green: atrasaoCozinhaGreen,
+      atrasao_bar_green: atrasaoBarGreen,
+      stockout_drinks_status: stockoutDrinksStatus,
+      stockout_comidas_status: stockoutComidasStatus,
     };
   });
 


### PR DESCRIPTION
## Summary

Bateria de 3 fixes em /estrategico/planejamento-comercial + 1 em stockout (auto-heal D-1).

### Commits

* **0a384723** — `etl_gold_planejamento_full`: popular 14 KPIs de producao (mix %b/%d/%c, atrasao cozinha/bar, stockout drinks/comidas/bebidas, t_coz/t_bar) lendo de operations.eventos_base. Re-roda 60 dias automaticamente.

* **a4eb8597** — Couvert Deb + auto-heal stockout loud:
  * `couvert_vr_contahub` populado em gold.planejamento (SUM vd_vrcouvert do bronze ContaHub).
  * Front inverte calculo da coluna couv/art: agora `c_art / couvert * 100` (% do couvert que paga o artista). Antes era invertido.
  * `revalidar_stockout_dia_anterior_ambos_bares_v2` apontava pra tabelas que NAO existem mais (`contahub_stockout`, `contahub_stockout_processado` — foram pra schema bronze/silver). Erro caia no EXCEPTION e era silenciado. Causa do caso 28/04 (silver vazio o dia inteiro). Corrigido pra usar bronze/silver corretos + alerta Discord LOUD se auto-heal falhar.

## Validacao Ord 22-28/04 (mix + atrasos + stockout)

| Data | %B | %D | %C | Atr.Coz | Atr.Bar | SO Drinks | SO Comidas |
|---|---|---|---|---|---|---|---|
| 22/04 | 53,36 | 22,80 | 23,84 | 75 | 421 | 0,0% | 0,0% |
| 24/04 | 67,85 | 21,09 | 11,06 | 226 | 1.738 | 9,5% | 0,0% |
| 25/04 | 60,84 | 17,58 | 21,58 | 227 | 2.288 | 8,4% | 2,3% |

## Validacao couvert + couv/art

| Bar/Data | $Couvert | c_art | c_art/couvert |
|---|---|---|---|
| Ord 22/04 | R\$ 3.375 | R\$ 2.074 | 61,45% |
| Ord 24/04 | R\$ 22.425 | R\$ 22.880 | 102,03% |
| Deb 23/04 | R\$ 450 | R\$ 350 | 77,78% |
| Deb 24/04 | R\$ 2.568 | R\$ 800 | 31,15% |

## Validacao stockout auto-heal

* `revalidar_stockout_dia_anterior_ambos_bares_v2()` rodada em 28/04: detecta silver populado, skipa, sem alerta.
* Em caso real de falha: dispara alerta Discord com chave dedup `stockout_silencioso_d1_<data>_<bar>`.

## Garantia automatica

* Cron 462 `gold-desempenho` (12:00 BRT diario) -> etl_gold_planejamento_all_bars
* Cron 352 `stockout-retry-d-1-ambos-v2` (07:20 BRT diario) -> auto-heal stockout
* Cron 312 `alerta-stockout-faltante-ontem` (10:40 BRT) -> alerta backup

## Test plan

- [ ] Vercel build verde
- [ ] /estrategico/planejamento-comercial Ord+Deb mostra mix, atrasos, stockout populados
- [ ] Deb mostra \$couvert preenchido (vinha zero antes)
- [ ] Coluna couv/art bate com c_art/couvert (formula invertida)
- [ ] Stockout amanha: cron 352 valida e auto-heal se necessario

🤖 Generated with [Claude Code](https://claude.com/claude-code)