### PR TITLE
fix(consultas): aplicar filtro de categoria no backend ("Apenas CMV" ignorado)

### DIFF
--- a/frontend/src/app/api/financeiro/contaazul/consultas/lancamentos-retroativos/route.ts
+++ b/frontend/src/app/api/financeiro/contaazul/consultas/lancamentos-retroativos/route.ts
@@ -17,6 +17,8 @@ export async function GET(request: NextRequest) {
     const competenciaApos = searchParams.get('competencia_apos');
     const barId = searchParams.get('bar_id');
     const mesesRetroativos = parseInt(searchParams.get('meses_retroativos') || '1');
+    const categoriasParam = searchParams.get('categorias');
+    const categorias = categoriasParam ? categoriasParam.split(',').map(c => c.trim()).filter(Boolean) : [];
 
     let query = supabase
       .schema('bronze' as any)
@@ -40,6 +42,7 @@ export async function GET(request: NextRequest) {
     if (criadoAntes) query = query.lte('data_criacao_ca', criadoAntes);
     if (competenciaAntes) query = query.lte('data_competencia', competenciaAntes);
     if (competenciaApos) query = query.gte('data_competencia', competenciaApos);
+    if (categorias.length > 0) query = query.in('categoria_nome', categorias);
 
     const { data, error } = await query;
 


### PR DESCRIPTION
## Summary
Frontend de `/ferramentas/consultas` enviava `?categorias=...` no botão "Apenas CMV" e na seleção manual, mas o backend route não lia esse param nem filtrava — vinha tudo independente da categoria.

## Fix
- `lancamentos-retroativos/route.ts`: parse de `categorias` (csv) + `.in('categoria_nome', categorias)`

## Test plan
- [ ] Clicar em "📦 Apenas CMV" e buscar — deve trazer só Custo Bebidas/Comida/Drinks/Outros
- [ ] Selecionar categorias específicas — deve filtrar pelas selecionadas
- [ ] Sem filtro de categoria — comportamento atual (traz tudo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)