### PR TITLE
refactor(contaazul-sync): escrever direto em bronze (medallion fase 3)

### DIFF
--- a/backend/supabase/functions/contaazul-sync/index.ts
+++ b/backend/supabase/functions/contaazul-sync/index.ts
@@ -351,7 +351,8 @@ async function syncLancamentos(
             conciliado: item.conciliado || false,
             renegociacao: item.renegociacao || null,
             raw_data: item,
-            updated_at: new Date().toISOString()
+            // Bronze tem synced_at em vez de updated_at
+            synced_at: new Date().toISOString()
           }
         })
 
@@ -359,12 +360,14 @@ async function syncLancamentos(
           if (batchIdx === 0) {
             console.log('[contaazul-sync] Primeiro registro:', JSON.stringify(lancamentos[0]))
           }
-          
+
+          // Escreve direto em bronze (medallion clássico). Antes escrevia em integrations
+          // e havia uma cópia separada (sync_contaazul_integrations_to_bronze) que ficou redundante.
           const { error, data: upsertData } = await supabase
-            .schema('integrations')
-            .from('contaazul_lancamentos')
+            .schema('bronze')
+            .from('bronze_contaazul_lancamentos')
             .upsert(lancamentos, { onConflict: 'contaazul_id,bar_id' })
-            .select('id')
+            .select('contaazul_id')
 
           if (error) {
             console.error('[contaazul-sync] Erro ao inserir lancamentos batch ' + (batchIdx + 1) + ':', JSON.stringify(error))


### PR DESCRIPTION
## Summary

Continuação do refactor medallion. Antes:
\`\`\`
CA API → integrations.contaazul_lancamentos (sync 8h)
       → bronze.bronze_contaazul_lancamentos (cópia 30min depois)
       → silver/gold (lê de bronze)
\`\`\`

Agora:
\`\`\`
CA API → bronze.bronze_contaazul_lancamentos (sync 8h direto)
       → silver/gold (lê de bronze)
\`\`\`

## Mudanças

- **\`contaazul-sync\` (edge)**: upsert agora é em \`bronze.bronze_contaazul_lancamentos\` em vez de \`integrations.contaazul_lancamentos\`. Trocado \`updated_at\` (não existe em bronze) por \`synced_at\`.
- **\`marcar_excluidos_contaazul\` (RPC)**: atualiza apenas bronze. Antes atualizava ambos.
- **Cron \`bronze-contaazul-from-integrations\`**: desativado (não precisa mais).

## Validação

| Bar | Métrica | Bronze | Gold |
|---|---|---|---|
| Ord | Atrações Abr | R\$ 386.784,04 | R\$ 386.784,04 ✅ |
| Deb | Atrações Abr | R\$ 13.200,00 | R\$ 13.200,00 ✅ |
| Ord | CMV Compras Abr | — | R\$ 421.592,04 |
| Deb | CMV Compras Abr | — | R\$ 83.103,66 |

Soft-delete continua funcionando: 389 fantasmas Ord, 82 Deb.

## Próxima fase (futura)

Drop \`integrations.contaazul_lancamentos\` e demais funções zumbi (\`sync_contaazul_integrations_to_bronze\` etc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)