### PR TITLE
fix(cmv+planejamento): faturamento bruto≠líquido + cmv mensal auto + reservas eventos_base

### DIFF
--- a/backend/supabase/functions/cmv-semanal-auto/index.ts
+++ b/backend/supabase/functions/cmv-semanal-auto/index.ts
@@ -156,7 +156,7 @@ serve(async (req) => {
       let queryDesempenho = supabase
         .schema('gold')
         .from('desempenho')
-        .select('numero_semana, ano, data_inicio, data_fim, faturamento_total, faturamento_entrada, comissao')
+        .select('numero_semana, ano, data_inicio, data_fim, faturamento_total')
         .eq('bar_id', barId)
         .eq('granularidade', 'semanal')
         .eq('ano', anoAtual)
@@ -261,8 +261,6 @@ serve(async (req) => {
         const semanaEmAndamento = weekRange.end >= hoje;
 
         let faturamentoBruto = sem.faturamento_total || 0;
-        let comissao = (sem as any).comissao || 0;
-        let faturamentoCouvert = (sem as any).faturamento_entrada || 0;
 
         // Se a semana está em andamento E o faturamento está zerado, buscar do eventos_base
         if (semanaEmAndamento && faturamentoBruto === 0) {
@@ -275,18 +273,32 @@ serve(async (req) => {
             .eq('bar_id', barId)
             .gte('data_evento', weekRange.start)
             .lte('data_evento', weekRange.end);
-          
+
           if (eventosData && eventosData.length > 0) {
             faturamentoBruto = eventosData.reduce((sum, e) => sum + (parseFloat(e.real_r) || 0), 0);
             console.log(`✅ Faturamento do eventos_base: R$ ${faturamentoBruto}`);
           }
         }
-        
+
+        // Comissão (vd_vrrepique) e Couvert (vd_vrcouvert) direto do bronze ContaHub
+        // via RPC pra agregar no servidor (PostgREST limita 1000 linhas por default
+        // e algumas semanas tem ~4k vendas).
+        let comissao = 0;
+        let faturamentoCouvert = 0;
+        const { data: agg } = await supabase.rpc('get_comissao_couvert_periodo', {
+          p_bar_id: barId,
+          p_data_inicio: weekRange.start,
+          p_data_fim: weekRange.end,
+        });
+        if (Array.isArray(agg) && agg.length > 0) {
+          comissao = parseFloat(agg[0].comissao) || 0;
+          faturamentoCouvert = parseFloat(agg[0].couvert) || 0;
+        }
+
         console.log(`\n⏱️ [${Date.now() - barStartTime}ms] Processando semana ${numeroSemana}...`);
-        console.log(`📊 [DEBUG] Faturamento de gold.desempenho: R$ ${faturamentoBruto}`);
-        
-        // Faturamento Limpo = Faturamento Total - Comissão - Faturamento Couvert
-        // NOTA: "Faturamento Couvert" da planilha = faturamento_entrada (não couvert_atracoes)
+        console.log(`📊 [DEBUG] Bruto: R$ ${faturamentoBruto} | Comissao: R$ ${comissao.toFixed(2)} | Couvert: R$ ${faturamentoCouvert.toFixed(2)}`);
+
+        // Faturamento Limpo = Faturamento Total - Comissão (taxa servico) - Faturamento Couvert
         const faturamentoLimpo = faturamentoBruto - comissao - faturamentoCouvert;
         
         // Calcular datas da semana se não existirem

--- a/database/migrations/2026-04-30-agregar-cmv-mensal-auto.sql
+++ b/database/migrations/2026-04-30-agregar-cmv-mensal-auto.sql
@@ -1,0 +1,196 @@
+-- 2026-04-30: Gerar financial.cmv_mensal automaticamente do banco
+--
+-- Bugs reportados pelo socio:
+--   * Mar/2026 Deb cmv_mensal todo zerado (planilha vazia)
+--   * Abr/2026 Ord+Deb sem linha (planilha sem mes)
+--   * Compras jan/fev Deb muito altas (150k/145k vs ~78k/96k real)
+--   * Linha fantasma mai/2026 Deb (duplicacao da fev)
+--
+-- Causa: financial.cmv_mensal era populado via sync-cmv-mensal a partir
+-- de uma planilha mensal Google Sheets. Quando socio nao preenchia (ou
+-- havia bug no sync), os dados ficavam zerados/missing/duplicados.
+--
+-- Fix: criar funcao agregar_cmv_mensal_auto(bar_id, ano, mes) que monta
+-- o cmv_mensal direto do banco com data EXATA por dia:
+--   * Compras: silver.contaazul_lancamentos_diarios (data_competencia)
+--   * Comissao+Couvert: get_comissao_couvert_periodo (bronze ContaHub)
+--   * Faturamento: gold.planejamento.faturamento_total_consolidado
+--   * Consumos: get_consumos_classificados_semana (bronze ContaHub)
+--   * Fator consumo: operations.bar_regras_negocio.cmv_fator_consumo
+--   * Estoques: cmv_semanal das semanas cuja quinta-feira ISO cai no mes
+--     (primeira semana do mes pra inicial, ultima pra final)
+--
+-- Cron diario 12:30 BRT (jobid 467) recalcula mes corrente +
+-- mes anterior (primeiros 7 dias do mes).
+--
+-- Validacao Deb 2026:
+--   Jan: 150k (planilha) -> 78,8k (auto, real)
+--   Fev: 145k -> 96,8k
+--   Mar: 0 (zerado) -> 72,3k (compras corretas, CMV 32,98%)
+--   Abr: nao existia -> 73,8k, CMV 25,37%
+
+CREATE OR REPLACE FUNCTION public.agregar_cmv_mensal_auto(
+  p_bar_id integer, p_ano integer, p_mes integer
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  v_data_inicio date := make_date(p_ano, p_mes, 1);
+  v_data_fim date := (make_date(p_ano, p_mes, 1) + INTERVAL '1 month' - INTERVAL '1 day')::date;
+  v_compras_comida numeric := 0; v_compras_bebidas numeric := 0;
+  v_compras_drinks numeric := 0; v_compras_outros numeric := 0;
+  v_compras_alim numeric := 0; v_compras_total numeric := 0;
+  v_faturamento numeric := 0; v_comissao numeric := 0; v_couvert numeric := 0;
+  v_fat_cmvivel numeric := 0;
+  v_consumo_socios numeric := 0; v_consumo_clientes numeric := 0;
+  v_consumo_artistas numeric := 0; v_consumo_funcionarios numeric := 0;
+  v_consumo_total numeric := 0; v_fator numeric := 1;
+  v_estoque_inicial numeric := 0; v_estoque_final numeric := 0;
+  v_estoque_inicial_func numeric := 0; v_estoque_final_func numeric := 0;
+  v_cmv_real numeric := 0; v_cmv_pct numeric := 0; v_cma_total numeric := 0;
+BEGIN
+  SELECT cmv_fator_consumo::numeric INTO v_fator
+  FROM operations.bar_regras_negocio WHERE bar_id = p_bar_id LIMIT 1;
+  v_fator := COALESCE(v_fator, 1);
+
+  SELECT
+    COALESCE(SUM(valor_bruto) FILTER (WHERE categoria_nome ILIKE '%custo comida%'), 0),
+    COALESCE(SUM(valor_bruto) FILTER (WHERE categoria_nome ILIKE '%custo bebida%'), 0),
+    COALESCE(SUM(valor_bruto) FILTER (WHERE categoria_nome ILIKE '%custo drink%'), 0),
+    COALESCE(SUM(valor_bruto) FILTER (WHERE categoria_nome ILIKE '%custo outros%'), 0),
+    COALESCE(SUM(valor_bruto) FILTER (WHERE categoria_nome ILIKE '%alimenta%'), 0)
+  INTO v_compras_comida, v_compras_bebidas, v_compras_drinks, v_compras_outros, v_compras_alim
+  FROM silver.contaazul_lancamentos_diarios
+  WHERE bar_id = p_bar_id
+    AND data_competencia BETWEEN v_data_inicio AND v_data_fim
+    AND tipo = 'DESPESA';
+
+  v_compras_total := v_compras_comida + v_compras_bebidas + v_compras_drinks + v_compras_outros;
+
+  SELECT COALESCE(SUM(faturamento_total_consolidado), 0) INTO v_faturamento
+  FROM gold.planejamento WHERE bar_id = p_bar_id AND data_evento BETWEEN v_data_inicio AND v_data_fim;
+
+  SELECT comissao, couvert INTO v_comissao, v_couvert
+  FROM public.get_comissao_couvert_periodo(p_bar_id, v_data_inicio, v_data_fim);
+
+  v_fat_cmvivel := v_faturamento - COALESCE(v_comissao, 0) - COALESCE(v_couvert, 0);
+
+  SELECT
+    COALESCE(SUM(total) FILTER (WHERE categoria='socios'), 0) * v_fator,
+    COALESCE(SUM(total) FILTER (WHERE categoria='clientes'), 0) * v_fator,
+    COALESCE(SUM(total) FILTER (WHERE categoria='artistas'), 0) * v_fator,
+    COALESCE(SUM(total) FILTER (WHERE categoria='funcionarios'), 0) * v_fator
+  INTO v_consumo_socios, v_consumo_clientes, v_consumo_artistas, v_consumo_funcionarios
+  FROM public.get_consumos_classificados_semana(p_bar_id, v_data_inicio, v_data_fim);
+
+  v_consumo_total := v_consumo_socios + v_consumo_clientes + v_consumo_artistas + v_consumo_funcionarios;
+
+  SELECT estoque_inicial, estoque_inicial_funcionarios
+  INTO v_estoque_inicial, v_estoque_inicial_func
+  FROM financial.cmv_semanal
+  WHERE bar_id = p_bar_id
+    AND EXTRACT(month FROM (date_trunc('week', make_date(ano, 1, 4)) + ((semana-1)*INTERVAL '1 week') + INTERVAL '3 days')::date) = p_mes
+    AND EXTRACT(year FROM (date_trunc('week', make_date(ano, 1, 4)) + ((semana-1)*INTERVAL '1 week') + INTERVAL '3 days')::date) = p_ano
+  ORDER BY ano ASC, semana ASC LIMIT 1;
+
+  SELECT estoque_final, estoque_final_funcionarios
+  INTO v_estoque_final, v_estoque_final_func
+  FROM financial.cmv_semanal
+  WHERE bar_id = p_bar_id
+    AND EXTRACT(month FROM (date_trunc('week', make_date(ano, 1, 4)) + ((semana-1)*INTERVAL '1 week') + INTERVAL '3 days')::date) = p_mes
+    AND EXTRACT(year FROM (date_trunc('week', make_date(ano, 1, 4)) + ((semana-1)*INTERVAL '1 week') + INTERVAL '3 days')::date) = p_ano
+    AND estoque_final > 0
+  ORDER BY ano DESC, semana DESC LIMIT 1;
+
+  v_estoque_inicial := COALESCE(v_estoque_inicial, 0);
+  v_estoque_final := COALESCE(v_estoque_final, 0);
+  v_estoque_inicial_func := COALESCE(v_estoque_inicial_func, 0);
+  v_estoque_final_func := COALESCE(v_estoque_final_func, 0);
+
+  v_cmv_real := v_estoque_inicial + v_compras_total - v_estoque_final - v_consumo_total;
+  v_cmv_pct := CASE WHEN v_fat_cmvivel > 0 THEN (v_cmv_real / v_fat_cmvivel * 100) ELSE 0 END;
+  v_cma_total := v_compras_alim + v_estoque_inicial_func - v_estoque_final_func;
+
+  INSERT INTO financial.cmv_mensal (
+    bar_id, ano, mes, data_inicio, data_fim,
+    estoque_inicial, estoque_final,
+    compras, compras_alimentacao,
+    consumo_socios, consumo_beneficios, consumo_rh_operacao, consumo_rh_escritorio, consumo_artista,
+    cmv_real, faturamento_cmvivel, cmv_real_percentual, cmv_limpo_percentual,
+    faturamento_total,
+    estoque_inicial_funcionarios, estoque_final_funcionarios, cma_total,
+    fonte, updated_at, created_at
+  ) VALUES (
+    p_bar_id, p_ano, p_mes, v_data_inicio, v_data_fim,
+    v_estoque_inicial, v_estoque_final,
+    v_compras_total, v_compras_alim,
+    v_consumo_socios, v_consumo_clientes, v_consumo_funcionarios, 0, v_consumo_artistas,
+    v_cmv_real, v_fat_cmvivel, v_cmv_pct, v_cmv_pct,
+    v_faturamento,
+    v_estoque_inicial_func, v_estoque_final_func, v_cma_total,
+    'auto-agregado', NOW(), NOW()
+  )
+  ON CONFLICT (bar_id, ano, mes) DO UPDATE SET
+    data_inicio = EXCLUDED.data_inicio, data_fim = EXCLUDED.data_fim,
+    estoque_inicial = EXCLUDED.estoque_inicial, estoque_final = EXCLUDED.estoque_final,
+    compras = EXCLUDED.compras, compras_alimentacao = EXCLUDED.compras_alimentacao,
+    consumo_socios = EXCLUDED.consumo_socios,
+    consumo_beneficios = EXCLUDED.consumo_beneficios,
+    consumo_rh_operacao = EXCLUDED.consumo_rh_operacao,
+    consumo_rh_escritorio = EXCLUDED.consumo_rh_escritorio,
+    consumo_artista = EXCLUDED.consumo_artista,
+    cmv_real = EXCLUDED.cmv_real, faturamento_cmvivel = EXCLUDED.faturamento_cmvivel,
+    cmv_real_percentual = EXCLUDED.cmv_real_percentual,
+    cmv_limpo_percentual = EXCLUDED.cmv_limpo_percentual,
+    faturamento_total = EXCLUDED.faturamento_total,
+    estoque_inicial_funcionarios = EXCLUDED.estoque_inicial_funcionarios,
+    estoque_final_funcionarios = EXCLUDED.estoque_final_funcionarios,
+    cma_total = EXCLUDED.cma_total, fonte = EXCLUDED.fonte, updated_at = NOW();
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.agregar_cmv_mensal_auto(integer, integer, integer) TO anon, authenticated, service_role;
+
+-- Cleanup: deletar linhas antigas zeradas/duplicadas
+DELETE FROM financial.cmv_mensal WHERE bar_id=4 AND ano=2026 AND mes IN (3,5);
+
+-- Re-rodar 2025+2026 todos meses Ord+Deb
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN SELECT b, a, m FROM (VALUES (3),(4)) AS bb(b)
+    CROSS JOIN (VALUES (2025),(2026)) AS aa(a)
+    CROSS JOIN generate_series(1,12) AS m
+    WHERE NOT (a = 2026 AND m > EXTRACT(month FROM CURRENT_DATE)::integer)
+      AND NOT (a = 2025 AND m < 3 AND b = 3)
+  LOOP
+    BEGIN PERFORM public.agregar_cmv_mensal_auto(r.b, r.a, r.m);
+    EXCEPTION WHEN OTHERS THEN RAISE WARNING 'bar=% a=% m=%: %', r.b, r.a, r.m, SQLERRM; END;
+  END LOOP;
+END $$;
+
+-- Cron diário 12:30 BRT (15:30 UTC) — recalcula mes corrente, e mes anterior nos primeiros 7 dias
+SELECT cron.unschedule('cmv-mensal-auto-diario') WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname='cmv-mensal-auto-diario');
+
+SELECT cron.schedule(
+  'cmv-mensal-auto-diario',
+  '30 15 * * *',
+  $cron$
+  DO $do$
+  DECLARE r record;
+  BEGIN
+    FOR r IN SELECT id FROM operations.bares WHERE ativo=true ORDER BY id LOOP
+      BEGIN
+        PERFORM public.agregar_cmv_mensal_auto(r.id, EXTRACT(year FROM CURRENT_DATE)::integer, EXTRACT(month FROM CURRENT_DATE)::integer);
+        IF EXTRACT(day FROM CURRENT_DATE) <= 7 THEN
+          PERFORM public.agregar_cmv_mensal_auto(r.id,
+            EXTRACT(year FROM (CURRENT_DATE - INTERVAL '1 month'))::integer,
+            EXTRACT(month FROM (CURRENT_DATE - INTERVAL '1 month'))::integer);
+        END IF;
+      EXCEPTION WHEN OTHERS THEN NULL; END;
+    END LOOP;
+  END $do$;
+  $cron$
+);

--- a/database/migrations/2026-04-30-cmv-get-comissao-couvert-rpc.sql
+++ b/database/migrations/2026-04-30-cmv-get-comissao-couvert-rpc.sql
@@ -1,0 +1,39 @@
+-- 2026-04-30: RPC pra cmv-semanal-auto somar comissao + couvert
+--
+-- Bug: cmv_semanal mostrava faturamento_bruto = vendas_liquidas =
+-- faturamento_cmvivel (3 colunas iguais) em todas as semanas.
+--
+-- Causa: a edge function cmv-semanal-auto lia sem.comissao e
+-- sem.faturamento_entrada de gold.desempenho — esses campos sao 0
+-- (gold nao popula). Logo:
+--   faturamentoLimpo = bruto - 0 - 0 = bruto.
+--
+-- Fix tentativa 1: ler bronze.bronze_contahub_avendas_vendasperiodo
+-- direto via PostgREST. NAO funcionou — bronze tem ~4000 linhas/semana
+-- e PostgREST default limita 1000 -> sum incompleto (S15 Ord: 25k de
+-- 101k esperado).
+--
+-- Fix tentativa 2 (esta migration): RPC SQL que agrega no servidor.
+-- Edge function chama via supabase.rpc() e recebe valor agregado.
+--
+-- Validacao S15 Ord: bruto 382.769, liquido 281.094 (diff 101.675 =
+-- 32.050 repique + 69.625 couvert).
+
+CREATE OR REPLACE FUNCTION public.get_comissao_couvert_periodo(
+  p_bar_id integer,
+  p_data_inicio date,
+  p_data_fim date
+)
+RETURNS TABLE(comissao numeric, couvert numeric)
+LANGUAGE sql
+SECURITY DEFINER
+AS $function$
+  SELECT
+    COALESCE(SUM(vd_vrrepique), 0)::numeric(14,2) AS comissao,
+    COALESCE(SUM(vd_vrcouvert), 0)::numeric(14,2) AS couvert
+  FROM bronze.bronze_contahub_avendas_vendasperiodo
+  WHERE bar_id = p_bar_id
+    AND vd_dtgerencial::date BETWEEN p_data_inicio AND p_data_fim;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_comissao_couvert_periodo(integer, date, date) TO anon, authenticated, service_role;

--- a/database/migrations/2026-04-30-etl-planejamento-reservas-eventos-base.sql
+++ b/database/migrations/2026-04-30-etl-planejamento-reservas-eventos-base.sql
@@ -1,0 +1,84 @@
+-- 2026-04-30: ETL planejamento — usar eventos_base pra res_tot/res_p/num_mesas
+--
+-- Bug reportado pelo socio: /estrategico/planejamento-comercial Ord 01/04
+-- mostrava 'Reservas Total = 542' mas Getin so tem 197 sentados.
+--
+-- Causa: etl_gold_planejamento_full populava res_tot com
+-- COUNT(DISTINCT cv.vd) de silver.cliente_visitas — isso eh
+-- "vendas/mesas abertas no bar", nao "reservas Getin". 542 vendas
+-- unicas eh o numero de mesas atendidas no dia, nao reservas.
+--
+-- Fonte correta: operations.eventos_base (populado pelo
+-- calculate_evento_metrics, que ja le bronze.bronze_getin_reservations
+-- direto). 01/04 Ord eventos_base.res_tot=197, res_p=197 (10 mesas).
+--
+-- Fix em 6 patches REPLACE no DO block (idempotente):
+--   1. fase_eb le 4 cols novas: res_tot, res_p, num_mesas_tot, num_mesas_presentes
+--   2. Coluna res_p (era m.res_p, meta) -> COALESCE(eb_res_p, m.res_p, 0)
+--   3. Coluna res_tot (era c.res, vendas) -> COALESCE(eb_res_tot, 0)
+--   4. INSERT cols incluem num_mesas_tot/num_mesas_presentes (antes ficavam null)
+--   5. SELECT VALUES bind eb_num_mesas_tot/presentes
+--   6. ON CONFLICT atualiza essas 2 colunas tambem
+--
+-- Validacao Ord 01-04/04:
+--   01/04: 542/197 -> 197/197, mesas null/null -> 10/10
+--   02/04: ?/? -> 274/211, mesas -> 21/14
+--   04/04: ?/? -> 362/276, mesas -> 24/17
+--
+-- Re-roda Ord+Deb pros ultimos 60 dias automaticamente.
+
+DO $$
+DECLARE v_def text; v_new text;
+BEGIN
+  SELECT pg_get_functiondef(p.oid) INTO v_def FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+  WHERE p.proname='etl_gold_planejamento_full' AND n.nspname='public';
+
+  v_new := v_def;
+
+  v_new := REPLACE(v_new,
+    E'      eb.cl_real AS eb_cl_real,\n      eb.real_r AS eb_real_r,',
+    E'      eb.cl_real AS eb_cl_real,\n      eb.real_r AS eb_real_r,\n      COALESCE(eb.res_tot, 0)::integer AS eb_res_tot,\n      COALESCE(eb.res_p, 0)::integer AS eb_res_p,\n      COALESCE(eb.num_mesas_tot, 0)::integer AS eb_num_mesas_tot,\n      COALESCE(eb.num_mesas_presentes, 0)::integer AS eb_num_mesas_presentes,'
+  );
+
+  v_new := REPLACE(v_new,
+    E'    m.m1_r, m.cl_plan, m.res_p, m.lot_max, m.te_plan, m.tb_plan, m.c_artistico_plan,',
+    E'    m.m1_r, m.cl_plan, COALESCE(eb.eb_res_p, m.res_p, 0), m.lot_max, m.te_plan, m.tb_plan, m.c_artistico_plan,'
+  );
+
+  v_new := REPLACE(v_new,
+    E'    COALESCE(c.res,0), v.pub,',
+    E'    COALESCE(eb.eb_res_tot, 0), v.pub,'
+  );
+
+  v_new := REPLACE(v_new,
+    E'    res_tot, publico_real,\n    descontos, conta_assinada,',
+    E'    res_tot, publico_real,\n    num_mesas_tot, num_mesas_presentes,\n    descontos, conta_assinada,'
+  );
+
+  v_new := REPLACE(v_new,
+    E'    COALESCE(eb.eb_res_tot, 0), v.pub,\n    v.desc, v.assn,',
+    E'    COALESCE(eb.eb_res_tot, 0), v.pub,\n    eb.eb_num_mesas_tot, eb.eb_num_mesas_presentes,\n    v.desc, v.assn,'
+  );
+
+  v_new := REPLACE(v_new,
+    E'    publico_real=EXCLUDED.publico_real,\n    descontos=EXCLUDED.descontos,',
+    E'    publico_real=EXCLUDED.publico_real,\n    num_mesas_tot=EXCLUDED.num_mesas_tot,\n    num_mesas_presentes=EXCLUDED.num_mesas_presentes,\n    descontos=EXCLUDED.descontos,'
+  );
+
+  IF v_new <> v_def THEN
+    EXECUTE v_new;
+    RAISE NOTICE 'etl_gold_planejamento_full atualizado: usa eventos_base (Getin)';
+  ELSE
+    RAISE NOTICE 'ja esta atualizado (no-op)';
+  END IF;
+END $$;
+
+-- Re-rodar Ord+Deb 60 dias
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN SELECT id FROM operations.bares WHERE ativo=true ORDER BY id LOOP
+    BEGIN PERFORM public.etl_gold_planejamento_full(r.id, (CURRENT_DATE - INTERVAL '60 days')::date, CURRENT_DATE);
+    EXCEPTION WHEN OTHERS THEN RAISE WARNING 'bar=%: %', r.id, SQLERRM; END;
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary

3 commits que ficaram fora do PR #56 (foram pushados na branch depois do merge). Tudo ja aplicado no banco em producao via execucao manual; este PR alinha o codigo no main.

### 1. Planejamento-comercial Ord 01/04: 542 → 197

* res_tot vinha de COUNT(DISTINCT cv.vd) silver.cliente_visitas (= vendas/mesas, nao reservas).
* Fix: ler de operations.eventos_base (Getin via calculate_evento_metrics).
* Tambem popula num_mesas_tot/presentes (antes ficavam null).

### 2. CMV faturamento_bruto ≠ vendas_liquidas

* /ferramentas/cmv-semanal/tabela mostrava bruto = liquido = cmvivel (3 colunas iguais).
* Causa: edge function lia sem.comissao e sem.faturamento_entrada de gold.desempenho (= 0 sempre).
* Fix: RPC get_comissao_couvert_periodo agrega vd_vrrepique + vd_vrcouvert do bronze.
* Validacao S15 Ord: bruto 382.769, liquido 281.094 (diff 101.675 = 32.050 repique + 69.625 couvert).

### 3. CMV mensal automatico (elimina planilha manual)

* Mar/2026 Deb zerado, Abr/2026 sem linha, Jan/Fev altos, mai fantasma.
* Causa: cmv_mensal vinha de planilha mensal Sheets — quando socio nao preenchia ou sync bugava, dados ficavam zerados/missing.
* Fix: funcao agregar_cmv_mensal_auto monta do banco com data EXATA por dia:
  * Compras: silver.contaazul_lancamentos_diarios.data_competencia
  * Comissao+Couvert: bronze ContaHub via RPC
  * Faturamento: gold.planejamento.faturamento_total_consolidado
  * Consumos: get_consumos_classificados_semana (bronze ContaHub)
  * Estoques: cmv_semanal das semanas (quinta-feira ISO determina mes)
* Cron 467 diario 12:30 BRT recalcula mes corrente + mes anterior (primeiros 7 dias).

## Validacao Deb 2026

| | Antes (planilha) | Depois (auto) |
|---|---|---|
| Jan compras | 150k | 78,8k |
| Fev compras | 145k | 96,8k |
| Mar compras | 0 (zerado) | 72,3k (CMV 32,98%) |
| Abr compras | nao existia | 73,8k (CMV 25,37%) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)