### PR TITLE
chore(medallion): drop integrations.contaazul_lancamentos + migrar consumidores

### DIFF
--- a/backend/supabase/functions/_shared/calculators/calc-custos.ts
+++ b/backend/supabase/functions/_shared/calculators/calc-custos.ts
@@ -41,14 +41,15 @@ async function getCustoAtracao(
   categoriasAtracao: string[]
 ): Promise<{ valor: number; count: number }> {
   const { data, error } = await supabase
-    .schema('integrations')
-    .from('contaazul_lancamentos')
+    .schema('bronze')
+    .from('bronze_contaazul_lancamentos')
     .select('valor_bruto')
     .eq('bar_id', barId)
     .eq('tipo', 'DESPESA')
     .in('categoria_nome', categoriasAtracao)
     .gte('data_competencia', startDate)
-    .lte('data_competencia', endDate);
+    .lte('data_competencia', endDate)
+    .is('excluido_em', null);
 
   if (error) {
     console.warn('[calc-custos] Erro ao buscar lancamentos:', error.message);

--- a/backend/supabase/functions/cmv-semanal-auto/index.ts
+++ b/backend/supabase/functions/cmv-semanal-auto/index.ts
@@ -350,12 +350,13 @@ serve(async (req) => {
         // - Ordinário: ALIMENTAÇÃO
         // - Deboche: Alimentação
         const { data: compras } = await supabase
-          .schema('integrations')
-          .from('contaazul_lancamentos')
+          .schema('bronze')
+          .from('bronze_contaazul_lancamentos')
           .select('valor_bruto, categoria_nome, tipo')
           .eq('bar_id', barId)
           .gte('data_competencia', dataInicio)
           .lte('data_competencia', dataFim)
+          .is('excluido_em', null)
           .or('categoria_nome.ilike.%custo comida%,categoria_nome.ilike.%custo bebida%,categoria_nome.ilike.%custo drink%,categoria_nome.ilike.%custo outros%,categoria_nome.ilike.alimenta%');
 
         const comprasPorCategoria = {


### PR DESCRIPTION
## Summary

Conclui o refactor medallion para \`contaazul_lancamentos\`. Pipeline final:

\`\`\`
CA API ──→ bronze.bronze_contaazul_lancamentos
       ──→ silver.contaazul_lancamentos_diarios (etl_silver_*)
       ──→ gold.desempenho + financial.cmv_mensal
\`\`\`

## Mudanças

- **\`cmv-semanal-auto/index.ts\`**: lê de bronze (com filtro \`excluido_em IS NULL\`).
- **\`_shared/calculators/calc-custos.ts\`**: idem.
- **SQL functions** (migration aplicada): \`calculate_evento_metrics\` + \`verificar_sync_silencioso_falae_contaazul\` agora lêem de bronze.
- **Drop**: \`integrations.contaazul_lancamentos\`, \`sync_contaazul_integrations_to_bronze()\`, \`bronze_sync_integrations_to_bronze()\`.

## Validação pós-drop

Bronze Ord abril: **2.009 lançamentos** intactos. Pipeline silver/gold/CMV continua operando normalmente.

## Próximas tasks (futuras)

Outras tabelas em \`integrations.*\` ainda existem e serão migradas separadamente:
- Sympla (eventos, participantes, pedidos)
- Yuzer (pagamento, produtos, eventos, fatporhora)
- Umbler (conversas, mensagens, campanhas — afeta frontend)
- Getin (sync_logs)
- Google reviews
- Falae respostas

Tabelas de **config/credenciais/logs** ficam em integrations (não são dados raw):
\`bar_api_configs\`, \`google_oauth_tokens\`, \`falae_config\`, \`umbler_config\`, \`*_logs_sincronizacao\`, \`*_sync_logs\`, \`*_webhook_logs\`, \`*_imports\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)