### PR TITLE
feat(sidebar): adicionar Classificacao de Consumos no menu

### DIFF
--- a/frontend/src/components/layouts/MinimalSidebar.tsx
+++ b/frontend/src/components/layouts/MinimalSidebar.tsx
@@ -103,6 +103,7 @@ const defaultSidebarItems: SidebarItem[] = [
       { icon: Users, label: 'NPS Funcionários', href: '/ferramentas/nps', permission: 'gestao' },
       { icon: MessageCircle, label: 'Voz do Cliente', href: '/ferramentas/voz-cliente', permission: 'gestao' },
       { icon: TrendingUp, label: 'CMV Semanal', href: '/ferramentas/cmv-semanal', permission: 'gestao' },
+      { icon: Tag, label: 'Classificação de Consumos', href: '/ferramentas/consumos-classificacao', permission: 'gestao' },
       { icon: ChefHat, label: 'CMA - Alimentação', href: '/ferramentas/cma-semanal', permission: 'gestao' },
       // CMO removido — feature não implementada
       { icon: AlertTriangle, label: 'Stockout', href: '/ferramentas/stockout', permission: 'gestao' },

--- a/frontend/src/components/layouts/ModernSidebarOptimized.tsx
+++ b/frontend/src/components/layouts/ModernSidebarOptimized.tsx
@@ -178,6 +178,7 @@ const defaultSidebarItems: SidebarItem[] = [
       { icon: Calendar, label: 'Agendamento', href: '/ferramentas/agendamento', permission: 'financeiro_agendamento' },
       { icon: Users, label: 'NPS Funcionários', href: '/ferramentas/nps', permission: 'gestao' },
       { icon: MessageCircle, label: 'Voz do Cliente', href: '/ferramentas/voz-cliente', permission: 'gestao' },
+      { icon: Tag, label: 'Classificação de Consumos', href: '/ferramentas/consumos-classificacao', permission: 'gestao' },
       { icon: ChefHat, label: 'CMA - Alimentação', href: '/ferramentas/cma-semanal', permission: 'gestao' },
     ],
   },


### PR DESCRIPTION
Adiciona link no drawer Ferramentas (ModernSidebarOptimized + MinimalSidebar). Estava faltando após o PR #63 — só o tile na página /ferramentas tinha sido adicionado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)