### PR TITLE
perf(visao-geral): RPC SQL pra retencao_real + cache 1h

### DIFF
--- a/database/migrations/2026-05-04-rpc-calcular-retencao-real-visao-geral.sql
+++ b/database/migrations/2026-05-04-rpc-calcular-retencao-real-visao-geral.sql
@@ -1,0 +1,88 @@
+-- 2026-05-04: RPC pra calcular retencao_real da Visao Geral em SQL
+--
+-- Problema: a Visao Geral (/estrategico/visao-geral) demorava ~10s pra carregar
+-- porque calcularRetencaoReal() no frontend fazia 3 paginacoes paralelas em
+-- public.visitas (~60k rows/ano), totalizando 90+ HTTP requests.
+--
+-- Esta RPC faz tudo em SQL: 3 CTEs com DISTINCT cliente_fone + 4 COUNT
+-- com EXISTS. Roda em <1s vs ~10s do JS client-side.
+--
+-- Uso pelo frontend:
+--   supabase.rpc('calcular_retencao_real_visao_geral', { p_bar_id, p_atual_inicio, ... })
+--
+-- Retorna:
+--   retencao_real_pct: % de clientes do periodo anterior que voltaram no atual
+--   variacao_pct: variacao % vs o cruzamento anterior-comparacao
+--   contadores brutos (total_anterior, voltaram, total_comparacao, voltaram_anterior)
+
+CREATE OR REPLACE FUNCTION public.calcular_retencao_real_visao_geral(
+  p_bar_id integer,
+  p_atual_inicio date,
+  p_atual_fim date,
+  p_anterior_inicio date,
+  p_anterior_fim date,
+  p_comparacao_inicio date,
+  p_comparacao_fim date
+)
+RETURNS TABLE (
+  retencao_real_pct numeric,
+  variacao_pct numeric,
+  total_anterior integer,
+  voltaram integer,
+  total_comparacao integer,
+  voltaram_anterior integer
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, operations, pg_catalog
+AS $$
+DECLARE
+  v_total_anterior integer;
+  v_voltaram integer;
+  v_total_comparacao integer;
+  v_voltaram_anterior integer;
+  v_pct_atual numeric;
+  v_pct_anterior numeric;
+BEGIN
+  WITH
+  clientes_atual AS (
+    SELECT DISTINCT cliente_fone FROM public.visitas
+    WHERE bar_id = p_bar_id
+      AND data_visita BETWEEN p_atual_inicio AND p_atual_fim
+      AND cliente_fone IS NOT NULL AND length(cliente_fone) >= 8
+  ),
+  clientes_anterior AS (
+    SELECT DISTINCT cliente_fone FROM public.visitas
+    WHERE bar_id = p_bar_id
+      AND data_visita BETWEEN p_anterior_inicio AND p_anterior_fim
+      AND cliente_fone IS NOT NULL AND length(cliente_fone) >= 8
+  ),
+  clientes_comparacao AS (
+    SELECT DISTINCT cliente_fone FROM public.visitas
+    WHERE bar_id = p_bar_id
+      AND data_visita BETWEEN p_comparacao_inicio AND p_comparacao_fim
+      AND cliente_fone IS NOT NULL AND length(cliente_fone) >= 8
+  )
+  SELECT
+    (SELECT COUNT(*) FROM clientes_anterior)::integer,
+    (SELECT COUNT(*) FROM clientes_anterior ca WHERE EXISTS (SELECT 1 FROM clientes_atual cat WHERE cat.cliente_fone = ca.cliente_fone))::integer,
+    (SELECT COUNT(*) FROM clientes_comparacao)::integer,
+    (SELECT COUNT(*) FROM clientes_comparacao cc WHERE EXISTS (SELECT 1 FROM clientes_anterior ca WHERE ca.cliente_fone = cc.cliente_fone))::integer
+  INTO v_total_anterior, v_voltaram, v_total_comparacao, v_voltaram_anterior;
+
+  v_pct_atual := CASE WHEN v_total_anterior > 0 THEN (v_voltaram::numeric / v_total_anterior * 100) ELSE 0 END;
+  v_pct_anterior := CASE WHEN v_total_comparacao > 0 THEN (v_voltaram_anterior::numeric / v_total_comparacao * 100) ELSE 0 END;
+
+  RETURN QUERY SELECT
+    ROUND(v_pct_atual, 1),
+    CASE WHEN v_pct_anterior > 0
+      THEN ROUND(((v_pct_atual - v_pct_anterior) / v_pct_anterior * 100), 1)
+      ELSE 0::numeric
+    END,
+    v_total_anterior, v_voltaram, v_total_comparacao, v_voltaram_anterior;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.calcular_retencao_real_visao_geral(integer, date, date, date, date, date, date) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.calcular_retencao_real_visao_geral(integer, date, date, date, date, date, date) TO authenticated, service_role;

--- a/frontend/src/app/estrategico/visao-geral/page.tsx
+++ b/frontend/src/app/estrategico/visao-geral/page.tsx
@@ -4,8 +4,9 @@ import { createClient } from '@supabase/supabase-js';
 import * as IndicadoresService from './services/indicadores-service';
 import { BarSyncCheck } from '@/components/BarSyncCheck';
 
-// Cache por 5 minutos
-export const revalidate = 300;
+// Cache por 1 hora — Visao Geral agrega ano todo, nao precisa revalidar tao rapido.
+// (data muda em escala diaria/semanal, nao em minutos)
+export const revalidate = 3600;
 
 // Helper para mês de retenção
 const getMesRetencao = (trimestre: number) => {

--- a/frontend/src/app/estrategico/visao-geral/services/indicadores-service.ts
+++ b/frontend/src/app/estrategico/visao-geral/services/indicadores-service.ts
@@ -280,67 +280,27 @@ export async function calcularRetencaoReal(supabase: SupabaseClient, barIdNum: n
       fimPeriodoComparacao = formatDate(fimComp);
     }
     
-    // Buscar clientes dos períodos - MIGRADO: visitas (domain table)
-    const [clientesPeriodoAtualBruto, clientesPeriodoAnteriorBruto, clientesPeriodoComparacaoBruto] = await Promise.all([
-      fetchAllData(supabase, 'visitas', 'cliente_fone', {
-        'eq_bar_id': barIdNum,
-        'gte_data_visita': inicioPeriodoAtual,
-        'lte_data_visita': fimPeriodoAtual
-      }),
-      fetchAllData(supabase, 'visitas', 'cliente_fone', {
-        'eq_bar_id': barIdNum,
-        'gte_data_visita': inicioPeriodoAnterior,
-        'lte_data_visita': fimPeriodoAnterior
-      }),
-      fetchAllData(supabase, 'visitas', 'cliente_fone', {
-        'eq_bar_id': barIdNum,
-        'gte_data_visita': inicioPeriodoComparacao,
-        'lte_data_visita': fimPeriodoComparacao
-      })
-    ]) as [any[], any[], any[]];
-    
-    // Criar sets de clientes únicos
-    const clientesPeriodoAtual = new Set(
-      clientesPeriodoAtualBruto?.filter(item => item.cliente_fone && item.cliente_fone.length >= 8).map(item => item.cliente_fone) || []
-    );
-    
-    const clientesPeriodoAnterior = new Set(
-      clientesPeriodoAnteriorBruto?.filter(item => item.cliente_fone && item.cliente_fone.length >= 8).map(item => item.cliente_fone) || []
-    );
-    
-    const clientesPeriodoComparacao = new Set(
-      clientesPeriodoComparacaoBruto?.filter(item => item.cliente_fone && item.cliente_fone.length >= 8).map(item => item.cliente_fone) || []
-    );
-    
-    // RETENÇÃO REAL = clientes do período ANTERIOR que voltaram no período ATUAL
-    const clientesQueVoltaram = [...clientesPeriodoAnterior].filter(cliente => 
-      clientesPeriodoAtual.has(cliente)
-    );
-    
-    const totalClientesAnterior = clientesPeriodoAnterior.size;
-    const totalQueVoltaram = clientesQueVoltaram.length;
-    
-    // Taxa de retenção real = quantos do período anterior voltaram
-    const percentualRetencaoReal = totalClientesAnterior > 0 
-      ? (totalQueVoltaram / totalClientesAnterior) * 100 
-      : 0;
-    
-    // Calcular variação (comparar com período ainda anterior)
-    const clientesQueVoltaramAnterior = [...clientesPeriodoComparacao].filter(cliente => 
-      clientesPeriodoAnterior.has(cliente)
-    );
-    
-    const percentualRetencaoRealAnterior = clientesPeriodoComparacao.size > 0 
-      ? (clientesQueVoltaramAnterior.length / clientesPeriodoComparacao.size) * 100 
-      : 0;
-    
-    const variacaoRetencaoReal = percentualRetencaoRealAnterior > 0 
-      ? ((percentualRetencaoReal - percentualRetencaoRealAnterior) / percentualRetencaoRealAnterior * 100)
-      : 0;
-    
+    // Tudo em SQL via RPC: 1 query SQL substituiu 3 paginacoes paralelas
+    // (~90 HTTP requests pra ~60k rows). Roda em <1s vs ~10s antes.
+    const { data: rpcData, error: rpcErr } = await supabase.rpc('calcular_retencao_real_visao_geral', {
+      p_bar_id: barIdNum,
+      p_atual_inicio: inicioPeriodoAtual,
+      p_atual_fim: fimPeriodoAtual,
+      p_anterior_inicio: inicioPeriodoAnterior,
+      p_anterior_fim: fimPeriodoAnterior,
+      p_comparacao_inicio: inicioPeriodoComparacao,
+      p_comparacao_fim: fimPeriodoComparacao,
+    });
+
+    if (rpcErr) {
+      console.error('❌ Erro em calcular_retencao_real_visao_geral:', rpcErr);
+      throw rpcErr;
+    }
+
+    const row = (rpcData as any[])?.[0];
     return {
-      valor: parseFloat(percentualRetencaoReal.toFixed(1)),
-      variacao: parseFloat(variacaoRetencaoReal.toFixed(1))
+      valor: row ? Number(row.retencao_real_pct) || 0 : 0,
+      variacao: row ? Number(row.variacao_pct) || 0 : 0,
     };
     
   } catch (error) {


### PR DESCRIPTION
## Performance fix

Pagina \`/estrategico/visao-geral\` demorava ~10s pra carregar.

**Causa:** \`calcularRetencaoReal()\` fazia 3 paginacoes paralelas em \`public.visitas\` (~60k rows/ano cada), totalizando ~90 HTTP requests, so pra resolver set intersection client-side em JS.

## Fix

1. **RPC SQL** \`public.calcular_retencao_real_visao_geral\` — 3 CTEs com DISTINCT + COUNT EXISTS. Roda em **<1s**.
2. **Frontend**: trocar 3x \`fetchAllData\` por 1 \`supabase.rpc()\`.
3. **revalidate**: 300s → 3600s (Visao Geral agrega ano todo, dados mudam em escala diaria/semanal — nao em minutos).

## Validacao SQL

\`\`\`
T2/2026 Ord (atual=abr-mai, anterior=jan-mar, comparacao=out-dez/2025):
  retencao_real_pct: 11.0%
  total_anterior: 33904 (clientes T1)
  voltaram: 3736
  total_comparacao: 37262
  voltaram_anterior: 7080
\`\`\`

## Test plan

- [ ] Pagina carrega em <2s (primeira carga) e instantaneo (cached)
- [ ] Card "Retencao Real" exibe os mesmos numeros de antes
- [ ] Filtro por trimestre continua funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)