### PR TITLE
feat(ferramentas): UI classificacao de consumos (#91)

### DIFF
--- a/frontend/src/app/api/cmv-semanal/consumos-classificacao/keywords/[id]/route.ts
+++ b/frontend/src/app/api/cmv-semanal/consumos-classificacao/keywords/[id]/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const { ativo, pattern, categoria, descricao } = body;
+
+    const update: any = { atualizado_em: new Date().toISOString() };
+    if (typeof ativo === 'boolean') update.ativo = ativo;
+    if (pattern) update.pattern = pattern.toLowerCase().trim();
+    if (categoria) update.categoria = categoria;
+    if (descricao !== undefined) update.descricao = descricao;
+
+    const { data, error } = await supabase
+      .schema('financial' as any)
+      .from('consumos_keywords')
+      .update(update)
+      .eq('id', parseInt(id))
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    return NextResponse.json({ keyword: data });
+  } catch (err: any) {
+    console.error('Erro PATCH keyword:', err);
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const { error } = await supabase
+      .schema('financial' as any)
+      .from('consumos_keywords')
+      .delete()
+      .eq('id', parseInt(id));
+
+    if (error) throw error;
+
+    return NextResponse.json({ ok: true });
+  } catch (err: any) {
+    console.error('Erro DELETE keyword:', err);
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/cmv-semanal/consumos-classificacao/keywords/route.ts
+++ b/frontend/src/app/api/cmv-semanal/consumos-classificacao/keywords/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+const CATEGORIAS_VALIDAS = [
+  'socios','artistas','funcionarios_operacao','funcionarios_escritorio','clientes','_descartado'
+];
+
+const PRIORIDADE_DEFAULT: Record<string, number> = {
+  '_descartado': 10,
+  'socios': 20,
+  'artistas': 30,
+  'funcionarios_operacao': 40,
+  'funcionarios_escritorio': 50,
+  'clientes': 60,
+};
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const includeInactive = searchParams.get('include_inactive') === 'true';
+
+    let query = supabase
+      .schema('financial' as any)
+      .from('consumos_keywords')
+      .select('*')
+      .order('prioridade', { ascending: true })
+      .order('id', { ascending: true });
+
+    if (!includeInactive) {
+      query = query.eq('ativo', true);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    return NextResponse.json({ keywords: data || [] });
+  } catch (err: any) {
+    console.error('Erro GET keywords:', err);
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { pattern, categoria, descricao, exemplo, bar_id } = body;
+
+    if (!pattern || !categoria) {
+      return NextResponse.json({ error: 'pattern e categoria sao obrigatorios' }, { status: 400 });
+    }
+
+    if (!CATEGORIAS_VALIDAS.includes(categoria)) {
+      return NextResponse.json({ error: `categoria invalida. Use: ${CATEGORIAS_VALIDAS.join(', ')}` }, { status: 400 });
+    }
+
+    const prioridade = PRIORIDADE_DEFAULT[categoria] ?? 100;
+
+    const { data, error } = await supabase
+      .schema('financial' as any)
+      .from('consumos_keywords')
+      .insert({
+        pattern: pattern.toLowerCase().trim(),
+        categoria,
+        prioridade,
+        descricao: descricao || null,
+        exemplo: exemplo || null,
+        bar_id: bar_id || null,
+        ativo: true,
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    return NextResponse.json({ keyword: data });
+  } catch (err: any) {
+    console.error('Erro POST keyword:', err);
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/cmv-semanal/consumos-classificacao/route.ts
+++ b/frontend/src/app/api/cmv-semanal/consumos-classificacao/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+function getWeekDateRange(year: number, week: number) {
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4Day = jan4.getUTCDay() || 7;
+  const week1Monday = new Date(jan4);
+  week1Monday.setUTCDate(jan4.getUTCDate() - (jan4Day - 1));
+  const start = new Date(week1Monday);
+  start.setUTCDate(week1Monday.getUTCDate() + (week - 1) * 7);
+  const end = new Date(start);
+  end.setUTCDate(start.getUTCDate() + 6);
+  const fmt = (d: Date) => d.toISOString().split('T')[0];
+  return { start: fmt(start), end: fmt(end) };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const barId = parseInt(searchParams.get('bar_id') || '0');
+    const ano = parseInt(searchParams.get('ano') || String(new Date().getFullYear()));
+    const semana = parseInt(searchParams.get('semana') || '0');
+
+    if (!barId || !semana) {
+      return NextResponse.json({ error: 'bar_id e semana sao obrigatorios' }, { status: 400 });
+    }
+
+    const { start, end } = getWeekDateRange(ano, semana);
+
+    // Pendencias (sem categoria)
+    const { data: pendencias, error: errPend } = await supabase.rpc('get_consumos_sem_categoria_semana', {
+      input_bar_id: barId,
+      input_data_inicio: start,
+      input_data_fim: end,
+    });
+    if (errPend) throw errPend;
+
+    // Categorizado (pra calcular cobertura)
+    const { data: categorizado, error: errCat } = await supabase.rpc('get_consumos_classificados_semana', {
+      input_bar_id: barId,
+      input_data_inicio: start,
+      input_data_fim: end,
+    });
+    if (errCat) throw errCat;
+
+    const totalCategorizado = (categorizado || []).reduce(
+      (sum: number, r: any) => sum + (parseFloat(r.total) || 0), 0
+    );
+    const totalSemPadrao = (pendencias || []).reduce(
+      (sum: number, r: any) => sum + (parseFloat(r.total_desconto) || 0), 0
+    );
+    const totalGeral = totalCategorizado + totalSemPadrao;
+    const pctCobertura = totalGeral > 0 ? (totalCategorizado / totalGeral) * 100 : 100;
+
+    return NextResponse.json({
+      periodo: { ano, semana, data_inicio: start, data_fim: end },
+      cobertura: {
+        total_categorizado: totalCategorizado,
+        total_sem_padrao: totalSemPadrao,
+        total_geral: totalGeral,
+        pct_cobertura: Math.round(pctCobertura * 100) / 100,
+      },
+      categorizado: categorizado || [],
+      pendencias: pendencias || [],
+    });
+  } catch (err: any) {
+    console.error('Erro GET consumos-classificacao:', err);
+    return NextResponse.json({ error: err.message || 'Erro ao buscar' }, { status: 500 });
+  }
+}

--- a/frontend/src/app/ferramentas/consumos-classificacao/page.tsx
+++ b/frontend/src/app/ferramentas/consumos-classificacao/page.tsx
@@ -1,0 +1,465 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Switch } from '@/components/ui/switch';
+import { Tag, RefreshCw, Plus, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { usePageTitle } from '@/contexts/PageTitleContext';
+import { useBar } from '@/contexts/BarContext';
+import { toast } from 'sonner';
+
+interface Pendencia {
+  mesa: string;
+  motivo: string;
+  qtd_itens: number;
+  total_desconto: number;
+}
+
+interface Categorizado {
+  categoria: string;
+  total: number;
+}
+
+interface Cobertura {
+  total_categorizado: number;
+  total_sem_padrao: number;
+  total_geral: number;
+  pct_cobertura: number;
+}
+
+interface Keyword {
+  id: number;
+  pattern: string;
+  categoria: string;
+  prioridade: number;
+  bar_id: number | null;
+  descricao: string | null;
+  exemplo: string | null;
+  ativo: boolean;
+}
+
+const CATEGORIAS = [
+  { value: 'socios', label: 'Sócios', color: 'bg-purple-500/10 text-purple-700 dark:text-purple-300' },
+  { value: 'artistas', label: 'Artistas', color: 'bg-pink-500/10 text-pink-700 dark:text-pink-300' },
+  { value: 'funcionarios_operacao', label: 'Funcionários (Operação)', color: 'bg-blue-500/10 text-blue-700 dark:text-blue-300' },
+  { value: 'funcionarios_escritorio', label: 'Funcionários (Escritório)', color: 'bg-indigo-500/10 text-indigo-700 dark:text-indigo-300' },
+  { value: 'clientes', label: 'Clientes (Benefícios)', color: 'bg-green-500/10 text-green-700 dark:text-green-300' },
+  { value: '_descartado', label: 'Descartar', color: 'bg-gray-500/10 text-gray-700 dark:text-gray-300' },
+];
+
+function getCategoriaInfo(cat: string) {
+  return CATEGORIAS.find(c => c.value === cat) || { label: cat, color: 'bg-gray-100 text-gray-700' };
+}
+
+function getCurrentWeek(): number {
+  const d = new Date();
+  const start = new Date(d.getFullYear(), 0, 1);
+  const diff = (d.getTime() - start.getTime()) / 86400000;
+  return Math.ceil((diff + start.getDay() + 1) / 7);
+}
+
+function fmtBRL(v: number) {
+  return v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+export default function ConsumosClassificacaoPage() {
+  const { setPageTitle } = usePageTitle();
+  const { selectedBar } = useBar();
+
+  const [ano, setAno] = useState(new Date().getFullYear());
+  const [semana, setSemana] = useState(getCurrentWeek());
+  const [loading, setLoading] = useState(false);
+
+  const [cobertura, setCobertura] = useState<Cobertura | null>(null);
+  const [categorizado, setCategorizado] = useState<Categorizado[]>([]);
+  const [pendencias, setPendencias] = useState<Pendencia[]>([]);
+  const [keywords, setKeywords] = useState<Keyword[]>([]);
+  const [showInactive, setShowInactive] = useState(false);
+
+  // Modal de atribuir categoria
+  const [modalOpen, setModalOpen] = useState(false);
+  const [pendSelecionada, setPendSelecionada] = useState<Pendencia | null>(null);
+  const [novoPattern, setNovoPattern] = useState('');
+  const [novaCategoria, setNovaCategoria] = useState('clientes');
+  const [novaDescricao, setNovaDescricao] = useState('');
+
+  useEffect(() => {
+    setPageTitle('🏷️ Classificação de Consumos');
+    return () => setPageTitle('');
+  }, [setPageTitle]);
+
+  const buscarDados = useCallback(async () => {
+    if (!selectedBar?.id) return;
+    setLoading(true);
+    try {
+      const [resPend, resKw] = await Promise.all([
+        fetch(`/api/cmv-semanal/consumos-classificacao?bar_id=${selectedBar.id}&ano=${ano}&semana=${semana}`),
+        fetch(`/api/cmv-semanal/consumos-classificacao/keywords?include_inactive=${showInactive}`),
+      ]);
+
+      const [dataPend, dataKw] = await Promise.all([resPend.json(), resKw.json()]);
+
+      if (resPend.ok) {
+        setCobertura(dataPend.cobertura);
+        setCategorizado(dataPend.categorizado);
+        setPendencias(dataPend.pendencias);
+      } else {
+        toast.error('Erro ao buscar pendências: ' + dataPend.error);
+      }
+
+      if (resKw.ok) {
+        setKeywords(dataKw.keywords);
+      } else {
+        toast.error('Erro ao buscar keywords: ' + dataKw.error);
+      }
+    } catch (e: any) {
+      toast.error('Erro: ' + e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedBar, ano, semana, showInactive]);
+
+  useEffect(() => {
+    buscarDados();
+  }, [buscarDados]);
+
+  const abrirModalAtribuir = (pend: Pendencia) => {
+    setPendSelecionada(pend);
+    // Sugerir pattern: motivo (sem espaços extras, em lowercase, sem pontuação)
+    const sugestao = (pend.motivo !== '(sem motivo)' ? pend.motivo : pend.mesa)
+      .toLowerCase()
+      .replace(/[^a-záàâãéèêíïóôõöúüç0-9 ]/gi, '')
+      .trim();
+    setNovoPattern(sugestao);
+    setNovaCategoria('clientes');
+    setNovaDescricao(`Aprendido de "${pend.motivo}" / mesa "${pend.mesa}"`);
+    setModalOpen(true);
+  };
+
+  const salvarKeyword = async () => {
+    if (!novoPattern.trim()) {
+      toast.error('Pattern é obrigatório');
+      return;
+    }
+    try {
+      const res = await fetch('/api/cmv-semanal/consumos-classificacao/keywords', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          pattern: novoPattern,
+          categoria: novaCategoria,
+          descricao: novaDescricao,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        toast.success('Keyword adicionada — recarregando...');
+        setModalOpen(false);
+        await buscarDados();
+      } else {
+        toast.error('Erro: ' + data.error);
+      }
+    } catch (e: any) {
+      toast.error('Erro: ' + e.message);
+    }
+  };
+
+  const toggleAtivo = async (kw: Keyword) => {
+    try {
+      const res = await fetch(`/api/cmv-semanal/consumos-classificacao/keywords/${kw.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ativo: !kw.ativo }),
+      });
+      if (res.ok) {
+        toast.success(`Keyword ${!kw.ativo ? 'ativada' : 'desativada'}`);
+        await buscarDados();
+      } else {
+        const data = await res.json();
+        toast.error('Erro: ' + data.error);
+      }
+    } catch (e: any) {
+      toast.error('Erro: ' + e.message);
+    }
+  };
+
+  const corCobertura =
+    !cobertura ? 'text-gray-500' :
+    cobertura.pct_cobertura >= 95 ? 'text-green-600 dark:text-green-400' :
+    cobertura.pct_cobertura >= 90 ? 'text-yellow-600 dark:text-yellow-400' :
+    'text-red-600 dark:text-red-400';
+
+  const keywordsAgrupadas = CATEGORIAS.map(cat => ({
+    ...cat,
+    items: keywords.filter(k => k.categoria === cat.value),
+  })).filter(g => g.items.length > 0);
+
+  return (
+    <div className="container mx-auto p-4 space-y-4">
+      {/* Filtros */}
+      <Card>
+        <CardContent className="pt-4">
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="space-y-1">
+              <Label className="text-xs">Ano</Label>
+              <Input type="number" value={ano} onChange={(e) => setAno(parseInt(e.target.value) || ano)} className="w-24" />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Semana</Label>
+              <Input type="number" value={semana} onChange={(e) => setSemana(parseInt(e.target.value) || semana)} className="w-24" min={1} max={53} />
+            </div>
+            <Button onClick={buscarDados} disabled={loading} variant="outline" size="sm">
+              <RefreshCw className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+              Atualizar
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Cobertura */}
+      {cobertura && (
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+          <Card>
+            <CardContent className="pt-4">
+              <div className="text-xs text-muted-foreground">Cobertura</div>
+              <div className={`text-2xl font-bold ${corCobertura}`}>
+                {cobertura.pct_cobertura.toFixed(1)}%
+              </div>
+              <div className="text-xs text-muted-foreground mt-1">
+                {cobertura.pct_cobertura >= 95 ? (
+                  <span className="inline-flex items-center gap-1 text-green-600"><CheckCircle2 className="h-3 w-3" /> Excelente</span>
+                ) : cobertura.pct_cobertura >= 90 ? (
+                  <span className="inline-flex items-center gap-1 text-yellow-600"><AlertTriangle className="h-3 w-3" /> Atenção</span>
+                ) : (
+                  <span className="inline-flex items-center gap-1 text-red-600"><AlertTriangle className="h-3 w-3" /> Crítico</span>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-4">
+              <div className="text-xs text-muted-foreground">Categorizado</div>
+              <div className="text-2xl font-bold">{fmtBRL(cobertura.total_categorizado)}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-4">
+              <div className="text-xs text-muted-foreground">Sem Padrão</div>
+              <div className={`text-2xl font-bold ${cobertura.total_sem_padrao > 0 ? 'text-orange-600' : 'text-green-600'}`}>
+                {fmtBRL(cobertura.total_sem_padrao)}
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-4">
+              <div className="text-xs text-muted-foreground">Total Descontos</div>
+              <div className="text-2xl font-bold">{fmtBRL(cobertura.total_geral)}</div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Tabs */}
+      <Tabs defaultValue="pendencias" className="w-full">
+        <TabsList>
+          <TabsTrigger value="pendencias">
+            Pendências da Semana
+            {pendencias.length > 0 && (
+              <Badge variant="destructive" className="ml-2">{pendencias.length}</Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="categorizado">Por Categoria</TabsTrigger>
+          <TabsTrigger value="keywords">
+            Keywords Cadastradas
+            <Badge variant="secondary" className="ml-2">{keywords.length}</Badge>
+          </TabsTrigger>
+        </TabsList>
+
+        {/* Pendências */}
+        <TabsContent value="pendencias" className="space-y-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Consumos sem categoria — semana {semana}/{ano}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {pendencias.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground">
+                  <CheckCircle2 className="h-12 w-12 mx-auto text-green-500 mb-2" />
+                  <p>Nenhum consumo sem categoria nessa semana 🎉</p>
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b">
+                        <th className="text-left py-2 px-2">Mesa</th>
+                        <th className="text-left py-2 px-2">Motivo</th>
+                        <th className="text-right py-2 px-2">Itens</th>
+                        <th className="text-right py-2 px-2">R$</th>
+                        <th className="text-right py-2 px-2">Ação</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {pendencias.map((p, i) => (
+                        <tr key={i} className="border-b hover:bg-muted/50">
+                          <td className="py-2 px-2 font-mono text-xs">{p.mesa}</td>
+                          <td className="py-2 px-2">{p.motivo}</td>
+                          <td className="py-2 px-2 text-right">{p.qtd_itens}</td>
+                          <td className="py-2 px-2 text-right font-mono">{fmtBRL(p.total_desconto)}</td>
+                          <td className="py-2 px-2 text-right">
+                            <Button size="sm" variant="outline" onClick={() => abrirModalAtribuir(p)}>
+                              <Tag className="h-3 w-3 mr-1" />
+                              Atribuir
+                            </Button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Categorizado */}
+        <TabsContent value="categorizado">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Distribuição por categoria — semana {semana}/{ano}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2">
+                {categorizado.map((c) => {
+                  const info = getCategoriaInfo(c.categoria);
+                  return (
+                    <div key={c.categoria} className="flex items-center justify-between p-3 rounded-lg bg-muted/30">
+                      <Badge className={info.color}>{info.label}</Badge>
+                      <span className="font-mono font-semibold">{fmtBRL(parseFloat(String(c.total)))}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Keywords */}
+        <TabsContent value="keywords">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle className="text-base">Keywords cadastradas</CardTitle>
+              <div className="flex items-center gap-2">
+                <Label className="text-xs">Mostrar inativas</Label>
+                <Switch checked={showInactive} onCheckedChange={setShowInactive} />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                {keywordsAgrupadas.map((g) => (
+                  <div key={g.value}>
+                    <div className="flex items-center gap-2 mb-2">
+                      <Badge className={g.color}>{g.label}</Badge>
+                      <span className="text-xs text-muted-foreground">({g.items.length})</span>
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+                      {g.items.map((kw) => (
+                        <div key={kw.id} className={`p-2 rounded border text-xs ${kw.ativo ? 'bg-card' : 'bg-muted/30 opacity-60'}`}>
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="flex-1 min-w-0">
+                              <code className="font-mono text-xs break-all">{kw.pattern}</code>
+                              {kw.descricao && (
+                                <div className="text-muted-foreground text-[10px] mt-1 truncate" title={kw.descricao}>
+                                  {kw.descricao}
+                                </div>
+                              )}
+                            </div>
+                            <Switch checked={kw.ativo} onCheckedChange={() => toggleAtivo(kw)} />
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      {/* Modal de atribuir categoria */}
+      <Dialog open={modalOpen} onOpenChange={setModalOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Atribuir categoria</DialogTitle>
+            <DialogDescription>
+              {pendSelecionada && (
+                <>
+                  Mesa <code className="text-xs">{pendSelecionada.mesa}</code> /
+                  motivo <strong>{pendSelecionada.motivo}</strong> /
+                  R$ {pendSelecionada.total_desconto}
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label className="text-xs">Pattern (regex POSIX, sem acento, lowercase)</Label>
+              <Input value={novoPattern} onChange={(e) => setNovoPattern(e.target.value)} />
+              <p className="text-[10px] text-muted-foreground">
+                Use boundaries <code>\m</code>/<code>\M</code> pra evitar falsos matches em nomes curtos
+                (ex: <code>\mana\M</code> só pega "ana", não "banana").
+              </p>
+            </div>
+
+            <div className="space-y-1">
+              <Label className="text-xs">Categoria</Label>
+              <Select value={novaCategoria} onValueChange={setNovaCategoria}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {CATEGORIAS.map((c) => (
+                    <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1">
+              <Label className="text-xs">Descrição (opcional)</Label>
+              <Input value={novaDescricao} onChange={(e) => setNovaDescricao(e.target.value)} />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setModalOpen(false)}>Cancelar</Button>
+            <Button onClick={salvarKeyword}>
+              <Plus className="h-4 w-4 mr-1" />
+              Adicionar Keyword
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/app/ferramentas/consumos-classificacao/page.tsx
+++ b/frontend/src/app/ferramentas/consumos-classificacao/page.tsx
@@ -429,7 +429,7 @@ export default function ConsumosClassificacaoPage() {
               <Input value={novoPattern} onChange={(e) => setNovoPattern(e.target.value)} />
               <p className="text-[10px] text-muted-foreground">
                 Use boundaries <code>\m</code>/<code>\M</code> pra evitar falsos matches em nomes curtos
-                (ex: <code>\mana\M</code> só pega "ana", não "banana").
+                (ex: <code>\mana\M</code> só pega &quot;ana&quot;, não &quot;banana&quot;).
               </p>
             </div>
 

--- a/frontend/src/app/ferramentas/page.tsx
+++ b/frontend/src/app/ferramentas/page.tsx
@@ -31,7 +31,8 @@ import {
   Terminal,
   Coffee,
   Wallet,
-  Megaphone
+  Megaphone,
+  Tag
 } from 'lucide-react';
 import Link from 'next/link';
 
@@ -118,6 +119,22 @@ export default function FerramentasPage() {
       buttonBorderColor: 'border-emerald-500 dark:border-emerald-700',
       buttonTextColor: 'text-emerald-600 dark:text-emerald-400',
       features: 'Tabela CMV • Visualização • Análise Semanal',
+      status: 'active'
+    },
+    // Classificação de Consumos
+    {
+      title: 'Classificação de Consumos',
+      description: 'Auto-classificação dos descontos do ContaHub (5 categorias) + revisão de pendências',
+      icon: Tag,
+      href: '/ferramentas/consumos-classificacao',
+      badge: 'Novo',
+      badgeColor: 'border-amber-200 text-amber-700 dark:border-amber-700 dark:text-amber-300',
+      iconBgColor: 'bg-amber-100 dark:bg-amber-900/30',
+      iconTextColor: 'text-amber-600 dark:text-amber-400',
+      buttonBgColor: 'bg-amber-500/10 dark:bg-amber-900/20',
+      buttonBorderColor: 'border-amber-500 dark:border-amber-700',
+      buttonTextColor: 'text-amber-600 dark:text-amber-400',
+      features: 'Pendências • Keywords • Cobertura semanal',
       status: 'active'
     },
     // DRE


### PR DESCRIPTION
## Summary
Tela em /ferramentas/consumos-classificacao pra RH classificar pendências sem mexer em SQL — fecha o loop da arquitetura entregue no PR #62.

- Card de cobertura semanal (% categorizado / R$ sem-padrão)
- Aba "Pendências": lista com botão "Atribuir" → modal sugere pattern + escolhe categoria
- Aba "Por Categoria": distribuição visual da semana
- Aba "Keywords Cadastradas": 109 keywords agrupadas por categoria com toggle ativo
- Tile no /ferramentas com badge "Novo"

## API routes criadas
- `GET /api/cmv-semanal/consumos-classificacao` — pendências + cobertura
- `GET/POST /api/cmv-semanal/consumos-classificacao/keywords`
- `PATCH/DELETE /api/cmv-semanal/consumos-classificacao/keywords/[id]`

## Test plan
- [x] tsc passou sem erros
- [ ] Abrir /ferramentas/consumos-classificacao — semana 17 Ord deve mostrar 97,8% cobertura
- [ ] Atribuir keyword nova de teste e validar que cobertura sobe

🤖 Generated with [Claude Code](https://claude.com/claude-code)