### PR TITLE
fix(ui): qui_sab_dom Ord oculto + couv/art Deb invertido + cmv consumacoes (re-aplicar)

### DIFF
--- a/backend/supabase/functions/cmv-semanal-auto/index.ts
+++ b/backend/supabase/functions/cmv-semanal-auto/index.ts
@@ -387,75 +387,40 @@ serve(async (req) => {
         const comprasCmvTotal = comprasPorCategoria.cozinha + comprasPorCategoria.bebidas + comprasPorCategoria.drinks + comprasPorCategoria.outros;
         console.log(`⏱️ [${Date.now() - semanaStartTime}ms] Compras processadas: R$ ${comprasCmvTotal.toFixed(2)}`);
 
-        // 4.2. Buscar CONSUMAÇÕES (4 categorias) - valores BRUTOS (sem multiplicador)
-        // TODO(rodrigo/2026-04): Reabilitar busca de consumações do bronze_contahub_vendas_analitico
-        // Contexto: Desabilitado temporariamente por timeout. Usar valores da planilha CMV enquanto isso.
-        // Issue: Investigar performance da RPC get_consumos_classificados_semana
+        // 4.2. Buscar CONSUMAÇÕES (4 categorias) via RPC SQL (server-side classifica)
         let consumacoes = {
           total_consumo_socios: 0,
           mesa_adm_casa: 0,
           mesa_beneficios_cliente: 0,
-          mesa_banda_dj: 0
+          mesa_banda_dj: 0,
         };
-        /*
         try {
-          const PADROES_SOCIOS = ['sócios', 'socios', 'socio', 'sócio', 'x-socio', 'x-sócio', 'x-soc', 'gonza', 'corbal', 'diogo', 'diego', 'cadu', 'augusto', 'rodrigo', 'digao', 'vinicius', 'vini', 'bueno', 'kaizen', 'caisen', 'joão pedro', 'joao pedro', 'jp', '3v', 'cantucci', 'moai', 'luan', 'viny'];
-          const PADROES_CLIENTES = ['aniver', 'anivers', 'aniversário', 'aniversario', 'aniversariante', 'niver', 'voucher', 'benefício', 'beneficio', 'mesa mágica', 'mágica', 'influencer', 'influ', 'influencia', 'influência', 'club', 'clube', 'midia', 'mídia', 'social', 'insta', 'digital', 'cliente', 'ambev', 'promoção', 'chegadeira', 'nct'];
-          const PADROES_ARTISTAS = ['musico', 'músicos', 'dj', 'banda', 'artista', 'breno', 'benza', 'stz', 'zelia', 'tia', 'samba', 'sambadona', 'doze', 'boca', 'boka', 'pé', 'chão', 'pe no', 'segunda', 'resenha', 'pagode', 'roda', 'reconvexa', 'rodie', 'roudier', 'roudi', 'som', 'técnico', 'tecnico', 'pv', 'paulo victor', 'prod', 'elas', 'bonsai', 'afrika', 'caju', 'negrita'];
-          const PADROES_FUNCIONARIOS = ['funcionários', 'funcionario', 'rh', 'financeiro', 'fin', 'mkt', 'marketing', 'slu', 'adm', 'administrativo', 'prêmio', 'confra', 'wendel', 'natalia', 'nato', 'x dudu', 'kauan', 'ana bia', 'teixeira', 'jhonny', 'andreia', 'lucia', 'phelipe', 'isabel', 'dakota', 'thais', 'edna', 'richard', 'gustavo', 'aladim', 'duarte', 'renan', 'henrique', 'deivid', 'vivi', 'rafa', 'adriana'];
+          const { data: consumosClassificados, error: consumosError } = await supabase.rpc('get_consumos_classificados_semana', {
+            input_bar_id: barId,
+            input_data_inicio: dataInicio,
+            input_data_fim: dataFim,
+          });
 
-          const matchPattern = (texto: string, patterns: string[]): boolean => {
-            const t = texto.toLowerCase();
-            return patterns.some(p => t.includes(p.toLowerCase()));
-          };
-
-          const classificarRegistro = (vdMesadesc: string, motivo: string): 'socios' | 'artistas' | 'funcionarios' | 'clientes' | null => {
-            const textoCompleto = `${vdMesadesc} ${motivo}`.toLowerCase();
-            
-            // Verificar CLIENTES primeiro (aniversário tem prioridade sobre nomes de sócios)
-            if (matchPattern(textoCompleto, PADROES_CLIENTES)) return 'clientes';
-            if (matchPattern(textoCompleto, PADROES_ARTISTAS)) return 'artistas';
-            if (matchPattern(textoCompleto, PADROES_FUNCIONARIOS)) return 'funcionarios';
-            if (matchPattern(textoCompleto, PADROES_SOCIOS)) return 'socios';
-            return null;
-          };
-
-          // Buscar consumos já classificados via SQL (função get_consumos_classificados_semana)
-          // Filtrar apenas valorfinal = 0 (consumos especiais onde o desconto = preço de venda)
-          try {
-            const { data: consumosClassificados, error: consumosError } = await supabase.rpc('get_consumos_classificados_semana', {
-              input_bar_id: barId,
-              input_data_inicio: dataInicio,
-              input_data_fim: dataFim
-            });
-
-            if (consumosError) {
-              console.error('  ⚠️ Erro ao buscar consumos classificados:', consumosError);
-            } else if (consumosClassificados && consumosClassificados.length > 0) {
-              const totais = { socios: 0, artistas: 0, funcionarios: 0, clientes: 0 };
-              
-              for (const item of consumosClassificados) {
-                const cat = item.categoria as 'socios' | 'artistas' | 'funcionarios' | 'clientes';
-                const valor = parseFloat(String(item.total)) || 0;
-                if (totais[cat] !== undefined) {
-                  totais[cat] = valor;
-                }
+          if (consumosError) {
+            console.error('  ⚠️ Erro ao buscar consumos classificados:', consumosError);
+          } else if (consumosClassificados && consumosClassificados.length > 0) {
+            const totais = { socios: 0, artistas: 0, funcionarios: 0, clientes: 0 };
+            for (const item of consumosClassificados) {
+              const cat = item.categoria as 'socios' | 'artistas' | 'funcionarios' | 'clientes';
+              const valor = parseFloat(String(item.total)) || 0;
+              if (totais[cat] !== undefined) {
+                totais[cat] = valor;
               }
-              
-              consumacoes.total_consumo_socios = totais.socios;
-              consumacoes.mesa_banda_dj = totais.artistas;
-              consumacoes.mesa_adm_casa = totais.funcionarios;
-              consumacoes.mesa_beneficios_cliente = totais.clientes;
-              console.log(`  👥 Consumações: Sócios R$ ${totais.socios.toFixed(2)}, Artistas R$ ${totais.artistas.toFixed(2)}, Funcionários R$ ${totais.funcionarios.toFixed(2)}, Clientes R$ ${totais.clientes.toFixed(2)}`);
             }
-          } catch (rpcErr) {
-            console.error('  ⚠️ Erro ao chamar RPC get_consumos_classificados_semana:', rpcErr);
+            consumacoes.total_consumo_socios = totais.socios;
+            consumacoes.mesa_banda_dj = totais.artistas;
+            consumacoes.mesa_adm_casa = totais.funcionarios;
+            consumacoes.mesa_beneficios_cliente = totais.clientes;
+            console.log(`  👥 Consumações: Sócios R$ ${totais.socios.toFixed(2)}, Artistas R$ ${totais.artistas.toFixed(2)}, Funcionários R$ ${totais.funcionarios.toFixed(2)}, Clientes R$ ${totais.clientes.toFixed(2)}`);
           }
-        } catch (err) {
-          console.error('  ⚠️ Erro ao buscar consumações:', err);
+        } catch (rpcErr) {
+          console.error('  ⚠️ Erro ao chamar RPC get_consumos_classificados_semana:', rpcErr);
         }
-        */
-        console.log('  ⚠️ Busca de consumos de bronze_contahub_vendas_analitico DESABILITADA (usar valores da planilha)');
         console.log(`⏱️ [${Date.now() - semanaStartTime}ms] Consumos processados`);
 
         // 4.3. Cálculo de estoque final da contagem

--- a/frontend/src/app/estrategico/desempenho/components/DesempenhoClient.tsx
+++ b/frontend/src/app/estrategico/desempenho/components/DesempenhoClient.tsx
@@ -239,14 +239,12 @@ return [
         metricas: [
           { key: 'perc_faturamento_ate_19h', label: '% Fat. até 19h', status: 'auto' as const, fonte: 'eventos_base', calculo: 'Média fat_19h_percent', formato: 'percentual' as const },
           { key: 'perc_faturamento_apos_22h', label: '% Fat. após 22h', status: 'auto' as const, fonte: 'bronze_contahub_operacional_fatporhora', calculo: 'Soma após 22h', formato: 'percentual' as const },
-          // Indicadores diferentes por bar: Ordinário (QUI+SÁB+DOM) vs Deboche (TER+QUA+QUI e SEX+SÁB)
+          // Indicadores por bar: Deboche (TER+QUA+QUI e SEX+SÁB). Ord nao tem (QUI+SÁB+DOM removido por decisao do socio)
           ...(barId === 4 ? [
             { key: 'ter_qua_qui', label: 'TER+QUA+QUI', status: 'auto' as const, fonte: 'eventos_base', calculo: 'Soma real_r terça/quarta/quinta', formato: 'moeda' as const },
             { key: 'sex_sab', label: 'SEX+SÁB', status: 'auto' as const, fonte: 'eventos_base', calculo: 'Soma real_r sexta/sábado', formato: 'moeda' as const },
             { key: 'perc_happy_hour', label: '% PROMO HH', status: 'auto' as const, fonte: 'bronze_contahub_vendas_analitico', calculo: 'grp_desc=Happy Hour / Total vendas', formato: 'percentual' as const },
-          ] : [
-            { key: 'qui_sab_dom', label: 'QUI+SÁB+DOM', status: 'auto' as const, fonte: 'eventos_base', calculo: 'Soma real_r', formato: 'moeda' as const },
-          ]),
+          ] : []),
           { key: 'conta_assinada_valor', label: 'Conta Assinada', status: 'auto' as const, fonte: 'faturamento_pagamentos', calculo: 'Soma meio=Conta Assinada', formato: 'moeda_com_percentual' as const, percentualKey: 'conta_assinada_perc' },
           { key: 'descontos_valor', label: 'Descontos', status: 'auto' as const, fonte: 'visitas', calculo: 'Soma valor_desconto', formato: 'moeda_com_percentual' as const, percentualKey: 'descontos_perc', temTooltipDetalhes: true },
           { key: 'cancelamentos', label: 'Cancelamentos', status: 'auto' as const, fonte: 'bronze_contahub_vendas_cancelamentos', calculo: 'Soma custototal', formato: 'moeda' as const, temTooltipDetalhes: true, detalhesKey: 'cancelamentos_detalhes' },

--- a/frontend/src/app/estrategico/planejamento-comercial/components/PlanejamentoClient.tsx
+++ b/frontend/src/app/estrategico/planejamento-comercial/components/PlanejamentoClient.tsx
@@ -995,7 +995,7 @@ export function PlanejamentoClient({ initialData, serverMes, serverAno }: Planej
                                             : 'text-[hsl(var(--muted-foreground))]'
                                       }`}>
                                         {evento.c_art > 0 && evento.couvert_vr_contahub && evento.couvert_vr_contahub > 0
-                                          ? formatarPercentual((evento.c_art / evento.couvert_vr_contahub) * 100)
+                                          ? formatarPercentual((evento.couvert_vr_contahub / evento.c_art) * 100)
                                           : evento.c_art > 0 ? '0,0%' : '-'}
                                       </span>
                                     ) : (

--- a/frontend/src/app/estrategico/planejamento-comercial/services/planejamento-service.ts
+++ b/frontend/src/app/estrategico/planejamento-comercial/services/planejamento-service.ts
@@ -280,9 +280,9 @@ export async function getPlanejamentoComercial(
     const couvertContahub = evento.couvert_vr_contahub !== null && evento.couvert_vr_contahub !== undefined
       ? Number(evento.couvert_vr_contahub)
       : 0;
-    // c_art / couvert <= 1.0 = green (couvert cobre o custo artistico)
+    // couvert / c_art >= 1.0 = green (couvert cobre o custo artistico — quanto maior melhor)
     const couvertCArtGreen = cArt > 0 && couvertContahub > 0
-      && (cArt / couvertContahub) <= metas.couvert_c_art_ratio_meta;
+      && (couvertContahub / cArt) >= metas.couvert_c_art_ratio_meta;
 
     const atrasaoCozinhaGreen = (evento.atrasao_cozinha || 0) <= metas.atrasao_cozinha_meta;
     const atrasaoBarGreen = (evento.atrasao_bar || 0) <= metas.atrasao_bar_meta;


### PR DESCRIPTION
## Summary

Re-aplicar os 3 fixes UI que ficaram fora do PR #59 (foram pushados depois do merge).

## Mudancas

1. **Desempenho mensal Ord**: coluna QUI+SAB+DOM ocultada (decisao do socio).
2. **Planejamento Comercial Deb**: couv/art exibe **couvert / c_art × 100** (invertido conforme socio pediu — quanto maior, melhor).
3. **CMV consumacoes**: bloco da RPC \`get_consumos_classificados_semana\` re-habilitado (estava comentado desde abril por TODO antigo de timeout). Edge function ja foi deployada ontem com o fix — esse PR so alinha o codigo no main.

## Test plan

- [ ] Vercel build verde
- [ ] /estrategico/desempenho?visao=mensal Ord NAO mostra mais QUI+SAB+DOM
- [ ] /estrategico/planejamento-comercial Deb couv/art mostra valores >100% quando couvert > c_art (ex: Ord 24/03 = 102%)
- [ ] /ferramentas/cmv-semanal/tabela consumacoes populadas (Ord S14 socios R\$ 950, banda R\$ 10k)

🤖 Generated with [Claude Code](https://claude.com/claude-code)