### PR TITLE
fix(cmv-mensal): pipeline robusta + bonificações 100% manuais

### DIFF
--- a/backend/supabase/functions/sync-cmv-mensal/index.ts
+++ b/backend/supabase/functions/sync-cmv-mensal/index.ts
@@ -22,6 +22,7 @@ interface SyncRequest {
   bar_id?: number
   ano?: number
   debug?: boolean
+  preview_only?: boolean // se true, lê do Sheets e retorna sem salvar no banco (útil pra debug)
 }
 
 // ====== FALLBACK ROW MAP MENSAL (usado se banco não tiver configuração) ======
@@ -247,7 +248,7 @@ serve(async (req) => {
 
   try {
     const body: SyncRequest = await req.json().catch(() => ({}))
-    const { bar_id, ano, debug = false } = body
+    const { bar_id, ano, debug = false, preview_only = false } = body
 
     console.log('📊 Sync CMV Mensal v2.0 - Iniciando', { bar_id, ano })
 
@@ -332,11 +333,18 @@ serve(async (req) => {
           const dataInicioSerial = dataInicioRow[col]
           const dataFimSerial = dataFimRow[col]
           const anoColuna = anosRow[col]
-          
+
           if (typeof dataInicioSerial === 'number' && dataInicioSerial > 40000) {
+            const dataInicioJS = excelDateToJS(dataInicioSerial)
+            // Aceita apenas colunas mensais genuínas: data_inicio = dia 1 do mês.
+            // (Algumas planilhas têm colunas semanais misturadas na aba "CMV Mensal" — ex: Deb tem
+            // col Q=01/04 mensal, mas R/S/T/U começam em 08/04, 15/04, 22/04, 29/04 (semanas).
+            // Sem esse filtro, a última coluna semanal sobrescrevia o mensal correto.)
+            if (dataInicioJS.getDate() !== 1) continue
+
             const { mes, ano: anoCalculado } = getMesFromExcelDate(dataInicioSerial)
             const anoFinal = typeof anoColuna === 'number' ? anoColuna : anoCalculado
-            
+
             colunasMeses.set(col, {
               mes,
               ano: anoFinal,
@@ -350,6 +358,7 @@ serve(async (req) => {
 
         let mesesAtualizados = 0
         let mesesErro = 0
+        const previewMeses: any[] = []
 
         for (const [col, info] of colunasMeses) {
           // Filtrar por ano se especificado
@@ -380,7 +389,8 @@ serve(async (req) => {
           updateData.consumo_rh_escritorio = parseMonetario(getVal(ROW_MAP.consumo_rh_esc, col))
           updateData.consumo_artista = parseMonetario(getVal(ROW_MAP.consumo_artista, col))
           updateData.outros_ajustes = parseMonetario(getVal(ROW_MAP.outros_ajustes, col))
-          updateData.ajuste_bonificacoes = parseMonetario(getVal(ROW_MAP.ajuste_bonif, col))
+          // Bonificações são 100% manuais (UI cmv_mensal). NÃO ler da planilha.
+          // updateData.ajuste_bonificacoes — preservado pelo upsert via DEFAULT
           updateData.cmv_real = parseMonetario(getVal(ROW_MAP.cmv_real, col))
           updateData.faturamento_cmvivel = parseMonetario(getVal(ROW_MAP.fat_cmvivel, col))
           updateData.cmv_limpo_percentual = parsePercentual(getVal(ROW_MAP.cmv_limpo_pct, col))
@@ -405,6 +415,33 @@ serve(async (req) => {
                           updateData.cmv_real !== 0 ||
                           updateData.faturamento_cmvivel !== 0
           
+          // Preview mode: coleta o que LERIA do Sheets sem upsertar
+          if (preview_only) {
+            previewMeses.push({
+              ano: info.ano,
+              mes: info.mes,
+              data_inicio: info.dataInicio,
+              data_fim: info.dataFim,
+              col_planilha: col,
+              raw: {
+                estoque_inicial_raw: getVal(ROW_MAP.estoque_inicial, col),
+                compras_raw: getVal(ROW_MAP.compras, col),
+                estoque_final_raw: getVal(ROW_MAP.estoque_final, col),
+                cmv_real_raw: getVal(ROW_MAP.cmv_real, col),
+                fat_cmvivel_raw: getVal(ROW_MAP.fat_cmvivel, col),
+              },
+              parsed: {
+                estoque_inicial: updateData.estoque_inicial,
+                compras: updateData.compras,
+                estoque_final: updateData.estoque_final,
+                cmv_real: updateData.cmv_real,
+                fat_cmvivel: updateData.faturamento_cmvivel,
+                tem_dados: temDados,
+              }
+            })
+            continue
+          }
+
           if (!temDados) {
             if (debug) console.log(`⏭️ ${info.ano}/${info.mes}: sem dados válidos`)
             continue
@@ -444,7 +481,8 @@ serve(async (req) => {
           bar_nome: barConfig.nome,
           success: true,
           meses_atualizados: mesesAtualizados,
-          meses_erro: mesesErro
+          meses_erro: mesesErro,
+          ...(preview_only ? { preview_meses: previewMeses } : {})
         })
 
       } catch (barError: any) {

--- a/backend/supabase/functions/sync-cmv-sheets/index.ts
+++ b/backend/supabase/functions/sync-cmv-sheets/index.ts
@@ -548,18 +548,11 @@ serve(async (req) => {
             if (v > 0) { updateData.cmv_teorico_percentual = v; temDados = true }
           }
           
-          // Bonificações
-          const bonifContratoVal = rows[ROW_MAP.bonificacao_contrato]?.[col]
-          if (bonifContratoVal !== undefined) {
-            const v = parseMonetario(bonifContratoVal)
-            if (v > 0) { updateData.bonificacao_contrato_anual = v; temDados = true }
-          }
-          
-          const outrasBonifVal = rows[ROW_MAP.outras_bonificacoes]?.[col]
-          if (outrasBonifVal !== undefined) {
-            const v = parseMonetario(outrasBonifVal)
-            if (v > 0) { updateData.ajuste_bonificacoes = v; temDados = true }
-          }
+          // Bonificações: 100% manuais via UI (cmv_mensal). Sync NÃO popula mais.
+          // Motivo: planilha Sheet tem fórmulas residuais que vinham com casas decimais
+          // quebradas (ex: 7267,007874015748) e o sócio não preencheu — eram fantasmas.
+          // bonificacao_contrato_anual / ajuste_bonificacoes / bonificacao_cashback_mensal
+          // ficam só em cmv_mensal, editáveis via PUT /api/cmv-semanal/mensal.
           
           const outrosAjustesVal = rows[ROW_MAP.outros_ajustes]?.[col]
           if (outrosAjustesVal !== undefined) {

--- a/frontend/src/app/api/cmv-semanal/mensal/route.ts
+++ b/frontend/src/app/api/cmv-semanal/mensal/route.ts
@@ -163,8 +163,8 @@ export async function GET(request: NextRequest) {
         consumo_artista: parseFloat(String(cmvMensal.consumo_artista || 0)),
         outros_ajustes: parseFloat(String(cmvMensal.outros_ajustes || 0)),
         ajuste_bonificacoes: parseFloat(String(cmvMensal.ajuste_bonificacoes || 0)),
-        bonificacao_contrato_anual: 0,
-        bonificacao_cashback_mensal: 0,
+        bonificacao_contrato_anual: parseFloat(String(cmvMensal.bonificacao_contrato_anual || 0)),
+        bonificacao_cashback_mensal: parseFloat(String(cmvMensal.bonificacao_cashback_mensal || 0)),
         cmv_real: parseFloat(String(cmvMensal.cmv_real || 0)),
         cmv_limpo_percentual: parseFloat(String(cmvMensal.cmv_limpo_percentual || 0)),
         cmv_teorico_percentual: parseFloat(String(cmvMensal.cmv_teorico_percentual || 0)),
@@ -567,6 +567,7 @@ export async function PUT(request: NextRequest) {
       'consumo_socios', 'consumo_beneficios', 'consumo_artista',
       'consumo_rh_operacao', 'consumo_rh_escritorio',
       'outros_ajustes', 'ajuste_bonificacoes',
+      'bonificacao_contrato_anual', 'bonificacao_cashback_mensal',
       'estoque_inicial', 'estoque_final', 'compras',
       'estoque_inicial_funcionarios', 'estoque_final_funcionarios', 'compras_alimentacao',
     ];


### PR DESCRIPTION
## Summary

CMV mensal estava com 4 bugs encadeados que faziam os números divergirem da planilha. Esse commit + 5 migrations no Supabase resolvem ponta a ponta.

### Bug 1 — ordem agregar > sync = sobrescrita silenciosa
Cron `cmv-mensal-auto-diario` (12:30 BRT) sobrescrevia diariamente os estoques lidos do Sheet. Tudo voltava pra \`fonte='auto-agregado'\` com fórmula bugada (duplicação ano=2025/sem=53 vs 2026/sem=1).
- **Fix**: \`agregar_cmv_mensal_auto\` preserva estoques quando \`fonte='planilha'/'mista'/'manual'\`. Cron novo \`sync-cmv-mensal-diario\` 12:20 BRT (10min antes do agregar).

### Bug 2 — sync lia colunas-fantasma na aba CMV Mensal
Planilha Deb tinha na linha 2 valores extras (R: 08/04, S: 15/04, T: 22/04, U: 29/04) interpretados como abril → última col sobrescrevia a mensal Q (01/04). Deb abr ficava com est_ini=0, compras=513, est_fim=0.
- **Fix**: \`sync-cmv-mensal\` aceita só colunas onde \`data_inicio\` cai no dia 1 do mês. Adicionado modo \`preview_only\` pra debug.

### Bug 3 — compras ignorava entradas (RECEITA) nas categorias CUSTO
Conta Azul tem \`tipo='RECEITA'\` em CUSTO COMIDA/BEBIDA/DRINK (devoluções/bonificações de fornecedor). Função filtrava só DESPESA → compras infladas. Impacto: Deb fev/26 **-R\$ 24k**, Ord abr/26 **-R\$ 21k** em CUSTO BEBIDAS.
- **Fix**: \`compras = SUM(DESPESA - RECEITA)\` por categoria.

### Bug 4 — bonificações automáticas fantasmas + UI editável quebrada
Sheet Deb tinha fórmula residual em \`bonificacao_contrato\` que carregava valores fracionários (ex: 7267,007874015748) pra \`cmv_semanal\` mesmo com sócio NÃO preenchendo. UI mostrava editável mas PUT não tinha \`bonificacao_contrato_anual\`/\`cashback_mensal\` em \`camposPermitidos\` → editar+salvar não fazia nada.
- **Decisão**: bonificações 100% manuais via UI mensal.
- \`cmv_mensal\` ganha colunas \`bonificacao_contrato_anual\` + \`bonificacao_cashback_mensal\`. Histórico zerado.
- \`agregar_cmv_mensal_auto\`: preserva bonificações sempre + considera como redutor do \`cmv_real\`.
- PUT aceita os 2 campos, GET lê direto do \`cmv_mensal\`.
- \`sync-cmv-sheets\` e \`sync-cmv-mensal\` pararam de popular bonificações.

## Migrations aplicadas no Supabase (ordem)

1. \`cmv_mensal_auto_preserva_planilha\`
2. \`cron_sync_cmv_mensal_diario\`
3. \`cmv_compras_subtrai_receitas\`
4. \`cmv_mensal_bonificacoes_manual_e_zerar_historico\`
5. \`cmv_mensal_auto_preserva_bonificacoes\`

## Test plan

- [ ] Abrir \`/ferramentas/cmv-semanal/tabela?visao=mensal\` — campos Bonificação Contrato Anual e Cashback Mensal devem aparecer com valor 0
- [ ] Editar campo, salvar, recarregar — valor deve persistir
- [ ] Aguardar cron 12:20 BRT (sync) + 12:30 BRT (agregar) — bonificação salva manualmente NÃO pode ser sobrescrita
- [ ] Conferir Deb fev/26 e Ord abr/26 — \`compras\` deve refletir DESPESA - RECEITA (≈ R\$ 24k e R\$ 21k a menos respectivamente)
- [ ] Conferir Deb abr/26 — est_ini=46.640, compras=75.223 (CA), est_fim=40.315

🤖 Generated with [Claude Code](https://claude.com/claude-code)