### PR TITLE
feat(consumos): drill-down modal por categoria + Diego=operacao

### DIFF
--- a/database/migrations/2026-05-01-consumos-detalhes-categoria-rpc.sql
+++ b/database/migrations/2026-05-01-consumos-detalhes-categoria-rpc.sql
@@ -1,0 +1,49 @@
+-- 2026-05-01: RPC pra drill-down dos consumos por categoria
+--
+-- Suporta UI de /ferramentas/consumos-classificacao - aba "Por Categoria"
+-- com modal que lista mesa | motivo | qtd | valor | data, ordenado data DESC.
+
+CREATE OR REPLACE FUNCTION public.get_consumos_detalhes_categoria(
+  input_bar_id integer,
+  input_data_inicio date,
+  input_data_fim date,
+  input_categoria text
+)
+RETURNS TABLE(data date, mesa text, motivo text, qtd_itens bigint, valor numeric)
+LANGUAGE plpgsql AS $$
+BEGIN
+  RETURN QUERY
+  WITH periodo_com_motivo AS (
+    SELECT DISTINCT ON (vd_mesadesc) vd_mesadesc as mesa_p, vd_motivodesconto as motivo_p
+    FROM bronze.bronze_contahub_avendas_vendasperiodo
+    WHERE bar_id = input_bar_id
+      AND vd_dtgerencial >= input_data_inicio
+      AND vd_dtgerencial <= input_data_fim
+      AND vd_motivodesconto IS NOT NULL AND vd_motivodesconto != ''
+    ORDER BY vd_mesadesc, vd_dtgerencial DESC
+  )
+  SELECT
+    ca.trn_dtgerencial::date AS data,
+    ca.vd_mesadesc::text AS mesa,
+    COALESCE(p.motivo_p, '(sem motivo)')::text AS motivo,
+    COUNT(*)::bigint AS qtd_itens,
+    ROUND(SUM(ca.desconto)::numeric, 2) AS valor
+  FROM bronze.bronze_contahub_avendas_porproduto_analitico ca
+  LEFT JOIN periodo_com_motivo p ON ca.vd_mesadesc = p.mesa_p
+  WHERE ca.bar_id = input_bar_id
+    AND ca.trn_dtgerencial >= input_data_inicio
+    AND ca.trn_dtgerencial <= input_data_fim
+    AND ca.valorfinal = 0 AND ca.desconto > 0
+    AND public.classificar_consumo(ca.vd_mesadesc, p.motivo_p, input_bar_id) = input_categoria
+  GROUP BY ca.trn_dtgerencial, ca.vd_mesadesc, p.motivo_p
+  ORDER BY ca.trn_dtgerencial DESC, valor DESC;
+END;
+$$;
+
+-- Override: Diego = funcionario de operacao (NAO socio, mesmo se garcom marcar errado)
+-- Prioridade 5 garante avaliacao antes do regex \msocio\M (prioridade 20)
+DELETE FROM financial.consumos_keywords WHERE pattern='diego' AND categoria='socios';
+INSERT INTO financial.consumos_keywords (pattern, categoria, prioridade, descricao)
+VALUES ('diego', 'funcionarios_operacao', 5,
+  'Funcionario Diego (Ord). Override prio 5 garante que cai em operacao mesmo se garcom marcar como Socio.')
+ON CONFLICT DO NOTHING;

--- a/frontend/src/app/api/cmv-semanal/consumos-classificacao/detalhes/route.ts
+++ b/frontend/src/app/api/cmv-semanal/consumos-classificacao/detalhes/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+function getWeekDateRange(year: number, week: number) {
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4Day = jan4.getUTCDay() || 7;
+  const week1Monday = new Date(jan4);
+  week1Monday.setUTCDate(jan4.getUTCDate() - (jan4Day - 1));
+  const start = new Date(week1Monday);
+  start.setUTCDate(week1Monday.getUTCDate() + (week - 1) * 7);
+  const end = new Date(start);
+  end.setUTCDate(start.getUTCDate() + 6);
+  const fmt = (d: Date) => d.toISOString().split('T')[0];
+  return { start: fmt(start), end: fmt(end) };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const barId = parseInt(searchParams.get('bar_id') || '0');
+    const ano = parseInt(searchParams.get('ano') || String(new Date().getFullYear()));
+    const semana = parseInt(searchParams.get('semana') || '0');
+    const categoria = searchParams.get('categoria') || '';
+
+    if (!barId || !semana || !categoria) {
+      return NextResponse.json({ error: 'bar_id, semana e categoria sao obrigatorios' }, { status: 400 });
+    }
+
+    const { start, end } = getWeekDateRange(ano, semana);
+
+    const { data, error } = await supabase.rpc('get_consumos_detalhes_categoria', {
+      input_bar_id: barId,
+      input_data_inicio: start,
+      input_data_fim: end,
+      input_categoria: categoria,
+    });
+
+    if (error) throw error;
+
+    return NextResponse.json({
+      categoria,
+      periodo: { ano, semana, data_inicio: start, data_fim: end },
+      itens: data || [],
+    });
+  } catch (err: any) {
+    console.error('Erro GET detalhes:', err);
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/frontend/src/app/ferramentas/consumos-classificacao/page.tsx
+++ b/frontend/src/app/ferramentas/consumos-classificacao/page.tsx
@@ -47,6 +47,14 @@ interface Cobertura {
   pct_cobertura: number;
 }
 
+interface DetalheItem {
+  data: string;
+  mesa: string;
+  motivo: string;
+  qtd_itens: number;
+  valor: number;
+}
+
 interface Keyword {
   id: number;
   pattern: string;
@@ -102,6 +110,12 @@ export default function ConsumosClassificacaoPage() {
   const [novoPattern, setNovoPattern] = useState('');
   const [novaCategoria, setNovaCategoria] = useState('clientes');
   const [novaDescricao, setNovaDescricao] = useState('');
+
+  // Modal de drill-down por categoria
+  const [modalDetalhesOpen, setModalDetalhesOpen] = useState(false);
+  const [categoriaDetalhes, setCategoriaDetalhes] = useState<string | null>(null);
+  const [detalhes, setDetalhes] = useState<DetalheItem[]>([]);
+  const [loadingDetalhes, setLoadingDetalhes] = useState(false);
 
   useEffect(() => {
     setPageTitle('🏷️ Classificação de Consumos');
@@ -162,6 +176,26 @@ export default function ConsumosClassificacaoPage() {
     setNovaCategoria(categoriaPre);
     setNovaDescricao('');
     setModalOpen(true);
+  };
+
+  const abrirDetalhes = async (categoria: string) => {
+    if (!selectedBar?.id) return;
+    setCategoriaDetalhes(categoria);
+    setModalDetalhesOpen(true);
+    setLoadingDetalhes(true);
+    setDetalhes([]);
+    try {
+      const res = await fetch(
+        `/api/cmv-semanal/consumos-classificacao/detalhes?bar_id=${selectedBar.id}&ano=${ano}&semana=${semana}&categoria=${categoria}`
+      );
+      const data = await res.json();
+      if (res.ok) setDetalhes(data.itens || []);
+      else toast.error('Erro: ' + data.error);
+    } catch (e: any) {
+      toast.error('Erro: ' + e.message);
+    } finally {
+      setLoadingDetalhes(false);
+    }
   };
 
   const salvarKeyword = async () => {
@@ -361,12 +395,19 @@ export default function ConsumosClassificacaoPage() {
                 {categorizado.map((c) => {
                   const info = getCategoriaInfo(c.categoria);
                   return (
-                    <div key={c.categoria} className="flex items-center justify-between p-3 rounded-lg bg-muted/30">
+                    <button
+                      key={c.categoria}
+                      onClick={() => abrirDetalhes(c.categoria)}
+                      className="w-full flex items-center justify-between p-3 rounded-lg bg-muted/30 hover:bg-muted/60 transition-colors text-left"
+                    >
                       <Badge className={info.color}>{info.label}</Badge>
                       <span className="font-mono font-semibold">{fmtBRL(parseFloat(String(c.total)))}</span>
-                    </div>
+                    </button>
                   );
                 })}
+                <p className="text-xs text-muted-foreground text-center pt-2">
+                  Clique numa categoria para ver os itens detalhados
+                </p>
               </div>
             </CardContent>
           </Card>
@@ -483,6 +524,74 @@ export default function ConsumosClassificacaoPage() {
               Adicionar Keyword
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Modal de drill-down por categoria */}
+      <Dialog open={modalDetalhesOpen} onOpenChange={setModalDetalhesOpen}>
+        <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>
+              {categoriaDetalhes && (
+                <span className="flex items-center gap-2">
+                  Detalhes —
+                  <Badge className={getCategoriaInfo(categoriaDetalhes).color}>
+                    {getCategoriaInfo(categoriaDetalhes).label}
+                  </Badge>
+                </span>
+              )}
+            </DialogTitle>
+            <DialogDescription>
+              Semana {semana}/{ano} — itens ordenados da data mais recente pra mais antiga
+            </DialogDescription>
+          </DialogHeader>
+
+          {loadingDetalhes ? (
+            <div className="text-center py-8 text-muted-foreground">
+              <RefreshCw className="h-6 w-6 mx-auto animate-spin mb-2" />
+              Carregando...
+            </div>
+          ) : detalhes.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              Nenhum item encontrado
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="sticky top-0 bg-background">
+                  <tr className="border-b">
+                    <th className="text-left py-2 px-2">Data</th>
+                    <th className="text-left py-2 px-2">Mesa</th>
+                    <th className="text-left py-2 px-2">Motivo</th>
+                    <th className="text-right py-2 px-2">Itens</th>
+                    <th className="text-right py-2 px-2">Valor</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {detalhes.map((d, i) => (
+                    <tr key={i} className="border-b hover:bg-muted/50">
+                      <td className="py-2 px-2 text-xs whitespace-nowrap">
+                        {new Date(d.data).toLocaleDateString('pt-BR')}
+                      </td>
+                      <td className="py-2 px-2 font-mono text-xs">{d.mesa}</td>
+                      <td className="py-2 px-2 text-xs">{d.motivo}</td>
+                      <td className="py-2 px-2 text-right">{d.qtd_itens}</td>
+                      <td className="py-2 px-2 text-right font-mono">{fmtBRL(parseFloat(String(d.valor)))}</td>
+                    </tr>
+                  ))}
+                  <tr className="font-semibold bg-muted/30">
+                    <td colSpan={3} className="py-2 px-2">Total</td>
+                    <td className="py-2 px-2 text-right">
+                      {detalhes.reduce((sum, d) => sum + d.qtd_itens, 0)}
+                    </td>
+                    <td className="py-2 px-2 text-right font-mono">
+                      {fmtBRL(detalhes.reduce((sum, d) => sum + parseFloat(String(d.valor)), 0))}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          )}
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
Modal pra clicar em cada categoria e ver os itens detalhados (data DESC).

## Mudanças
- **UI**: cards na aba 'Por Categoria' clicáveis, abrem modal com tabela
- **Modal**: data | mesa | motivo | qtd | valor, ordenado data DESC, total no rodapé
- **API**: GET /api/cmv-semanal/consumos-classificacao/detalhes
- **RPC**: get_consumos_detalhes_categoria(bar, ini, fim, categoria)
- **Diego**: removido de socios, adicionado em operacao com prio 5 (override mesmo quando garçom marca 'Socio')

🤖 Generated with [Claude Code](https://claude.com/claude-code)