### PR TITLE
fix(post-medallion): rotas e RPC quebradas após drop de integrations.contaazul_*

### DIFF
--- a/frontend/src/app/api/debug/conta-azul-lancamentos/route.ts
+++ b/frontend/src/app/api/debug/conta-azul-lancamentos/route.ts
@@ -11,10 +11,11 @@ export async function GET(request: NextRequest) {
     const dataFim = searchParams.get('data_fim') || '2026-04-05';
     
     const { data, error } = await supabase
-      .schema('integrations' as any)
-      .from('contaazul_lancamentos')
+      .schema('bronze' as any)
+      .from('bronze_contaazul_lancamentos')
       .select('categoria_nome, valor_bruto, tipo, descricao, data_competencia')
       .eq('bar_id', barId)
+      .is('excluido_em', null)
       .gte('data_competencia', dataInicio)
       .lte('data_competencia', dataFim)
       .order('data_competencia', { ascending: true });

--- a/frontend/src/app/api/estrategico/orcamentacao/analise-detalhada/route.ts
+++ b/frontend/src/app/api/estrategico/orcamentacao/analise-detalhada/route.ts
@@ -4,20 +4,22 @@ import { NextResponse } from 'next/server';
 export const dynamic = 'force-dynamic'
 
 // Função para buscar dados com paginação (contorna limite de 1000 do Supabase)
-async function fetchAllData(supabase: any, tableName: string, columns: string, filters: any = {}) {
+async function fetchAllData(supabase: any, tableName: string, columns: string, filters: any = {}, schema?: string) {
   let allData: any[] = [];
   let from = 0;
   const limit = 1000;
-  
+
+  const base = schema ? supabase.schema(schema) : supabase;
+
   const MAX_ITERATIONS = 1000;
   let iterations = 0;
   while (iterations < MAX_ITERATIONS) {
     iterations++;
-    let query = supabase
+    let query = base
       .from(tableName)
       .select(columns)
       .range(from, from + limit - 1);
-    
+
     // Aplicar filtros
     Object.entries(filters).forEach(([key, value]) => {
       if (key.includes('gte_')) {
@@ -28,6 +30,8 @@ async function fetchAllData(supabase: any, tableName: string, columns: string, f
         query = query.eq(key.replace('eq_', ''), value);
       } else if (key.includes('in_')) {
         query = query.in(key.replace('in_', ''), value);
+      } else if (key.startsWith('is_')) {
+        query = query.is(key.replace('is_', ''), value);
       }
     });
     
@@ -86,12 +90,13 @@ export async function GET(request: Request) {
       endDate = `${ano}-12-31`;
     }
 
-    // Buscar lan�amentos do Conta Azul para o período
-    const lancamentosData = await fetchAllData(supabase, 'contaazul_lancamentos', 'categoria_nome, status, valor_bruto, data_competencia, data_pagamento', {
+    // Buscar lançamentos do Conta Azul para o período (bronze pós-medallion)
+    const lancamentosData = await fetchAllData(supabase, 'bronze_contaazul_lancamentos', 'categoria_nome, status, valor_bruto, data_competencia, data_pagamento', {
       'eq_bar_id': parseInt(barId),
+      'is_excluido_em': null,
       'gte_data_competencia': startDate,
       'lte_data_competencia': endDate
-    });
+    }, 'bronze');
 
     // Mapa de categorias problemáticas que o usuário mencionou
     const categoriasProblematicas = [

--- a/frontend/src/app/api/estrategico/orcamentacao/todos-meses/route.ts
+++ b/frontend/src/app/api/estrategico/orcamentacao/todos-meses/route.ts
@@ -36,6 +36,8 @@ async function fetchAllPaginated<T>(
         query = query.lte(filter.column, filter.value);
       } else if (filter.operator === 'in') {
         query = query.in(filter.column, filter.value);
+      } else if (filter.operator === 'is') {
+        query = query.is(filter.column, filter.value);
       }
     }
 
@@ -390,22 +392,24 @@ export async function GET(request: Request) {
       // Query 2: Conta Azul todos (projeção) - COM PAGINAÇÃO
       fetchAllPaginated<{ categoria_nome: string; status: string; valor_bruto: string; data_competencia: string }>(
         supabase,
-        'contaazul_lancamentos',
+        'bronze_contaazul_lancamentos',
         'categoria_nome, status, valor_bruto, data_competencia',
         [
           { column: 'bar_id', operator: 'eq', value: parseInt(barId) },
+          { column: 'excluido_em', operator: 'is', value: null },
           { column: 'data_competencia', operator: 'gte', value: dataInicio },
           { column: 'data_competencia', operator: 'lte', value: dataFim }
         ]
       ),
-      
+
       // Query 3: Conta Azul pagos (realizado) - COM PAGINAÇÃO - usar data_pagamento
       fetchAllPaginated<{ categoria_nome: string; status: string; valor_bruto: string; data_pagamento: string }>(
         supabase,
-        'contaazul_lancamentos',
+        'bronze_contaazul_lancamentos',
         'categoria_nome, status, valor_bruto, data_pagamento',
         [
           { column: 'bar_id', operator: 'eq', value: parseInt(barId) },
+          { column: 'excluido_em', operator: 'is', value: null },
           { column: 'status', operator: 'in', value: ['PAGO', 'LIQUIDADO'] },
           { column: 'data_pagamento', operator: 'gte', value: dataInicio },
           { column: 'data_pagamento', operator: 'lte', value: dataFim }

--- a/frontend/src/app/api/financeiro/contaazul/consultas/lancamentos-retroativos/route.ts
+++ b/frontend/src/app/api/financeiro/contaazul/consultas/lancamentos-retroativos/route.ts
@@ -19,18 +19,19 @@ export async function GET(request: NextRequest) {
     const mesesRetroativos = parseInt(searchParams.get('meses_retroativos') || '1');
 
     let query = supabase
-      .schema('integrations' as any)
-      .from('contaazul_lancamentos')
+      .schema('bronze' as any)
+      .from('bronze_contaazul_lancamentos')
       .select(`
         contaazul_id, bar_id, tipo, status, status_traduzido,
         descricao, valor_bruto, valor_pago, valor_nao_pago,
         data_competencia, data_vencimento, data_pagamento,
-        data_criacao_ca, data_alteracao_ca, created_at, updated_at,
+        data_criacao_ca, data_alteracao_ca, synced_at,
         categoria_id, categoria_nome,
         pessoa_id, pessoa_nome,
         numero_parcela, total_parcelas,
         todos_centros_custo
       `)
+      .is('excluido_em', null)
       .order('data_criacao_ca', { ascending: false })
       .limit(500);
 

--- a/frontend/src/app/api/financeiro/contaazul/lancamentos/route.ts
+++ b/frontend/src/app/api/financeiro/contaazul/lancamentos/route.ts
@@ -56,10 +56,11 @@ export async function GET(request: NextRequest) {
     const offset = (page - 1) * limit;
 
     let query = supabase
-      .schema('integrations' as any)
-      .from('contaazul_lancamentos')
+      .schema('bronze' as any)
+      .from('bronze_contaazul_lancamentos')
       .select('*', { count: 'exact' })
-      .eq('bar_id', parseInt(barId));
+      .eq('bar_id', parseInt(barId))
+      .is('excluido_em', null);
 
     if (tipo) query = query.eq('tipo', tipo);
     if (status) query = query.eq('status', status);
@@ -84,10 +85,11 @@ export async function GET(request: NextRequest) {
     }
 
     const queryTotais = supabase
-      .schema('integrations' as any)
-      .from('contaazul_lancamentos')
+      .schema('bronze' as any)
+      .from('bronze_contaazul_lancamentos')
       .select('valor_bruto, valor_pago, status, tipo')
-      .eq('bar_id', parseInt(barId));
+      .eq('bar_id', parseInt(barId))
+      .is('excluido_em', null);
 
     if (tipo) queryTotais.eq('tipo', tipo);
     if (status) queryTotais.eq('status', status);

--- a/frontend/src/app/api/financeiro/contaazul/status/route.ts
+++ b/frontend/src/app/api/financeiro/contaazul/status/route.ts
@@ -38,10 +38,9 @@ export async function GET(request: NextRequest) {
 
     const supabase = getSupabaseAdmin();
 
-    const integrationsClient = supabase.schema('integrations' as any);
     const bronzeClient = supabase.schema('bronze' as any);
     const [lancamentosCount, categoriasCount, centrosCustoCount, pessoasCount, contasCount] = await Promise.all([
-      integrationsClient.from('contaazul_lancamentos').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId)),
+      bronzeClient.from('bronze_contaazul_lancamentos').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId)).is('excluido_em', null),
       bronzeClient.from('bronze_contaazul_categorias').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId)),
       bronzeClient.from('bronze_contaazul_centros_custo').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId)),
       bronzeClient.from('bronze_contaazul_pessoas').select('id', { count: 'exact', head: true }).eq('bar_id', parseInt(barId)),

--- a/frontend/src/app/api/financeiro/dre-categorias/route.ts
+++ b/frontend/src/app/api/financeiro/dre-categorias/route.ts
@@ -79,9 +79,10 @@ export async function GET(request: NextRequest) {
     const mes = searchParams.get('mes');
 
     let query = supabase
-      .schema('integrations' as any)
-      .from('contaazul_lancamentos')
-      .select('categoria_nome, valor_bruto, bar_id');
+      .schema('bronze' as any)
+      .from('bronze_contaazul_lancamentos')
+      .select('categoria_nome, valor_bruto, bar_id')
+      .is('excluido_em', null);
 
     if (barId) query = query.eq('bar_id', parseInt(barId));
     if (ano && mes) {

--- a/frontend/src/app/api/saude-dados/resumo/route.ts
+++ b/frontend/src/app/api/saude-dados/resumo/route.ts
@@ -40,12 +40,13 @@ export async function GET(request: NextRequest) {
     const ontem = new Date()
     ontem.setDate(ontem.getDate() - 1)
 
-    // Verificar syncs do Conta Azul nas últimas 24h
+    // Verificar syncs do Conta Azul nas últimas 24h (bronze pós-medallion)
     const { data: syncs } = await supabase
-      .schema('integrations' as any)
-      .from('contaazul_lancamentos')
+      .schema('bronze' as any)
+      .from('bronze_contaazul_lancamentos')
       .select('id')
-      .gte('created_at', ontem.toISOString())
+      .is('excluido_em', null)
+      .gte('synced_at', ontem.toISOString())
 
     const syncsOk = syncs?.length || 0
     const syncsTotal = syncs?.length || 0

--- a/frontend/src/app/api/saude-dados/route.ts
+++ b/frontend/src/app/api/saude-dados/route.ts
@@ -13,8 +13,12 @@ export async function GET(request: NextRequest) {
     const barId = user.bar_id
     if (!barId) return NextResponse.json({ error: 'bar_id é obrigatório' }, { status: 400 })
 
+    const systemClient = supabase.schema('system' as any)
+    const integrationsClient = supabase.schema('integrations' as any)
+    const silverClient = supabase.schema('silver' as any)
+
     // Buscar validações dos últimos 30 dias
-    const { data: validacoes, error: validacoesError } = await supabase
+    const { data: validacoes, error: validacoesError } = await systemClient
       .from('validacao_dados_diaria')
       .select('*')
       .eq('bar_id', barId)
@@ -26,7 +30,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Buscar alertas (últimos 50)
-    const { data: alertas, error: alertasError } = await supabase
+    const { data: alertas, error: alertasError } = await systemClient
       .from('sistema_alertas')
       .select('*')
       .order('criado_em', { ascending: false })
@@ -37,7 +41,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Buscar dados bloqueados
-    const { data: bloqueados, error: bloqueadosError } = await supabase
+    const { data: bloqueados, error: bloqueadosError } = await systemClient
       .from('dados_bloqueados')
       .select('*')
       .eq('bar_id', barId)
@@ -49,47 +53,55 @@ export async function GET(request: NextRequest) {
       console.error('Erro ao buscar bloqueados:', bloqueadosError)
     }
 
-    // NIBO descontinuado - dados mantidos apenas para histórico
-    const niboSync = null;
-
-    const { data: contahubSync } = await supabase
-      .schema('silver' as never)
+    const { data: contahubSync } = await silverClient
       .from('faturamento_pagamentos')
       .select('atualizado_em')
       .eq('bar_id', barId)
       .order('atualizado_em', { ascending: false })
       .limit(1)
-      .single()
+      .maybeSingle()
 
-    const { data: symplaSync } = await supabase
+    const { data: symplaSync } = await integrationsClient
       .from('sympla_pedidos')
       .select('created_at')
       .order('created_at', { ascending: false })
       .limit(1)
-      .single()
+      .maybeSingle()
 
-    const { data: yuzerSync } = await supabase
+    const { data: yuzerSync } = await silverClient
       .from('silver_yuzer_pagamentos_evento')
       .select('created_at')
       .order('created_at', { ascending: false })
       .limit(1)
-      .single()
+      .maybeSingle()
 
-    // NIBO descontinuado
-    const niboCount = 0;
-
-    const { count: contahubCount } = await supabase
-      .schema('silver' as never)
+    const { count: contahubCount } = await silverClient
       .from('faturamento_pagamentos')
       .select('*', { count: 'exact', head: true })
       .eq('bar_id', barId)
 
+    const bronzeClient = supabase.schema('bronze' as any)
+    const { data: contaazulSync } = await bronzeClient
+      .from('bronze_contaazul_lancamentos')
+      .select('synced_at')
+      .eq('bar_id', barId)
+      .is('excluido_em', null)
+      .order('synced_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    const { count: contaazulCount } = await bronzeClient
+      .from('bronze_contaazul_lancamentos')
+      .select('*', { count: 'exact', head: true })
+      .eq('bar_id', barId)
+      .is('excluido_em', null)
+
     const statusSyncs = [
       {
         sistema: 'Conta Azul',
-        ultima_sync: null,
-        status: 'integrado via lancamentos_financeiros',
-        registros: 0
+        ultima_sync: contaazulSync?.synced_at || null,
+        status: contaazulSync ? 'ok' : 'sem dados',
+        registros: contaazulCount || 0
       },
       {
         sistema: 'ContaHub',

--- a/frontend/src/app/api/saude-dados/syncs/route.ts
+++ b/frontend/src/app/api/saude-dados/syncs/route.ts
@@ -33,17 +33,18 @@ export async function GET(request: NextRequest) {
       erros: 0
     })
 
-    // Conta Azul — verificar último lançamento importado
+    // Conta Azul — verificar último lançamento importado (bronze pós-medallion)
     const { data: contaazulData } = await supabase
-      .schema('integrations' as any)
-      .from('contaazul_lancamentos')
-      .select('created_at')
-      .order('created_at', { ascending: false })
+      .schema('bronze' as any)
+      .from('bronze_contaazul_lancamentos')
+      .select('synced_at')
+      .is('excluido_em', null)
+      .order('synced_at', { ascending: false })
       .limit(1)
 
     syncStatus.push({
       sistema: 'Conta Azul',
-      ultima_sync: contaazulData?.[0]?.created_at ? new Date(contaazulData[0].created_at).toLocaleString('pt-BR') : 'N/A',
+      ultima_sync: contaazulData?.[0]?.synced_at ? new Date(contaazulData[0].synced_at).toLocaleString('pt-BR') : 'N/A',
       status: contaazulData && contaazulData.length > 0 ? 'ok' : 'warning',
       registros: contaazulData?.length || 0,
       erros: 0

--- a/frontend/src/app/api/saude-dados/validar/route.ts
+++ b/frontend/src/app/api/saude-dados/validar/route.ts
@@ -13,20 +13,20 @@ export async function POST(request: NextRequest) {
     const barId = user.bar_id
     if (!barId) return NextResponse.json({ error: 'bar_id é obrigatório' }, { status: 400 })
 
-    // Executar validação para ontem
-    const { data, error } = await supabase.rpc('executar_validacao_diaria', {
-      p_data: null, // null = ontem
-      p_bar_id: barId
-    })
+    const { data, error } = await supabase.rpc('validar_dados_contahub_diario')
 
     if (error) {
       console.error('Erro ao executar validação:', error)
       return NextResponse.json({ success: false, error: error.message }, { status: 500 })
     }
 
+    const resultados = (data ?? []).filter((r: any) => r.bar_id === barId)
+    const problemas = resultados.length
+
     return NextResponse.json({
       success: true,
-      resultado: data
+      problemas_detectados: problemas,
+      resultado: resultados
     })
 
   } catch (error: any) {

--- a/frontend/src/app/configuracoes/saude-dados/page.tsx
+++ b/frontend/src/app/configuracoes/saude-dados/page.tsx
@@ -24,6 +24,7 @@ import { LoadingState } from '@/components/ui/loading-state'
 import { usePageTitle } from '@/contexts/PageTitleContext'
 import { format, parseISO, subDays } from 'date-fns'
 import { ptBR } from 'date-fns/locale'
+import { toast } from 'sonner'
 
 interface Validacao {
   id: number
@@ -108,12 +109,21 @@ export default function SaudeDadosPage() {
       setExecutandoValidacao(true)
       const response = await fetch('/api/saude-dados/validar', { method: 'POST' })
       const data = await response.json()
-      
+
       if (data.success) {
+        const n = data.problemas_detectados ?? 0
+        if (n === 0) {
+          toast.success('Validação OK', { description: 'Nenhum problema detectado' })
+        } else {
+          toast.warning(`${n} problema(s) detectado(s)`, { description: 'Verifique a aba Validações' })
+        }
         fetchData()
+      } else {
+        toast.error('Erro ao validar', { description: data.error || 'Tente novamente' })
       }
-    } catch (error) {
+    } catch (error: any) {
       console.error('Erro ao executar validação:', error)
+      toast.error('Erro ao validar', { description: error?.message })
     } finally {
       setExecutandoValidacao(false)
     }

--- a/frontend/src/app/estrategico/orcamentacao/services/orcamentacao-service.ts
+++ b/frontend/src/app/estrategico/orcamentacao/services/orcamentacao-service.ts
@@ -213,6 +213,7 @@ async function fetchAllPaginated<T>(
       else if (filter.operator === 'gte') query = query.gte(filter.column, filter.value);
       else if (filter.operator === 'lte') query = query.lte(filter.column, filter.value);
       else if (filter.operator === 'in') query = query.in(filter.column, filter.value);
+      else if (filter.operator === 'is') query = query.is(filter.column, filter.value);
     }
     const { data, error } = await query.range(offset, offset + pageSize - 1);
     if (error) { console.error(`Erro ao buscar ${table}:`, error); break; }
@@ -300,13 +301,15 @@ export async function getOrcamentacaoCompleta(supabase: SupabaseClient, barId: n
 
   const [planejadosResult, dadosNiboTodos, dadosNiboPagos, manuaisResult, eventosResult] = await Promise.all([
     supabase.from('orcamentacao').select('*').eq('bar_id', barId).in('ano', anosUnicos),
-    fetchAllPaginated<any>(supabase, 'contaazul_lancamentos', 'categoria_nome, status, valor_bruto, data_competencia', [
+    fetchAllPaginated<any>(supabase, 'bronze_contaazul_lancamentos', 'categoria_nome, status, valor_bruto, data_competencia', [
       { column: 'bar_id', operator: 'eq', value: barId },
+      { column: 'excluido_em', operator: 'is', value: null },
       { column: 'data_competencia', operator: 'gte', value: dataInicio },
       { column: 'data_competencia', operator: 'lte', value: dataFim }
     ]),
-    fetchAllPaginated<any>(supabase, 'contaazul_lancamentos', 'categoria_nome, status, valor_bruto, data_pagamento', [
+    fetchAllPaginated<any>(supabase, 'bronze_contaazul_lancamentos', 'categoria_nome, status, valor_bruto, data_pagamento', [
       { column: 'bar_id', operator: 'eq', value: barId },
+      { column: 'excluido_em', operator: 'is', value: null },
       { column: 'status', operator: 'in', value: ['PAGO', 'LIQUIDADO'] },
       { column: 'data_pagamento', operator: 'gte', value: dataInicio },
       { column: 'data_pagamento', operator: 'lte', value: dataFim }

--- a/frontend/src/lib/supabase/table-schemas.ts
+++ b/frontend/src/lib/supabase/table-schemas.ts
@@ -161,12 +161,9 @@ export const TABLE_SCHEMAS = {
   // ============================================
   api_credentials: 'integrations',
   bar_api_configs: 'integrations',
-  contaazul_categorias: 'integrations',
-  contaazul_centros_custo: 'integrations',
-  contaazul_contas_financeiras: 'integrations',
-  contaazul_lancamentos: 'integrations',
+  // contaazul_categorias / centros_custo / contas_financeiras / lancamentos / pessoas
+  // foram dropadas no refactor medallion. Use bronze_contaazul_* (já mapeadas abaixo).
   contaazul_logs_sincronizacao: 'integrations',
-  contaazul_pessoas: 'integrations',
   falae_config: 'integrations',  // config/credenciais — fica em integrations
   // falae_respostas: dropada de integrations; usar bronze_falae_respostas
   getin_reservas: 'bronze',  // existe em bronze sem prefixo


### PR DESCRIPTION
## Summary
Refactor medallion deixou várias telas/RPCs apontando pra `integrations.contaazul_*` (dropada). Telas afetadas:

- 🔴 `/configuracoes/monitoramento` — DB 0mb / 0 eventos / 0 alertas (RPC `system.health_metrics_snapshot()` quebrada)
- 🔴 `/ferramentas/consultas` — 500 ("could not find the table integrations.contaazul")
- 🔴 `/configuracoes/saude-dados` — botão "Validar Agora" sem efeito + página vazia (queries sem `.schema('system')`, RPC inexistente)
- 🔴 Orçamentação, DRE, financeiro/contaazul — silenciosamente vazias

## Changes

**DB migration** (`health_metrics_snapshot_aponta_bronze_contaazul`):
- Apontar pra `bronze.bronze_contaazul_lancamentos` com `excluido_em IS NULL`
- Validado: agora retorna 898 eventos / 3455MB / sync 2026-05-07

**14 frontend files** migrados pra `bronze_contaazul_lancamentos` + filtro `excluido_em IS NULL`:
- `api/financeiro/contaazul/{status,lancamentos,consultas/lancamentos-retroativos}`
- `api/financeiro/dre-categorias`
- `api/saude-dados/{route,resumo,syncs,validar}`
- `api/debug/conta-azul-lancamentos`
- `api/estrategico/orcamentacao/{todos-meses,analise-detalhada}`
- `estrategico/orcamentacao/services/orcamentacao-service`
- `lib/supabase/table-schemas` (removido mapping das 5 tabelas dropadas)
- `configuracoes/saude-dados/page` (toast de feedback no botão)

**`/saude-dados/validar`**: trocado RPC inexistente `executar_validacao_diaria` → `validar_dados_contahub_diario`.

## Test plan
- [ ] `/configuracoes/monitoramento` mostra DB ~3.4GB, eventos ativos > 0
- [ ] `/configuracoes/saude-dados` carrega validações/alertas/syncs
- [ ] Botão "Validar Agora" mostra toast de sucesso
- [ ] `/ferramentas/consultas` carrega sem 500
- [ ] `/estrategico/orcamentacao` mostra dados de Conta Azul
- [ ] DRE financeiro carrega categorias

🤖 Generated with [Claude Code](https://claude.com/claude-code)