### PR TITLE
feat(cmv): auto-classificacao consumos com tabela editavel (5 categorias)

### DIFF
--- a/backend/supabase/functions/cmv-semanal-auto/index.ts
+++ b/backend/supabase/functions/cmv-semanal-auto/index.ts
@@ -387,12 +387,20 @@ serve(async (req) => {
         const comprasCmvTotal = comprasPorCategoria.cozinha + comprasPorCategoria.bebidas + comprasPorCategoria.drinks + comprasPorCategoria.outros;
         console.log(`⏱️ [${Date.now() - semanaStartTime}ms] Compras processadas: R$ ${comprasCmvTotal.toFixed(2)}`);
 
-        // 4.2. Buscar CONSUMAÇÕES (4 categorias) via RPC SQL (server-side classifica)
+        // 4.2. Buscar CONSUMAÇÕES (5 categorias) via RPC SQL (server-side classifica)
+        // Categorias: socios, artistas, funcionarios_operacao, funcionarios_escritorio, clientes
+        // Mapeamento -> tabela cmv_semanal:
+        //   socios                  -> total_consumo_socios
+        //   artistas                -> mesa_banda_dj
+        //   funcionarios_operacao   -> mesa_rh
+        //   funcionarios_escritorio -> mesa_adm_casa
+        //   clientes                -> mesa_beneficios_cliente
         let consumacoes = {
           total_consumo_socios: 0,
+          mesa_banda_dj: 0,
+          mesa_rh: 0,
           mesa_adm_casa: 0,
           mesa_beneficios_cliente: 0,
-          mesa_banda_dj: 0,
         };
         try {
           const { data: consumosClassificados, error: consumosError } = await supabase.rpc('get_consumos_classificados_semana', {
@@ -404,19 +412,20 @@ serve(async (req) => {
           if (consumosError) {
             console.error('  ⚠️ Erro ao buscar consumos classificados:', consumosError);
           } else if (consumosClassificados && consumosClassificados.length > 0) {
-            const totais = { socios: 0, artistas: 0, funcionarios: 0, clientes: 0 };
+            const mapField: Record<string, keyof typeof consumacoes> = {
+              socios: 'total_consumo_socios',
+              artistas: 'mesa_banda_dj',
+              funcionarios_operacao: 'mesa_rh',
+              funcionarios_escritorio: 'mesa_adm_casa',
+              clientes: 'mesa_beneficios_cliente',
+            };
             for (const item of consumosClassificados) {
-              const cat = item.categoria as 'socios' | 'artistas' | 'funcionarios' | 'clientes';
+              const cat = item.categoria as string;
+              const field = mapField[cat];
               const valor = parseFloat(String(item.total)) || 0;
-              if (totais[cat] !== undefined) {
-                totais[cat] = valor;
-              }
+              if (field) consumacoes[field] = valor;
             }
-            consumacoes.total_consumo_socios = totais.socios;
-            consumacoes.mesa_banda_dj = totais.artistas;
-            consumacoes.mesa_adm_casa = totais.funcionarios;
-            consumacoes.mesa_beneficios_cliente = totais.clientes;
-            console.log(`  👥 Consumações: Sócios R$ ${totais.socios.toFixed(2)}, Artistas R$ ${totais.artistas.toFixed(2)}, Funcionários R$ ${totais.funcionarios.toFixed(2)}, Clientes R$ ${totais.clientes.toFixed(2)}`);
+            console.log(`  👥 Consumações: Sócios R$ ${consumacoes.total_consumo_socios.toFixed(2)}, Artistas R$ ${consumacoes.mesa_banda_dj.toFixed(2)}, Op R$ ${consumacoes.mesa_rh.toFixed(2)}, Esc R$ ${consumacoes.mesa_adm_casa.toFixed(2)}, Clientes R$ ${consumacoes.mesa_beneficios_cliente.toFixed(2)}`);
           }
         } catch (rpcErr) {
           console.error('  ⚠️ Erro ao chamar RPC get_consumos_classificados_semana:', rpcErr);
@@ -610,8 +619,8 @@ serve(async (req) => {
             consumoSocios = (consumacoes.total_consumo_socios || 0) * fatorConsumo;
             consumoBeneficios = (consumacoes.mesa_beneficios_cliente || 0) * fatorConsumo;
             consumoArtista = (consumacoes.mesa_banda_dj || 0) * fatorConsumo;
-            const consumoAdm = (consumacoes.mesa_adm_casa || 0) * fatorConsumo;
-            consumoRh = consumoAdm; // mesa_adm_casa é o RH quando não vem da planilha
+            // RH = funcionarios_operacao (mesa_rh) + funcionarios_escritorio (mesa_adm_casa)
+            consumoRh = ((consumacoes.mesa_rh || 0) + (consumacoes.mesa_adm_casa || 0)) * fatorConsumo;
           }
           
           const totalConsumos = consumoSocios + consumoBeneficios + consumoArtista + consumoRh + outrosAjustes;
@@ -655,9 +664,10 @@ serve(async (req) => {
           compras_custo_drinks: comprasPorCategoria.drinks,
           // Consumações (valores BRUTOS - multiplicador aplicado no cálculo do CMV)
           total_consumo_socios: consumacoes.total_consumo_socios,
+          mesa_banda_dj: consumacoes.mesa_banda_dj,
+          mesa_rh: consumacoes.mesa_rh,
           mesa_adm_casa: consumacoes.mesa_adm_casa,
           mesa_beneficios_cliente: consumacoes.mesa_beneficios_cliente,
-          mesa_banda_dj: consumacoes.mesa_banda_dj,
           // Propagar estoque inicial da semana anterior (só se não veio da planilha)
           ...estoqueInicialUpdate,
           updated_at: new Date().toISOString()

--- a/database/migrations/2026-05-01-consumos-keywords-arquitetura.sql
+++ b/database/migrations/2026-05-01-consumos-keywords-arquitetura.sql
@@ -1,0 +1,258 @@
+-- 2026-05-01: Auto-classificacao de consumos (5 categorias) com tabela editavel
+--
+-- Substitui regex hardcoded em get_consumos_classificados_semana por lookup
+-- na tabela financial.consumos_keywords (editavel pela equipe RH/Financeiro
+-- via UI sem precisar de migration). Adiciona funcao classificar_consumo()
+-- e get_consumos_sem_categoria_semana() para suportar UI de pendencias.
+--
+-- Categorias: socios, artistas, funcionarios_operacao, funcionarios_escritorio, clientes
+-- (mais '_descartado' para erro abertura, arredondamento, etc.)
+--
+-- Cobertura abril/2026 Ord apos seed: 97.8% itens / 97.4% R$
+--   (vs 94% no regex hardcoded — ganho R$ 3.483/mes)
+--
+-- Validacao S17 Ord:
+--   socios:    R$ 39.95   (bateu manual)
+--   artistas:  R$ 13207
+--   clientes:  R$ 2427
+--   op:        R$ 2344
+--   escrit:    R$ 15
+
+CREATE TABLE IF NOT EXISTS financial.consumos_keywords (
+  id            SERIAL PRIMARY KEY,
+  pattern       TEXT NOT NULL,
+  categoria     TEXT NOT NULL,
+  prioridade    INT NOT NULL DEFAULT 100,
+  bar_id        INT NULL,
+  descricao     TEXT,
+  exemplo       TEXT,
+  ativo         BOOLEAN NOT NULL DEFAULT true,
+  criado_em     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  atualizado_em TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (categoria IN ('socios','artistas','funcionarios_operacao','funcionarios_escritorio','clientes','_descartado'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_consumos_keywords_lookup
+  ON financial.consumos_keywords (prioridade, categoria) WHERE ativo;
+
+COMMENT ON TABLE financial.consumos_keywords IS
+  'Keywords pra classificar consumos do ContaHub. Padrao POSIX regex, comparado contra unaccent(lower(mesa || motivo)). Menor prioridade = avaliada primeiro. bar_id NULL = vale pra todos.';
+
+-- Funcao de classificacao (lookup na tabela)
+CREATE OR REPLACE FUNCTION public.classificar_consumo(
+  p_mesa TEXT, p_motivo TEXT, p_bar_id INT
+)
+RETURNS TEXT
+LANGUAGE sql STABLE AS $$
+  SELECT k.categoria
+  FROM financial.consumos_keywords k
+  WHERE k.ativo
+    AND (k.bar_id IS NULL OR k.bar_id = p_bar_id)
+    AND unaccent(LOWER(p_mesa || ' ' || COALESCE(p_motivo, ''))) ~ k.pattern
+  ORDER BY k.prioridade, k.id
+  LIMIT 1;
+$$;
+
+-- Refatorar get_consumos_classificados_semana pra usar lookup table
+CREATE OR REPLACE FUNCTION public.get_consumos_classificados_semana(
+  input_bar_id integer, input_data_inicio date, input_data_fim date
+)
+RETURNS TABLE(categoria text, total numeric)
+LANGUAGE plpgsql AS $function$
+BEGIN
+  RETURN QUERY
+  WITH periodo_com_motivo AS (
+    SELECT DISTINCT ON (vd_mesadesc) vd_mesadesc as mesa_p, vd_motivodesconto as motivo_p
+    FROM bronze.bronze_contahub_avendas_vendasperiodo
+    WHERE bar_id = input_bar_id
+      AND vd_dtgerencial >= input_data_inicio
+      AND vd_dtgerencial <= input_data_fim
+      AND vd_motivodesconto IS NOT NULL AND vd_motivodesconto != ''
+    ORDER BY vd_mesadesc, vd_dtgerencial DESC
+  ),
+  consumos_com_categoria AS (
+    SELECT
+      ca.desconto,
+      public.classificar_consumo(ca.vd_mesadesc, p.motivo_p, input_bar_id) AS cat
+    FROM bronze.bronze_contahub_avendas_porproduto_analitico ca
+    LEFT JOIN periodo_com_motivo p ON ca.vd_mesadesc = p.mesa_p
+    WHERE ca.bar_id = input_bar_id
+      AND ca.trn_dtgerencial >= input_data_inicio
+      AND ca.trn_dtgerencial <= input_data_fim
+      AND ca.valorfinal = 0 AND ca.desconto > 0
+  )
+  SELECT cat, ROUND(SUM(desconto)::numeric, 2)
+  FROM consumos_com_categoria
+  WHERE cat IS NOT NULL AND cat != '_descartado'
+  GROUP BY cat ORDER BY cat;
+END;
+$function$;
+
+-- Funcao auxiliar pra UI: lista descontos SEM categoria (pra RH classificar)
+CREATE OR REPLACE FUNCTION public.get_consumos_sem_categoria_semana(
+  input_bar_id integer, input_data_inicio date, input_data_fim date
+)
+RETURNS TABLE(mesa text, motivo text, qtd_itens bigint, total_desconto numeric)
+LANGUAGE plpgsql AS $function$
+BEGIN
+  RETURN QUERY
+  WITH periodo_com_motivo AS (
+    SELECT DISTINCT ON (vd_mesadesc) vd_mesadesc as mesa_p, vd_motivodesconto as motivo_p
+    FROM bronze.bronze_contahub_avendas_vendasperiodo
+    WHERE bar_id = input_bar_id
+      AND vd_dtgerencial >= input_data_inicio
+      AND vd_dtgerencial <= input_data_fim
+      AND vd_motivodesconto IS NOT NULL AND vd_motivodesconto != ''
+    ORDER BY vd_mesadesc, vd_dtgerencial DESC
+  )
+  SELECT
+    ca.vd_mesadesc::text,
+    COALESCE(p.motivo_p, '(sem motivo)')::text,
+    COUNT(*),
+    ROUND(SUM(ca.desconto)::numeric, 2)
+  FROM bronze.bronze_contahub_avendas_porproduto_analitico ca
+  LEFT JOIN periodo_com_motivo p ON ca.vd_mesadesc = p.mesa_p
+  WHERE ca.bar_id = input_bar_id
+    AND ca.trn_dtgerencial >= input_data_inicio
+    AND ca.trn_dtgerencial <= input_data_fim
+    AND ca.valorfinal = 0 AND ca.desconto > 0
+    AND public.classificar_consumo(ca.vd_mesadesc, p.motivo_p, input_bar_id) IS NULL
+  GROUP BY 1, 2
+  ORDER BY 4 DESC;
+END;
+$function$;
+
+-- Atualizar agregar_cmv_mensal_auto: 5 categorias (op + esc separados)
+CREATE OR REPLACE FUNCTION public.agregar_cmv_mensal_auto(p_bar_id integer, p_ano integer, p_mes integer)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  v_data_inicio date := make_date(p_ano, p_mes, 1);
+  v_data_fim date := (make_date(p_ano, p_mes, 1) + INTERVAL '1 month' - INTERVAL '1 day')::date;
+  v_compras_comida numeric := 0; v_compras_bebidas numeric := 0;
+  v_compras_drinks numeric := 0; v_compras_outros numeric := 0;
+  v_compras_alim numeric := 0; v_compras_total numeric := 0;
+  v_faturamento numeric := 0; v_comissao numeric := 0; v_couvert numeric := 0;
+  v_fat_cmvivel numeric := 0;
+  v_consumo_socios numeric := 0; v_consumo_clientes numeric := 0;
+  v_consumo_artistas numeric := 0;
+  v_consumo_op numeric := 0; v_consumo_esc numeric := 0;
+  v_consumo_total numeric := 0; v_fator numeric := 1;
+  v_estoque_inicial numeric := 0; v_estoque_final numeric := 0;
+  v_estoque_inicial_func numeric := 0; v_estoque_final_func numeric := 0;
+  v_cmv_real numeric := 0; v_cmv_pct numeric := 0; v_cma_total numeric := 0;
+BEGIN
+  SELECT cmv_fator_consumo::numeric INTO v_fator
+  FROM operations.bar_regras_negocio WHERE bar_id = p_bar_id LIMIT 1;
+  v_fator := COALESCE(v_fator, 1);
+
+  SELECT
+    COALESCE(SUM(valor_bruto) FILTER (WHERE categoria_nome ILIKE '%custo comida%'), 0),
+    COALESCE(SUM(valor_bruto) FILTER (WHERE categoria_nome ILIKE '%custo bebida%'), 0),
+    COALESCE(SUM(valor_bruto) FILTER (WHERE categoria_nome ILIKE '%custo drink%'), 0),
+    COALESCE(SUM(valor_bruto) FILTER (WHERE categoria_nome ILIKE '%custo outros%'), 0),
+    COALESCE(SUM(valor_bruto) FILTER (WHERE categoria_nome ILIKE '%alimenta%'), 0)
+  INTO v_compras_comida, v_compras_bebidas, v_compras_drinks, v_compras_outros, v_compras_alim
+  FROM silver.contaazul_lancamentos_diarios
+  WHERE bar_id = p_bar_id
+    AND data_competencia BETWEEN v_data_inicio AND v_data_fim
+    AND tipo = 'DESPESA';
+
+  v_compras_total := v_compras_comida + v_compras_bebidas + v_compras_drinks + v_compras_outros;
+
+  SELECT COALESCE(SUM(faturamento_total_consolidado), 0) INTO v_faturamento
+  FROM gold.planejamento WHERE bar_id = p_bar_id AND data_evento BETWEEN v_data_inicio AND v_data_fim;
+
+  SELECT comissao, couvert INTO v_comissao, v_couvert
+  FROM public.get_comissao_couvert_periodo(p_bar_id, v_data_inicio, v_data_fim);
+
+  v_fat_cmvivel := v_faturamento - COALESCE(v_comissao, 0) - COALESCE(v_couvert, 0);
+
+  SELECT
+    COALESCE(SUM(total) FILTER (WHERE categoria='socios'), 0) * v_fator,
+    COALESCE(SUM(total) FILTER (WHERE categoria='clientes'), 0) * v_fator,
+    COALESCE(SUM(total) FILTER (WHERE categoria='artistas'), 0) * v_fator,
+    COALESCE(SUM(total) FILTER (WHERE categoria='funcionarios_operacao'), 0) * v_fator,
+    COALESCE(SUM(total) FILTER (WHERE categoria='funcionarios_escritorio'), 0) * v_fator
+  INTO v_consumo_socios, v_consumo_clientes, v_consumo_artistas, v_consumo_op, v_consumo_esc
+  FROM public.get_consumos_classificados_semana(p_bar_id, v_data_inicio, v_data_fim);
+
+  v_consumo_total := v_consumo_socios + v_consumo_clientes + v_consumo_artistas + v_consumo_op + v_consumo_esc;
+
+  SELECT estoque_inicial, estoque_inicial_funcionarios
+  INTO v_estoque_inicial, v_estoque_inicial_func
+  FROM financial.cmv_semanal
+  WHERE bar_id = p_bar_id
+    AND EXTRACT(month FROM (date_trunc('week', make_date(ano, 1, 4)) + ((semana-1)*INTERVAL '1 week') + INTERVAL '3 days')::date) = p_mes
+    AND EXTRACT(year FROM (date_trunc('week', make_date(ano, 1, 4)) + ((semana-1)*INTERVAL '1 week') + INTERVAL '3 days')::date) = p_ano
+  ORDER BY ano ASC, semana ASC LIMIT 1;
+
+  SELECT estoque_final, estoque_final_funcionarios
+  INTO v_estoque_final, v_estoque_final_func
+  FROM financial.cmv_semanal
+  WHERE bar_id = p_bar_id
+    AND EXTRACT(month FROM (date_trunc('week', make_date(ano, 1, 4)) + ((semana-1)*INTERVAL '1 week') + INTERVAL '3 days')::date) = p_mes
+    AND EXTRACT(year FROM (date_trunc('week', make_date(ano, 1, 4)) + ((semana-1)*INTERVAL '1 week') + INTERVAL '3 days')::date) = p_ano
+    AND estoque_final > 0
+  ORDER BY ano DESC, semana DESC LIMIT 1;
+
+  v_estoque_inicial := COALESCE(v_estoque_inicial, 0);
+  v_estoque_final := COALESCE(v_estoque_final, 0);
+  v_estoque_inicial_func := COALESCE(v_estoque_inicial_func, 0);
+  v_estoque_final_func := COALESCE(v_estoque_final_func, 0);
+
+  v_cmv_real := v_estoque_inicial + v_compras_total - v_estoque_final - v_consumo_total;
+  v_cmv_pct := CASE WHEN v_fat_cmvivel > 0 THEN (v_cmv_real / v_fat_cmvivel * 100) ELSE 0 END;
+  v_cma_total := v_compras_alim + v_estoque_inicial_func - v_estoque_final_func;
+
+  INSERT INTO financial.cmv_mensal (
+    bar_id, ano, mes, data_inicio, data_fim,
+    estoque_inicial, estoque_final,
+    compras, compras_alimentacao,
+    consumo_socios, consumo_beneficios, consumo_rh_operacao, consumo_rh_escritorio, consumo_artista,
+    cmv_real, faturamento_cmvivel, cmv_real_percentual, cmv_limpo_percentual,
+    faturamento_total,
+    estoque_inicial_funcionarios, estoque_final_funcionarios, cma_total,
+    fonte, updated_at, created_at
+  ) VALUES (
+    p_bar_id, p_ano, p_mes, v_data_inicio, v_data_fim,
+    v_estoque_inicial, v_estoque_final,
+    v_compras_total, v_compras_alim,
+    v_consumo_socios, v_consumo_clientes, v_consumo_op, v_consumo_esc, v_consumo_artistas,
+    v_cmv_real, v_fat_cmvivel, v_cmv_pct, v_cmv_pct,
+    v_faturamento,
+    v_estoque_inicial_func, v_estoque_final_func, v_cma_total,
+    'auto-agregado', NOW(), NOW()
+  )
+  ON CONFLICT (bar_id, ano, mes) DO UPDATE SET
+    data_inicio = EXCLUDED.data_inicio,
+    data_fim = EXCLUDED.data_fim,
+    estoque_inicial = EXCLUDED.estoque_inicial,
+    estoque_final = EXCLUDED.estoque_final,
+    compras = EXCLUDED.compras,
+    compras_alimentacao = EXCLUDED.compras_alimentacao,
+    consumo_socios = EXCLUDED.consumo_socios,
+    consumo_beneficios = EXCLUDED.consumo_beneficios,
+    consumo_rh_operacao = EXCLUDED.consumo_rh_operacao,
+    consumo_rh_escritorio = EXCLUDED.consumo_rh_escritorio,
+    consumo_artista = EXCLUDED.consumo_artista,
+    cmv_real = EXCLUDED.cmv_real,
+    faturamento_cmvivel = EXCLUDED.faturamento_cmvivel,
+    cmv_real_percentual = EXCLUDED.cmv_real_percentual,
+    cmv_limpo_percentual = EXCLUDED.cmv_limpo_percentual,
+    faturamento_total = EXCLUDED.faturamento_total,
+    estoque_inicial_funcionarios = EXCLUDED.estoque_inicial_funcionarios,
+    estoque_final_funcionarios = EXCLUDED.estoque_final_funcionarios,
+    cma_total = EXCLUDED.cma_total,
+    fonte = EXCLUDED.fonte,
+    updated_at = NOW();
+END;
+$function$;
+
+-- Seed inicial: 109 keywords (consolidando regex hardcoded + novos padroes
+-- encontrados na auditoria abril/2026 — Reconvexa, Pagode da Gigi, Permuta
+-- bistro, Isaias, despedida solteiro, social midia sem acento, etc).
+-- Aplicado direto via UI/MCP — apply_migration. Ver historico em
+-- consumos_keywords_seed_v1.sql se precisar replicar em outro ambiente.


### PR DESCRIPTION
## Summary
- Substitui regex hardcoded por lookup em `financial.consumos_keywords` (109 keywords) — RH/Financeiro pode adicionar padrões via UI sem migration.
- Separa `funcionarios_operacao` e `funcionarios_escritorio` (antes era um bloco só), populando `mesa_rh` e `mesa_adm_casa` em `cmv_semanal` (estavam zerados).
- Edge function `cmv-semanal-auto` mapeia 5 categorias.
- `agregar_cmv_mensal_auto` separa `consumo_rh_operacao` e `consumo_rh_escritorio`.
- Cobertura abril/2026 Ord: **94% → 97.8%** (–R$ 3.483 sem-padrão).
- S17 Ord validado: sócios R$ 39,95 bate manual.

## Mudanças no banco (já aplicadas via MCP)
- Tabela `financial.consumos_keywords` (109 rows seeded)
- `public.classificar_consumo(mesa, motivo, bar_id)` — lookup ordenado por prioridade
- `public.get_consumos_classificados_semana()` refatorada
- `public.get_consumos_sem_categoria_semana()` — nova, suporta UI de pendências
- `public.agregar_cmv_mensal_auto()` — 5 categorias
- UPDATE retroativo: `cmv_semanal` 2026 Ord+Deb e `cmv_mensal` abril/2026

## Test plan
- [x] S17 Ord: sócios R$ 39,95 bate manual
- [x] abril/2026 Ord: rh_operacao R$ 2.975 (era 0) + rh_escritorio R$ 359 (era 0)
- [x] abril/2026 Deb: rh_operacao R$ 820 + rh_escritorio R$ 1.349
- [ ] Deploy edge function cmv-semanal-auto
- [ ] Validar próximo cron (executa diariamente)

## Próximos passos
- UI em /ferramentas pra RH classificar pendências (task #91, PR separado)
- Alerta Discord se cobertura < 95% (task #92)

🤖 Generated with [Claude Code](https://claude.com/claude-code)