### PR TITLE
chore(medallion): contaazul auxiliares + drop google_reviews

### DIFF
--- a/backend/supabase/functions/contaazul-sync/index.ts
+++ b/backend/supabase/functions/contaazul-sync/index.ts
@@ -464,8 +464,8 @@ async function syncCategorias(
   }))
 
   const { error } = await supabase
-    .schema('integrations')
-    .from('contaazul_categorias')
+    .schema('bronze')
+    .from('bronze_contaazul_categorias')
     .upsert(categorias, { onConflict: 'contaazul_id,bar_id', ignoreDuplicates: false })
 
   if (error) {
@@ -515,8 +515,8 @@ async function syncCentrosCusto(
   }))
 
   const { error } = await supabase
-    .schema('integrations')
-    .from('contaazul_centros_custo')
+    .schema('bronze')
+    .from('bronze_contaazul_centros_custo')
     .upsert(centros, { onConflict: 'contaazul_id,bar_id', ignoreDuplicates: false })
 
   if (error) {
@@ -567,8 +567,8 @@ async function syncPessoas(
       }))
 
       const { error } = await supabase
-        .schema('integrations')
-        .from('contaazul_pessoas')
+        .schema('bronze')
+        .from('bronze_contaazul_pessoas')
         .upsert(pessoas, { onConflict: 'contaazul_id,bar_id', ignoreDuplicates: false })
 
       if (error) {
@@ -608,8 +608,8 @@ async function syncPessoas(
       }))
 
       const { error } = await supabase
-        .schema('integrations')
-        .from('contaazul_pessoas')
+        .schema('bronze')
+        .from('bronze_contaazul_pessoas')
         .upsert(pessoas, { onConflict: 'contaazul_id,bar_id', ignoreDuplicates: false })
 
       if (error) {
@@ -667,8 +667,8 @@ async function syncContasFinanceiras(
   }))
 
   const { error } = await supabase
-    .schema('integrations')
-    .from('contaazul_contas_financeiras')
+    .schema('bronze')
+    .from('bronze_contaazul_contas_financeiras')
     .upsert(contas, { onConflict: 'contaazul_id,bar_id', ignoreDuplicates: false })
 
   if (error) {

--- a/frontend/src/app/api/financeiro/contaazul/categorias/route.ts
+++ b/frontend/src/app/api/financeiro/contaazul/categorias/route.ts
@@ -31,8 +31,8 @@ export async function GET(request: NextRequest) {
       let from = 0;
       const PAGE = 1000;
       while (true) {
-        let query = (supabase.schema('integrations' as any) as any)
-          .from('contaazul_categorias')
+        let query = (supabase.schema('bronze' as any) as any)
+          .from('bronze_contaazul_categorias')
           .select('*')
           .eq('bar_id', parseInt(barId));
         if (tipo) query = query.eq('tipo', tipo);
@@ -114,8 +114,8 @@ export async function GET(request: NextRequest) {
 
     if (categoriasParaSalvar.length > 0) {
       const { error: upsertError } = await supabase
-        .schema('integrations' as any)
-        .from('contaazul_categorias')
+        .schema('bronze' as any)
+        .from('bronze_contaazul_categorias')
         .upsert(categoriasParaSalvar, {
           onConflict: 'contaazul_id',
         });
@@ -136,8 +136,8 @@ export async function GET(request: NextRequest) {
       .filter(Boolean);
     if (idsRecebidos.length > 0) {
       const { error: deactivateError } = await (supabase
-        .schema('integrations' as any) as any)
-        .from('contaazul_categorias')
+        .schema('bronze' as any) as any)
+        .from('bronze_contaazul_categorias')
         .update({ ativo: false, updated_at: new Date().toISOString() })
         .eq('bar_id', parseInt(barId))
         .not('contaazul_id', 'in', `(${idsRecebidos.map(id => `"${id}"`).join(',')})`);

--- a/frontend/src/app/api/financeiro/contaazul/centros-custo/route.ts
+++ b/frontend/src/app/api/financeiro/contaazul/centros-custo/route.ts
@@ -31,8 +31,8 @@ export async function GET(request: NextRequest) {
       const PAGE = 1000;
       while (true) {
         const { data, error } = await (supabase
-          .schema('integrations' as any) as any)
-          .from('contaazul_centros_custo')
+          .schema('bronze' as any) as any)
+          .from('bronze_contaazul_centros_custo')
           .select('*')
           .eq('bar_id', parseInt(barId))
           .order('nome')
@@ -111,8 +111,8 @@ export async function GET(request: NextRequest) {
 
     if (centrosParaSalvar.length > 0) {
       const { error: upsertError } = await supabase
-        .schema('integrations' as any)
-        .from('contaazul_centros_custo')
+        .schema('bronze' as any)
+        .from('bronze_contaazul_centros_custo')
         .upsert(centrosParaSalvar, {
           onConflict: 'contaazul_id',
         });
@@ -130,8 +130,8 @@ export async function GET(request: NextRequest) {
     const idsRecebidos = centrosParaSalvar.map(c => c.contaazul_id).filter(Boolean);
     if (idsRecebidos.length > 0) {
       const { error: deactivateError } = await (supabase
-        .schema('integrations' as any) as any)
-        .from('contaazul_centros_custo')
+        .schema('bronze' as any) as any)
+        .from('bronze_contaazul_centros_custo')
         .update({ ativo: false, updated_at: new Date().toISOString() })
         .eq('bar_id', parseInt(barId))
         .not('contaazul_id', 'in', `(${idsRecebidos.map(id => `"${id}"`).join(',')})`);

--- a/frontend/src/app/api/financeiro/contaazul/contas-financeiras/route.ts
+++ b/frontend/src/app/api/financeiro/contaazul/contas-financeiras/route.ts
@@ -27,8 +27,8 @@ export async function GET(request: NextRequest) {
 
     if (!sync) {
       const { data, error } = await (supabase
-        .schema('integrations' as any) as any)
-        .from('contaazul_contas_financeiras')
+        .schema('bronze' as any) as any)
+        .from('bronze_contaazul_contas_financeiras')
         .select('*')
         .eq('bar_id', parseInt(barId))
         .eq('ativo', true)
@@ -93,8 +93,8 @@ export async function GET(request: NextRequest) {
 
     if (contasParaSalvar.length > 0) {
       const { error: upsertError } = await (supabase
-        .schema('integrations' as any) as any)
-        .from('contaazul_contas_financeiras')
+        .schema('bronze' as any) as any)
+        .from('bronze_contaazul_contas_financeiras')
         .upsert(contasParaSalvar, { onConflict: 'contaazul_id' });
       if (upsertError) {
         console.error('Erro upsert contas:', upsertError);
@@ -109,8 +109,8 @@ export async function GET(request: NextRequest) {
     const idsRecebidos = contasParaSalvar.map((c: any) => c.contaazul_id).filter(Boolean);
     if (idsRecebidos.length > 0) {
       const { error: deactivateError } = await (supabase
-        .schema('integrations' as any) as any)
-        .from('contaazul_contas_financeiras')
+        .schema('bronze' as any) as any)
+        .from('bronze_contaazul_contas_financeiras')
         .update({ ativo: false, updated_at: new Date().toISOString() })
         .eq('bar_id', parseInt(barId))
         .not('contaazul_id', 'in', `(${idsRecebidos.map((id: string) => `"${id}"`).join(',')})`);

--- a/frontend/src/app/api/financeiro/contaazul/lancamentos/route.ts
+++ b/frontend/src/app/api/financeiro/contaazul/lancamentos/route.ts
@@ -209,8 +209,8 @@ export async function POST(request: NextRequest) {
       const documento = String(cpf_cnpj).replace(/\D/g, '');
       if (documento.length === 11 || documento.length === 14) {
         const { data: pessoa } = await (supabase
-          .schema('integrations' as any) as any)
-          .from('contaazul_pessoas')
+          .schema('bronze' as any) as any)
+          .from('bronze_contaazul_pessoas')
           .select('contaazul_id')
           .eq('bar_id', barIdNum)
           .eq('documento', documento)
@@ -236,8 +236,8 @@ export async function POST(request: NextRequest) {
       const PAGE = 1000;
       while (!resolvedPessoaId) {
         const { data: candidatos } = await (supabase
-          .schema('integrations' as any) as any)
-          .from('contaazul_pessoas')
+          .schema('bronze' as any) as any)
+          .from('bronze_contaazul_pessoas')
           .select('contaazul_id, nome')
           .eq('bar_id', barIdNum)
           .eq('perfil', 'FORNECEDOR')

--- a/frontend/src/app/api/financeiro/contaazul/match-fornecedores/route.ts
+++ b/frontend/src/app/api/financeiro/contaazul/match-fornecedores/route.ts
@@ -89,8 +89,8 @@ export async function POST(request: NextRequest) {
     const PAGE = 1000;
     while (true) {
       const { data: pessoas, error } = await (supabase
-        .schema('integrations' as any) as any)
-        .from('contaazul_pessoas')
+        .schema('bronze' as any) as any)
+        .from('bronze_contaazul_pessoas')
         .select('contaazul_id, nome, documento, email, telefone, perfil, ativo')
         .eq('bar_id', barId)
         .eq('perfil', 'FORNECEDOR')

--- a/frontend/src/app/api/financeiro/contaazul/pessoas/cadastrar/route.ts
+++ b/frontend/src/app/api/financeiro/contaazul/pessoas/cadastrar/route.ts
@@ -138,8 +138,8 @@ export async function POST(request: NextRequest) {
     };
 
     const { error: upErr } = await (supabase
-      .schema('integrations' as any) as any)
-      .from('contaazul_pessoas')
+      .schema('bronze' as any) as any)
+      .from('bronze_contaazul_pessoas')
       .upsert(localRow, { onConflict: 'contaazul_id' });
 
     if (upErr) {

--- a/frontend/src/app/api/financeiro/contaazul/stakeholders/route.ts
+++ b/frontend/src/app/api/financeiro/contaazul/stakeholders/route.ts
@@ -31,8 +31,8 @@ export async function GET(request: NextRequest) {
       let from = 0;
       const PAGE = 1000;
       while (true) {
-        let query = (supabase.schema('integrations' as any) as any)
-          .from('contaazul_pessoas')
+        let query = (supabase.schema('bronze' as any) as any)
+          .from('bronze_contaazul_pessoas')
           .select('*')
           .eq('bar_id', parseInt(barId));
         if (perfil) query = query.eq('perfil', perfil);
@@ -172,8 +172,8 @@ export async function GET(request: NextRequest) {
     const idsRecebidos = pessoasDedupadas.map(p => p.contaazul_id).filter(Boolean);
     if (idsRecebidos.length > 0) {
       const { error: deactivateError } = await (supabase
-        .schema('integrations' as any) as any)
-        .from('contaazul_pessoas')
+        .schema('bronze' as any) as any)
+        .from('bronze_contaazul_pessoas')
         .update({ ativo: false })
         .eq('bar_id', parseInt(barId))
         .not('contaazul_id', 'in', `(${idsRecebidos.map(id => `"${id}"`).join(',')})`);
@@ -185,8 +185,8 @@ export async function GET(request: NextRequest) {
     if (pessoasDedupadas.length > 0) {
       // Usar upsert para evitar duplicatas
       const { error: upsertError } = await supabase
-        .schema('integrations' as any)
-        .from('contaazul_pessoas')
+        .schema('bronze' as any)
+        .from('bronze_contaazul_pessoas')
         .upsert(pessoasDedupadas, {
           onConflict: 'contaazul_id,bar_id',
           ignoreDuplicates: false

--- a/frontend/src/app/api/financeiro/contaazul/status/route.ts
+++ b/frontend/src/app/api/financeiro/contaazul/status/route.ts
@@ -39,12 +39,13 @@ export async function GET(request: NextRequest) {
     const supabase = getSupabaseAdmin();
 
     const integrationsClient = supabase.schema('integrations' as any);
+    const bronzeClient = supabase.schema('bronze' as any);
     const [lancamentosCount, categoriasCount, centrosCustoCount, pessoasCount, contasCount] = await Promise.all([
       integrationsClient.from('contaazul_lancamentos').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId)),
-      integrationsClient.from('contaazul_categorias').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId)),
-      integrationsClient.from('contaazul_centros_custo').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId)),
-      integrationsClient.from('contaazul_pessoas').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId)),
-      integrationsClient.from('contaazul_contas_financeiras').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId))
+      bronzeClient.from('bronze_contaazul_categorias').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId)),
+      bronzeClient.from('bronze_contaazul_centros_custo').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId)),
+      bronzeClient.from('bronze_contaazul_pessoas').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId)),
+      bronzeClient.from('bronze_contaazul_contas_financeiras').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId))
     ]);
 
     const { data: lastLog } = await supabase


### PR DESCRIPTION
Fecha 100% contaazul em bronze (lancamentos, categorias, centros_custo, contas_financeiras, pessoas) + drop integrations.google_reviews (12.784 reg). Restante em integrations: só configs/logs + sympla/umbler/yuzer (próximas sprints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)