### PR TITLE
fix(crm): tabelas crm_segmentacao e crm_templates schema crm

### DIFF
--- a/frontend/src/app/api/crm/campanhas/route.ts
+++ b/frontend/src/app/api/crm/campanhas/route.ts
@@ -379,6 +379,7 @@ export async function GET(request: NextRequest) {
 
     // Buscar templates do banco
     const { data: templatesDB } = await supabase
+      .schema('crm' as any)
       .from('crm_templates')
       .select('*')
       .eq('ativo', true)
@@ -391,6 +392,7 @@ export async function GET(request: NextRequest) {
     let segmentosStats: Record<string, number> | null = null;
     if (incluirStats) {
       const { data: stats } = await supabase
+        .schema('crm' as any)
         .from('crm_segmentacao')
         .select('segmento')
         .then(res => {
@@ -493,6 +495,7 @@ export async function POST(request: NextRequest) {
 
     // 4. Buscar clientes do segmento alvo (usando tabela real!)
     let clientesQuery = supabase
+      .schema('crm' as any)
       .from('crm_segmentacao')
       .select('cliente_telefone, cliente_telefone_normalizado, cliente_nome, segmento')
       .in('segmento', segmento_alvo)

--- a/frontend/src/app/api/crm/lista-quente/route.ts
+++ b/frontend/src/app/api/crm/lista-quente/route.ts
@@ -746,6 +746,7 @@ export async function POST(request: NextRequest) {
     
     // Salvar o segmento na tabela crm_segmentacao
     const { data, error } = await supabase
+      .schema('crm' as any)
       .from('crm_segmentacao')
       .insert({
         bar_id,
@@ -799,6 +800,7 @@ export async function DELETE(request: NextRequest) {
     }
     
     const { error } = await supabase
+      .schema('crm' as any)
       .from('crm_segmentacao')
       .delete()
       .eq('id', segmentoId)

--- a/frontend/src/app/api/crm/segmentos/route.ts
+++ b/frontend/src/app/api/crm/segmentos/route.ts
@@ -11,6 +11,7 @@ export async function GET(request: NextRequest) {
     const barId = searchParams.get('bar_id') || '3';
     
     const { data, error } = await supabase
+      .schema('crm' as any)
       .from('crm_segmentacao')
       .select('*')
       .eq('bar_id', barId)


### PR DESCRIPTION
## Summary

Fix 500 em /analitico/clientes Lista Quente.

\`/api/crm/segmentos?bar_id=3\` retornava 500 — tabelas crm_* estao em schema \`crm\`, nao \`public\`.

## Mudancas

5 ocorrencias com .schema('crm'):
- /api/crm/segmentos (1)
- /api/crm/lista-quente (2 — insert + delete)
- /api/crm/campanhas (3 — templates + segmentacao stats + clientes alvo)

## Tabelas mortas (deixadas como estao)

\`crm_envios\`, \`crm_campanhas\`, \`crm_cupons\` referenciadas em campanhas/route.ts NAO existem em nenhum schema (features deletadas). Mantido fail-fast em vez de silent fallback.

## Test plan

- [ ] Vercel build verde
- [ ] /analitico/clientes Lista Quente carrega sem 500
- [ ] /api/crm/segmentos?bar_id=3 retorna 200 com array (vazio se nao houver segmentos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)