### PR TITLE
chore(gold-desempenho): drop NOT NULL pra mes corrente

### DIFF
--- a/database/migrations/2026-05-04-gold-desempenho-drop-notnull-mes-corrente.rollback.sql
+++ b/database/migrations/2026-05-04-gold-desempenho-drop-notnull-mes-corrente.rollback.sql
@@ -1,0 +1,12 @@
+-- Rollback 2026-05-04-gold-desempenho-drop-notnull-mes-corrente.sql
+--
+-- ATENCAO: rollback so funciona se TODAS as linhas tiverem valores nao-nulos
+-- nos 4 campos. Mes corrente pode ter NULLs — rodar SELECT antes:
+--   SELECT periodo, COUNT(*) FILTER (WHERE cmv IS NULL) cmv_null,
+--          COUNT(*) FILTER (WHERE cmv_limpo IS NULL) cmv_limpo_null
+--   FROM gold.desempenho GROUP BY periodo ORDER BY periodo DESC LIMIT 5;
+
+ALTER TABLE gold.desempenho ALTER COLUMN cmv_percentual SET NOT NULL;
+ALTER TABLE gold.desempenho ALTER COLUMN cmv_limpo SET NOT NULL;
+ALTER TABLE gold.desempenho ALTER COLUMN cmv SET NOT NULL;
+ALTER TABLE gold.desempenho ALTER COLUMN faturamento_cmvivel SET NOT NULL;

--- a/database/migrations/2026-05-04-gold-desempenho-drop-notnull-mes-corrente.sql
+++ b/database/migrations/2026-05-04-gold-desempenho-drop-notnull-mes-corrente.sql
@@ -1,0 +1,18 @@
+-- 2026-05-04: gold.desempenho — DROP NOT NULL nos 4 campos derivados de CMV
+-- pra permitir mes corrente entrar no gold antes do CMV ser fechado.
+--
+-- Contexto: cron `gold-desempenho` (12 UTC diario) chama
+-- etl_gold_desempenho_all_bars(14) → etl_gold_desempenho_mensal_range
+-- pra cada bar. O ETL falhava silenciosamente em mes corrente (maio/2026)
+-- porque CMV ainda nao tem valor (planilha CMV semanal so fecha quando
+-- a semana acaba), e os 4 campos abaixo eram NOT NULL.
+--
+-- Resultado: dashboard mensal so mostrava ate abril. Sem aviso.
+--
+-- Fix: relaxar NOT NULL — campos passam a aceitar NULL pra mes incompleto.
+-- O front ja tem fallback (toNum() retorna null) e exibe '—' nesses casos.
+
+ALTER TABLE gold.desempenho ALTER COLUMN faturamento_cmvivel DROP NOT NULL;
+ALTER TABLE gold.desempenho ALTER COLUMN cmv DROP NOT NULL;
+ALTER TABLE gold.desempenho ALTER COLUMN cmv_limpo DROP NOT NULL;
+ALTER TABLE gold.desempenho ALTER COLUMN cmv_percentual DROP NOT NULL;


### PR DESCRIPTION
## Summary

Cron `gold-desempenho` (diario 12 UTC) chama `etl_gold_desempenho_all_bars(14)` que cobre semanal+mensal pros ultimos 14 dias. Em mes corrente, o ETL mensal falhava silenciosamente porque 4 campos eram `NOT NULL` mas mes incompleto nao tem CMV ainda (planilha so fecha no fim da semana).

Resultado: dashboard mensal so ia ate o ultimo mes fechado. Maio/2026 nao aparecia.

## Mudancas

`gold.desempenho`: `DROP NOT NULL` em:
- `faturamento_cmvivel`
- `cmv`
- `cmv_limpo`
- `cmv_percentual`

Aplicado direto no banco em 2026-05-04 pra desbloquear maio/2026. Esta migration formaliza pra reprodutibilidade.

## Test plan

- [x] Mes corrente (maio/2026) entra em `gold.desempenho` granularidade=mensal
  - Ord: faturamento_total=R$126.380, cmo=165
  - Deb: faturamento_total=R$45.541, cmo=1000
- [x] Front (`/estrategico/desempenho?visao=mensal`) ja tem fallback `toNum() ?? null`, exibe '—' nos campos vazios

🤖 Generated with [Claude Code](https://claude.com/claude-code)