### PR TITLE
fix(desempenho-mensal): quebra_reservas zerado

### DIFF
--- a/frontend/src/app/estrategico/desempenho/services/desempenho-mensal-service.ts
+++ b/frontend/src/app/estrategico/desempenho/services/desempenho-mensal-service.ts
@@ -190,6 +190,14 @@ export async function getMeses(
       descontos_valor: descontoTotal,
       descontos_perc: faturamentoTotal > 0 ? (descontoTotal / faturamentoTotal) * 100 : 0,
 
+      // Quebra de reservas: (reservas_totais - reservas_presentes) / reservas_totais * 100
+      // (mesma formula do desempenho-service.ts semanal)
+      quebra_reservas: (toNum(g.reservas_totais) ?? 0) > 0
+        ? (((toNum(g.reservas_totais) ?? 0) - (toNum(g.reservas_presentes) ?? 0)) / (toNum(g.reservas_totais) ?? 1)) * 100
+        : 0,
+      reservas_totais: toNum(g.reservas_totais) ?? 0,
+      reservas_presentes: toNum(g.reservas_presentes) ?? 0,
+
       // Cancelamentos: gold cancelamentos_total -> front cancelamentos
       cancelamentos: toNum(g.cancelamentos_total) ?? toNum(g.cancelamentos),
 


### PR DESCRIPTION
## Causa raiz
`desempenho-mensal-service.ts` nunca calculava `quebra_reservas`. Apenas o semanal (`desempenho-service.ts:534`) tinha a fórmula. Por isso a aba mensal mostrava 0%.

## Fix
Replicar fórmula `(reservas_totais - reservas_presentes) / reservas_totais * 100` no mensal.

## Validação
Banco já tem os dados corretos:
- Ord abril/26 mensal: totais=5510, presentes=4386 → **20,4%** ✓ (bate com soma das semanas)
- Deb abril/26: zerado (problema diferente — Getin Deb não populando)

🤖 Generated with [Claude Code](https://claude.com/claude-code)