### PR TITLE
fix(quebra-reservas): usar mesas em vez de pessoas (semanal+mensal)

### DIFF
--- a/frontend/src/app/estrategico/desempenho/services/desempenho-mensal-service.ts
+++ b/frontend/src/app/estrategico/desempenho/services/desempenho-mensal-service.ts
@@ -190,10 +190,11 @@ export async function getMeses(
       descontos_valor: descontoTotal,
       descontos_perc: faturamentoTotal > 0 ? (descontoTotal / faturamentoTotal) * 100 : 0,
 
-      // Quebra de reservas: (reservas_totais - reservas_presentes) / reservas_totais * 100
+      // Quebra de reservas: (mesas_totais - mesas_presentes) / mesas_totais * 100
+      // Usa MESAS, nao pessoas — quebra eh por reserva nao comparecida.
       // (mesma formula do desempenho-service.ts semanal)
-      quebra_reservas: (toNum(g.reservas_totais) ?? 0) > 0
-        ? (((toNum(g.reservas_totais) ?? 0) - (toNum(g.reservas_presentes) ?? 0)) / (toNum(g.reservas_totais) ?? 1)) * 100
+      quebra_reservas: (toNum(g.mesas_totais) ?? 0) > 0
+        ? (((toNum(g.mesas_totais) ?? 0) - (toNum(g.mesas_presentes) ?? 0)) / (toNum(g.mesas_totais) ?? 1)) * 100
         : 0,
       reservas_totais: toNum(g.reservas_totais) ?? 0,
       reservas_presentes: toNum(g.reservas_presentes) ?? 0,

--- a/frontend/src/app/estrategico/desempenho/services/desempenho-service.ts
+++ b/frontend/src/app/estrategico/desempenho/services/desempenho-service.ts
@@ -527,12 +527,14 @@ export async function getSemanas(
       ? (cmvRsCalculado / s.faturamento_total) * 100
       : null;
 
-    // Calcular Quebra de Reservas = (Pessoas Total - Pessoas Presentes) / Pessoas Total × 100
-    // reservas_totais e reservas_presentes no banco = pessoas (não mesas)
-    const pessoasTotal = s.reservas_totais || 0;
-    const pessoasPresentes = s.reservas_presentes || 0;
-    const quebraReservas = pessoasTotal > 0 
-      ? ((pessoasTotal - pessoasPresentes) / pessoasTotal) * 100 
+    // Calcular Quebra de Reservas = (Mesas Reservadas - Mesas Presentes) / Mesas Reservadas × 100
+    // Usa MESAS (cada reserva = 1 mesa), nao pessoas — quebra eh por reserva nao comparecida.
+    // s.mesas_totais e s.mesas_presentes vem do GetIn (mesas_totais/mesas_presentes manuais
+    // ou agregado de reservas_totais_quantidade/reservas_presentes_quantidade do gold).
+    const mesasTotal = (s as any).mesas_totais || 0;
+    const mesasPresentes = (s as any).mesas_presentes || 0;
+    const quebraReservas = mesasTotal > 0
+      ? ((mesasTotal - mesasPresentes) / mesasTotal) * 100
       : 0;
 
     // Garantir que valores numéricos vindos como string do Postgres sejam convertidos


### PR DESCRIPTION
## Bug

A formula calculava `(reservas_totais - reservas_presentes) / reservas_totais` mas no banco esses campos representam **pessoas**, nao mesas. A tela exibe "Reservas Realizadas" e "Reservas Presentes" usando `mesas_totais`/`mesas_presentes`, entao o numero da quebra divergia do display.

## Validacao

Abril Ord (mensal):
- Display: 387 mesas, 267 presentes
- Antes: quebra = 20.4% (calc com pessoas: 5510 → 4386)
- Depois: quebra = **31.0%** (calc com mesas: 387 → 267) ✓ bate com display

## Mudancas

- `desempenho-service.ts` (semanal): `s.mesas_totais` / `s.mesas_presentes`
- `desempenho-mensal-service.ts` (mensal): `g.mesas_totais` / `g.mesas_presentes`

## Test plan

- [ ] `/estrategico/desempenho?visao=mensal` — Quebra Reservas bate com (mesas_totais - mesas_presentes) / mesas_totais
- [ ] `/estrategico/desempenho?visao=semanal` — idem semana a semana
- [ ] Deb (sem dados de mesas): quebra = 0 (esperado, nao quebra a UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)