### PR TITLE
fix(desempenho): stockout silver + cmo manual mensal + google ponderada

### DIFF
--- a/database/migrations/2026-04-29-etl-google-media-ponderada.sql
+++ b/database/migrations/2026-04-29-etl-google-media-ponderada.sql
@@ -1,0 +1,65 @@
+-- 2026-04-29: ETL semanal+mensal — media Google ponderada por reviews
+--
+-- Bug reportado pelo socio: media Google na tabela /estrategico/desempenho
+-- diferia do modal de detalhes:
+--   Mar/2026 Ord: tabela 4,90 vs modal 4,92
+--   Jan/2026 Ord: tabela 4,77 vs modal 4,83
+--
+-- Causa: ETL usava AVG(stars_medio) FILTER (WHERE total_reviews > 0).
+-- Modal usa SUM(stars_medio * total_reviews) / SUM(total_reviews).
+-- Para reviews, a media correta eh ponderada — um dia com 50 reviews
+-- pesa mais que um dia com 5.
+--
+-- Fix: alinhar ETL semanal e mensal pra usar a media ponderada (= modal).
+--
+-- Validacao: Mar/2026 4,90 -> 4,92, Jan/2026 4,77 -> 4,83 (bate modal).
+
+DO $$
+DECLARE v_def text; v_new text; v_func text;
+BEGIN
+  FOREACH v_func IN ARRAY ARRAY['etl_gold_desempenho_semanal','etl_gold_desempenho_mensal']
+  LOOP
+    SELECT pg_get_functiondef(p.oid) INTO v_def FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+    WHERE p.proname=v_func AND n.nspname='public';
+
+    v_new := REPLACE(v_def,
+      E'AVG(stars_medio) FILTER (WHERE total_reviews > 0)::numeric(4,2) as media_avaliacoes_google',
+      E'(SUM(stars_medio * total_reviews)::numeric / NULLIF(SUM(total_reviews), 0))::numeric(4,2) as media_avaliacoes_google'
+    );
+
+    IF v_new <> v_def THEN
+      EXECUTE v_new;
+      RAISE NOTICE '% atualizado: media google ponderada', v_func;
+    ELSE
+      RAISE NOTICE '% ja esta atualizado (no-op)', v_func;
+    END IF;
+  END LOOP;
+END $$;
+
+-- Re-rodar todos os meses 2025+2026
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN SELECT b, a, m FROM (VALUES (3),(4)) AS bb(b)
+    CROSS JOIN (VALUES (2025),(2026)) AS aa(a)
+    CROSS JOIN generate_series(1,12) AS m
+    WHERE NOT (a = 2026 AND m > EXTRACT(month FROM CURRENT_DATE))
+  LOOP
+    BEGIN PERFORM public.etl_gold_desempenho_mensal(r.b, r.a, r.m);
+    EXCEPTION WHEN OTHERS THEN NULL; END;
+  END LOOP;
+END $$;
+
+-- Re-rodar semanal ultimos 60 dias
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN
+    SELECT DISTINCT b.id as bar_id, EXTRACT(isoyear FROM d.dia)::integer as ano, EXTRACT(week FROM d.dia)::integer as semana
+    FROM operations.bares b CROSS JOIN generate_series(CURRENT_DATE - INTERVAL '60 days', CURRENT_DATE, '1 day') d(dia)
+    WHERE b.ativo=true
+  LOOP
+    BEGIN PERFORM public.etl_gold_desempenho_semanal(r.bar_id, r.ano, r.semana);
+    EXCEPTION WHEN OTHERS THEN NULL; END;
+  END LOOP;
+END $$;

--- a/database/migrations/2026-04-29-etl-semanal-stockout-usar-silver.sql
+++ b/database/migrations/2026-04-29-etl-semanal-stockout-usar-silver.sql
@@ -1,0 +1,57 @@
+-- 2026-04-29: ETL semanal stockout — usar silver (mesma fonte da ferramenta)
+--
+-- Bug reportado pelo socio: %bar em /estrategico/desempenho semanal
+-- mostra 21,82% para S17 Ord, mas /ferramentas/stockout mostra 14,61%
+-- pro mesmo periodo (20-26/04).
+--
+-- Causa: 2 fontes diferentes:
+--   * etl_gold_desempenho_semanal lia gold.gold_contahub_operacional_stockout
+--     com CASE manual de loc_desc (Bar = Chopp+Bar)
+--   * /ferramentas/stockout le silver.silver_contahub_operacional_stockout_processado
+--     com categoria_local pre-calculada e filtro incluido=true
+--   * etl_gold_desempenho_mensal ja usava silver (consistente).
+--
+-- Fix: alinhar ETL semanal pra usar silver+incluido=true igual mensal e
+-- igual a ferramenta. Calculo continua AVG dos % diarios.
+--
+-- Validacao S17/26 Ord: 21,82% -> 14,61% (bate ferramenta).
+--
+-- Re-roda todos bares/semanas dos ultimos 60 dias automaticamente.
+
+DO $$
+DECLARE v_def text; v_new text;
+BEGIN
+  SELECT pg_get_functiondef(p.oid) INTO v_def FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+  WHERE p.proname='etl_gold_desempenho_semanal' AND n.nspname='public';
+
+  v_new := v_def;
+
+  v_new := REPLACE(v_new,
+    E'fase_stockout_dia AS (\n    SELECT data_consulta,\n      CASE\n        WHEN loc_desc IN (''Preshh'',''Montados'',''Mexido'',''Drinks'',''Drinks Autorais'',''Shot e Dose'',''Batidos'') THEN ''Drinks''\n        WHEN loc_desc IN (''Cozinha'',''Cozinha 1'',''Cozinha 2'') THEN ''Comidas''\n        WHEN loc_desc IN (''Chopp'',''Bar'') THEN ''Bar''\n      END as categoria_local,\n      COUNT(DISTINCT prd) as total,\n      COUNT(DISTINCT prd) FILTER (WHERE prd_venda = ''N'') as stockout\n    FROM gold.gold_contahub_operacional_stockout\n    WHERE bar_id = p_bar_id AND data_consulta BETWEEN v_data_inicio AND v_data_fim\n      AND loc_desc NOT IN (''Pegue e Pague'',''Venda Volante'',''Baldes'',''PP'')\n    GROUP BY data_consulta, categoria_local\n    HAVING CASE WHEN loc_desc IN (''Preshh'',''Montados'',''Mexido'',''Drinks'',''Drinks Autorais'',''Shot e Dose'',''Batidos'') THEN ''Drinks'' WHEN loc_desc IN (''Cozinha'',''Cozinha 1'',''Cozinha 2'') THEN ''Comidas'' WHEN loc_desc IN (''Chopp'',''Bar'') THEN ''Bar'' END IS NOT NULL\n  )',
+    E'fase_stockout_dia AS (\n    SELECT data_consulta, categoria_local,\n      COUNT(DISTINCT prd) as total,\n      COUNT(DISTINCT prd) FILTER (WHERE prd_venda = ''N'') as stockout\n    FROM silver.silver_contahub_operacional_stockout_processado\n    WHERE bar_id = p_bar_id\n      AND data_consulta BETWEEN v_data_inicio AND v_data_fim\n      AND incluido = true\n    GROUP BY data_consulta, categoria_local\n  )'
+  );
+
+  IF v_new <> v_def THEN
+    EXECUTE v_new;
+    RAISE NOTICE 'etl_gold_desempenho_semanal alinhado com silver';
+  ELSE
+    RAISE NOTICE 'ja esta alinhado (no-op)';
+  END IF;
+END $$;
+
+-- Re-rodar ultimos 60 dias
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN
+    SELECT DISTINCT b.id as bar_id,
+      EXTRACT(isoyear FROM d.dia)::integer as ano,
+      EXTRACT(week FROM d.dia)::integer as semana
+    FROM operations.bares b CROSS JOIN generate_series(CURRENT_DATE - INTERVAL '60 days', CURRENT_DATE, '1 day') d(dia)
+    WHERE b.ativo=true
+    ORDER BY ano, semana
+  LOOP
+    BEGIN PERFORM public.etl_gold_desempenho_semanal(r.bar_id, r.ano, r.semana);
+    EXCEPTION WHEN OTHERS THEN RAISE WARNING 'bar=% ano=% sem=%: %', r.bar_id, r.ano, r.semana, SQLERRM; END;
+  END LOOP;
+END $$;

--- a/frontend/src/app/estrategico/desempenho/services/desempenho-mensal-service.ts
+++ b/frontend/src/app/estrategico/desempenho/services/desempenho-mensal-service.ts
@@ -42,6 +42,23 @@ export async function getMeses(
     return [];
   }
 
+  // Buscar meta.desempenho_manual pra aplicar overrides editados pelo socio
+  // (CMO, CMV teorico, NPS, stockout manual, etc — mesmo conceito do semanal)
+  const { data: manuaisData } = await supabase
+    .schema('meta' as never)
+    .from('desempenho_manual')
+    .select('*')
+    .eq('bar_id', barId)
+    .eq('granularidade', 'mensal')
+    .gte('ano', anoInicio)
+    .lte('ano', anoFim);
+
+  const manuaisMap = new Map<string, any>();
+  (manuaisData || []).forEach((m: any) => {
+    const key = `${m.ano}-${String(m.mes).padStart(2, '0')}`;
+    manuaisMap.set(key, m);
+  });
+
   // Buscar meta.marketing_semanal pra agregar campos g_* e gmn_*
   // (gold.desempenho so tem m_*, mas o front exibe Google Ads e Google Meu Negocio)
   const { data: marketingData } = await supabase
@@ -126,12 +143,36 @@ export async function getMeses(
     const faturamentoTotal = toNum(g.faturamento_total) ?? 0;
     const descontoTotal = toNum(g.desconto_total) ?? 0;
     const mkt = marketingMensalMap.get(g.periodo);
+    const manual = manuaisMap.get(g.periodo) || {};
 
     return {
       ...g,
       numero_semana: parseInt(g.periodo.split('-')[1]),
-      atualizado_em: g.calculado_em,
-      atualizado_por_nome: 'Sistema ETL',
+      atualizado_em: manual.atualizado_em ?? g.calculado_em,
+      atualizado_por_nome: manual.id ? 'Manual' : 'Sistema ETL',
+
+      // CMO: manual.cmo eh o % editado pelo socio. cmo_valor (R$) vem do gold.
+      // cmo_percentual: se tiver manual override, usa ele; senao calcula de gold.cmo/faturamento.
+      cmo: manual.cmo ?? null,
+      cmo_valor: toNum(g.cmo) ?? 0,
+      cmo_percentual: manual.cmo != null
+        ? Number(manual.cmo)
+        : (toNum(g.cmo) != null && faturamentoTotal > 0 ? (Number(g.cmo) / faturamentoTotal * 100) : 0),
+
+      // CMV manual override
+      cmv_teorico: manual.cmv_teorico ?? 0,
+      cmv_limpo: toNum(g.cmv_percentual) ?? manual.cmv_limpo ?? 0,
+      cmv_limpo_percentual: toNum(g.cmv_percentual) ?? manual.cmv_limpo ?? 0,
+      cmv_rs: toNum(g.cmv) ?? manual.cmv ?? 0,
+
+      // NPS overrides (igual semanal)
+      nps_digital: toNum(g.nps_digital) ?? manual.nps_digital ?? 0,
+      nps_digital_respostas: toNum(g.nps_digital_respostas) ?? manual.nps_digital_respostas ?? 0,
+      nps_salao: toNum(g.nps_salao) ?? manual.nps_salao ?? 0,
+      nps_salao_respostas: toNum(g.nps_salao_respostas) ?? manual.nps_salao_respostas ?? 0,
+      nps_reservas: toNum(g.nps_reservas) ?? manual.nps_reservas ?? 0,
+      nps_reservas_respostas: toNum(g.nps_reservas_respostas) ?? manual.nps_reservas_respostas ?? 0,
+      nota_felicidade_equipe: g.nota_felicidade_equipe ?? manual.nota_felicidade_equipe ?? null,
 
       // Tempos: gold em SEGUNDOS -> front em MINUTOS. Filtra clamp 9999 (outliers).
       tempo_saida_bar: tempoDrinks !== null && tempoDrinks < 9999 ? Math.round(tempoDrinks / 60 * 100) / 100 : null,


### PR DESCRIPTION
## Summary

3 bugs reportados pelo socio em /estrategico/desempenho (pos PR #55).

### 1. Stockout %bar (semanal) divergia da ferramenta

* /estrategico/desempenho S17 Ord mostrava \`%bar = 21,82%\`.
* /ferramentas/stockout (mesmo periodo) mostrava \`14,61%\`.
* Causa: 2 fontes diferentes.
  * ETL semanal lia \`gold.gold_contahub_operacional_stockout\` com CASE manual (Bar = Chopp+Bar).
  * Ferramenta + ETL mensal leem \`silver.silver_contahub_operacional_stockout_processado\` com \`incluido=true\`.
* Fix: alinhar ETL semanal pra silver+incluido. Re-roda 60 dias.
* Validacao: 21,82% -> **14,61%** (bate ferramenta).

### 2. CMO manual mensal nao persistia (visualmente)

* Socio zerava CMO=0% em todos os meses, recarregava e voltava com valores auto.
* Causa: \`desempenho-mensal-service.ts\` NAO buscava \`meta.desempenho_manual\`. PUT salvava OK, GET ignorava.
* Fix: service mensal busca manual + aplica overrides em CMO, CMV teorico, NPS digital/salao/reservas, nota felicidade equipe.
* Os 13 registros que o socio zerou (cmo=0) ja estao no banco — apos deploy, vao aparecer 0%.

### 3. Google media — tabela vs modal divergia

* Mar/2026 Ord: tabela \`4,90\` vs modal \`4,92\`.
* Jan/2026 Ord: tabela \`4,77\` vs modal \`4,83\`.
* Causa: ETL usava \`AVG(stars_medio)\` simples por dia. Modal usa \`SUM(stars × reviews) / SUM(reviews)\` — media ponderada (correta).
* Fix: alinhar ETL semanal+mensal pra ponderada. Re-roda 2025+2026.
* Validacao: Mar 4,90 -> **4,92**, Jan 4,77 -> **4,83**.

## Test plan

- [ ] Vercel build verde
- [ ] /estrategico/desempenho?visao=semanal S17 Ord %bar = 14,61%
- [ ] /estrategico/desempenho?visao=mensal Ord meses 2025+2026 mostram CMO=0% (zerados pelo socio)
- [ ] /estrategico/desempenho?visao=mensal Mar/2026 Ord media google = 4,92 e Jan = 4,83

🤖 Generated with [Claude Code](https://claude.com/claude-code)