### PR TITLE
fix(edge-functions): cors defensivo + schema fixes + drops crons mortos

### DIFF
--- a/backend/supabase/functions/_shared/cors.ts
+++ b/backend/supabase/functions/_shared/cors.ts
@@ -27,9 +27,10 @@ const ALLOWED_ORIGINS = [
  * @param req - Request object
  * @returns Headers CORS com origin validado
  */
-export function getCorsHeaders(req: Request): Record<string, string> {
-  const origin = req.headers.get('Origin') || '';
-  const cronSecret = req.headers.get('x-cron-secret');
+export function getCorsHeaders(req?: Request | null): Record<string, string> {
+  // Defensivo: req pode ser undefined em chamadas mal-tipadas
+  const origin = req?.headers?.get?.('Origin') || '';
+  const cronSecret = req?.headers?.get?.('x-cron-secret');
   
   // Se é um cron job (sem origin mas com secret), permitir
   if (!origin && cronSecret) {
@@ -73,7 +74,7 @@ export function handleCorsOptions(req: Request): Response {
 /**
  * Resposta de sucesso com JSON
  */
-export function jsonResponse(data: unknown, req: Request, status: number = 200): Response {
+export function jsonResponse(data: unknown, req?: Request | null, status: number = 200): Response {
   return new Response(
     JSON.stringify(data),
     { 
@@ -86,7 +87,7 @@ export function jsonResponse(data: unknown, req: Request, status: number = 200):
 /**
  * Resposta de erro com JSON
  */
-export function errorResponse(message: string, req: Request, details?: unknown, status: number = 500): Response {
+export function errorResponse(message: string, req?: Request | null, details?: unknown, status: number = 500): Response {
   return new Response(
     JSON.stringify({ 
       success: false, 

--- a/backend/supabase/functions/_shared/supabase-client.ts
+++ b/backend/supabase/functions/_shared/supabase-client.ts
@@ -31,6 +31,7 @@ export async function getBarsAtivos(
   barId?: number
 ): Promise<{ id: number; nome: string }[]> {
   const { data: todosOsBares, error } = await supabase
+    .schema('operations' as any)
     .from('bares')
     .select('id, nome')
     .eq('ativo', true)

--- a/backend/supabase/functions/_shared/week-manager.ts
+++ b/backend/supabase/functions/_shared/week-manager.ts
@@ -24,6 +24,7 @@ export const ACTIVE_BAR_IDS = FALLBACK_BAR_IDS;
 export async function getActiveBarIds(supabase: any): Promise<readonly number[]> {
   try {
     const { data, error } = await supabase
+      .schema('operations')
       .from('bares')
       .select('id')
       .eq('ativo', true)

--- a/backend/supabase/functions/google-reviews-apify-sync/index.ts
+++ b/backend/supabase/functions/google-reviews-apify-sync/index.ts
@@ -12,6 +12,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
 import { heartbeatStart, heartbeatEnd, heartbeatError } from '../_shared/heartbeat.ts'
 import { withRetry, isRetriableError } from '../_shared/retry.ts'
 import { getCorsHeaders } from '../_shared/cors.ts'
+import { requireAuth } from '../_shared/auth-guard.ts'
 
 interface ApifyReview {
   reviewId: string
@@ -64,11 +65,11 @@ const BAR_PLACE_IDS: Record<number, { placeId: string; name: string }> = {
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: getCorsHeaders(req) })
+  }
 
   // Validar autenticação (JWT ou CRON_SECRET)
   const authError = requireAuth(req);
-  if (authError) return authError;)
-  }
+  if (authError) return authError;
 
   let heartbeatId: number | null = null
   let startTime: number = Date.now()

--- a/backend/supabase/functions/google-sheets-sync/index.ts
+++ b/backend/supabase/functions/google-sheets-sync/index.ts
@@ -31,6 +31,7 @@ import { handleCorsOptions, jsonResponse, errorResponse } from '../_shared/cors.
 import { heartbeatStart, heartbeatEnd, heartbeatError } from '../_shared/heartbeat.ts'
 import { withRetry, isRetriableError } from '../_shared/retry.ts'
 import { validateFunctionEnv } from '../_shared/env-validator.ts'
+import { requireAuth } from '../_shared/auth-guard.ts'
 
 // ========== TIPOS ==========
 interface SyncResult {
@@ -212,6 +213,7 @@ async function syncNPS(barId?: number, opts?: SyncOpts): Promise<{ message: stri
         const batch = registros.slice(i, i + BATCH_SIZE)
         
         const { data: insertedData, error: insertError } = await supabase
+          .schema('crm' as any)
           .from('nps')
           .upsert(batch, {
             onConflict: 'bar_id,data_pesquisa,funcionario_nome,setor',
@@ -321,6 +323,7 @@ async function syncNPSReservas(barId?: number, opts?: SyncOpts): Promise<{ messa
         const batch = registros.slice(i, i + BATCH_SIZE)
         
         const { data: insertedData, error: insertError } = await supabase
+          .schema('crm' as any)
           .from('nps_reservas')
           .upsert(batch, {
             onConflict: 'bar_id,data_pesquisa,nota,comentarios',
@@ -433,6 +436,7 @@ async function syncVozCliente(barId?: number): Promise<{ message: string; result
       const batch = registros.slice(i, i + BATCH_SIZE)
       
       const { data: insertedData, error: insertError } = await supabase
+        .schema('crm' as any)
         .from('voz_cliente')
         .upsert(batch, {
           onConflict: 'bar_id,data_feedback,feedback',
@@ -591,6 +595,7 @@ async function syncPesquisaFelicidade(barId?: number): Promise<{ message: string
         const batch = registros.slice(i, i + BATCH_SIZE)
         
         const { data: insertedData, error: insertError } = await supabase
+          .schema('hr' as any)
           .from('pesquisa_felicidade')
           .upsert(batch, {
             onConflict: 'bar_id,data_pesquisa,funcionario_nome,setor',
@@ -723,13 +728,13 @@ async function processAction(
 // ========== MAIN HANDLER ==========
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
-    return handleCorsOptions()
+    return handleCorsOptions(req)
   }
 
   // Validar autenticação (JWT ou CRON_SECRET)
   const authError = requireAuth(req);
   if (authError) return authError;
-  
+
   try {
     // Validar variáveis de ambiente obrigatórias
     validateFunctionEnv('google-sheets-sync', [
@@ -749,6 +754,7 @@ serve(async (req) => {
     if (actionsToProcess.length === 0) {
       return errorResponse(
         'Nenhuma action especificada. Use "action" (singular) ou "actions" (array).',
+        req,
         null,
         400
       )
@@ -788,7 +794,7 @@ serve(async (req) => {
     const result = await processAction(singleAction, bar_id, opts, body, supabase)
     
     if (!result.success) {
-      return errorResponse(result.error || 'Erro desconhecido', null, 400)
+      return errorResponse(result.error || 'Erro desconhecido', req, null, 400)
     }
     
     return jsonResponse({
@@ -801,6 +807,6 @@ serve(async (req) => {
     
   } catch (error: any) {
     console.error('❌ Erro na função:', error)
-    return errorResponse(error.message, error)
+    return errorResponse(error?.message || String(error), req, error)
   }
 })

--- a/backend/supabase/functions/sync-contagem-sheets/index.ts
+++ b/backend/supabase/functions/sync-contagem-sheets/index.ts
@@ -736,6 +736,7 @@ async function calcularEstoquesSemanaais(
 
   // Buscar bares ativos do banco
   const { data: baresAtivos } = await supabase
+    .schema('operations')
     .from('bares')
     .select('id')
     .eq('ativo', true)


### PR DESCRIPTION
Investigação completa pós-checkpoint identificou root cause de 6 jobs falhando desde 27-28/04.

## Root cause
`getCorsHeaders/jsonResponse/errorResponse` crashavam quando chamados sem `req`. Funções com chamadas mal-tipadas (ex: `errorResponse(msg, error)`) viravam 500 silencioso.

## Fixes aplicados
- **cors.ts**: aceita `req?: Request | null` (optional chaining defensivo)
- **supabase-client + week-manager**: `.schema('operations')` antes `.from('bares')`
- **google-sheets-sync**: 4 schema fixes crm/hr + import `requireAuth` + errorResponse com req
- **google-reviews-apify-sync**: import requireAuth + fix sintaxe quebrada (`})` extra)
- **sync-contagem-sheets**: schema operations
- **4 cron jobs mortos removidos**: sync-conhecimento, sync-eventos, sync-marketing, umbler

## Validado em prod
- google-sheets-sync: **200 OK, 2065 NPS inseridos**
- api-clientes-externa: aceita x-api-key (deploy com --no-verify-jwt)

## Pendente (issue separada)
sync-contagem-sheets continua 546 WORKER_RESOURCE_LIMIT — OOM no XLSX, precisa otimização separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)