### PR TITLE
feat(financeiro): módulo Pedidos de Pagamento (substitui grupo WhatsApp)

### DIFF
--- a/database/migrations/2026-06-01-pedidos-pagamento.sql
+++ b/database/migrations/2026-06-01-pedidos-pagamento.sql
@@ -1,0 +1,148 @@
+-- ============================================================================
+-- Módulo "Pedidos de Pagamento" — substitui o grupo de WhatsApp de pagamentos.
+--
+-- Qualquer funcionário abre um pedido (reembolso / fornecedor / avulso /
+-- adiantamento). O financeiro (David) revisa, comenta, ajusta e aprova; ao
+-- aprovar, o sistema cria a conta a pagar no Conta Azul e agenda o PIX no Inter
+-- (motor que já existe em /api/financeiro/contaazul/lancamentos e
+-- /api/financeiro/inter/pix). Vínculo com o CA (pessoa/contato, categoria,
+-- centro de custo, conta pagadora) só acontece no momento da aprovação.
+--
+-- O schema `financial` já está exposto no PostgREST (pix_enviados funciona via
+-- supabase.schema('financial')); por isso só precisamos dos GRANTs + reload.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Pedido
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS financial.pedidos_pagamento (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  numero                   varchar,                       -- legível, ex PD-2026-0001 (fase 2)
+  bar_id                   integer NOT NULL,
+  tipo                     varchar NOT NULL,              -- 'reembolso'|'fornecedor'|'avulso'|'adiantamento'
+  status                   varchar NOT NULL DEFAULT 'aguardando_aprovacao',
+                           -- rascunho | aguardando_aprovacao | aprovado | agendado | pago
+                           -- | erro_ca | erro_inter | rejeitado | cancelado
+
+  -- Quem pediu
+  solicitante_id           varchar,                       -- usuarios.auth_id
+  solicitante_nome         varchar,
+
+  -- Conteúdo do pedido (preenchido pelo solicitante)
+  descricao                text NOT NULL,
+  valor                    numeric(12,2) NOT NULL,
+  data_competencia         date,
+  data_vencimento          date NOT NULL,
+  beneficiario_nome        varchar,
+  chave_pix                varchar,
+  tipo_chave               varchar,                       -- CPF|CNPJ|EMAIL|TELEFONE|CHAVE_ALEATORIA
+  cpf_cnpj                 varchar,
+  observacao               text,
+
+  -- Preenchido pelo financeiro na aprovação (vínculo Conta Azul / Inter)
+  categoria_id             varchar,                       -- UUID CA
+  categoria_nome           varchar,
+  centro_custo_id          varchar,                       -- UUID CA
+  centro_custo_nome        varchar,
+  contaazul_pessoa_id      varchar,                       -- UUID contato/fornecedor no CA
+  conta_financeira_id      varchar,                       -- UUID conta pagadora no CA
+  inter_credencial_id      integer,                       -- api_credentials.id (sistema inter)
+
+  -- Resultado da execução
+  contaazul_lancamento_id  varchar,                       -- protocolId devolvido pelo CA
+  inter_codigo_solicitacao varchar,                       -- código do PIX no Inter
+  erro_mensagem            text,
+
+  -- Decisão
+  aprovado_por_id          varchar,
+  aprovado_por_nome        varchar,
+  aprovado_em              timestamptz,
+  rejeitado_por_id         varchar,
+  rejeitado_por_nome       varchar,
+  rejeitado_em             timestamptz,
+  motivo_rejeicao          text,
+  pago_em                  timestamptz,
+
+  criado_por               varchar,
+  atualizado_por           varchar,
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pedidos_pag_bar_status
+  ON financial.pedidos_pagamento (bar_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_pedidos_pag_solicitante
+  ON financial.pedidos_pagamento (solicitante_id, created_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- 2. Comentários (thread solicitante ↔ financeiro)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS financial.pedidos_pagamento_comentarios (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pedido_id   uuid NOT NULL REFERENCES financial.pedidos_pagamento(id) ON DELETE CASCADE,
+  bar_id      integer NOT NULL,
+  autor_id    varchar,
+  autor_nome  varchar,
+  mensagem    text NOT NULL,
+  tipo        varchar NOT NULL DEFAULT 'comentario',  -- 'comentario' | 'sistema'
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pedidos_pag_coment_pedido
+  ON financial.pedidos_pagamento_comentarios (pedido_id, created_at);
+
+-- ---------------------------------------------------------------------------
+-- 3. Anexos (foto da nota / cupom / boleto)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS financial.pedidos_pagamento_anexos (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pedido_id       uuid NOT NULL REFERENCES financial.pedidos_pagamento(id) ON DELETE CASCADE,
+  bar_id          integer NOT NULL,
+  nome_original   varchar,
+  tipo_arquivo    varchar,
+  tamanho_bytes   bigint,
+  caminho_storage varchar NOT NULL,
+  url_publica     varchar,
+  uploadado_por   varchar,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pedidos_pag_anexos_pedido
+  ON financial.pedidos_pagamento_anexos (pedido_id);
+
+-- ---------------------------------------------------------------------------
+-- 4. Histórico de edições / transições (auditoria)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS financial.pedidos_pagamento_historico (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pedido_id       uuid NOT NULL REFERENCES financial.pedidos_pagamento(id) ON DELETE CASCADE,
+  bar_id          integer NOT NULL,
+  autor_id        varchar,
+  autor_nome      varchar,
+  campo           varchar,            -- nome do campo alterado, ou 'status'
+  valor_anterior  text,
+  valor_novo      text,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pedidos_pag_hist_pedido
+  ON financial.pedidos_pagamento_historico (pedido_id, created_at);
+
+-- ---------------------------------------------------------------------------
+-- Trigger updated_at (função compartilhada public.update_updated_at_column)
+-- ---------------------------------------------------------------------------
+DROP TRIGGER IF EXISTS update_pedidos_pagamento_updated_at ON financial.pedidos_pagamento;
+CREATE TRIGGER update_pedidos_pagamento_updated_at
+  BEFORE UPDATE ON financial.pedidos_pagamento
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- Grants pro PostgREST enxergar (mesmo padrão das outras tabelas em financial)
+-- ---------------------------------------------------------------------------
+GRANT USAGE ON SCHEMA financial TO authenticated, service_role, anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON financial.pedidos_pagamento             TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON financial.pedidos_pagamento_comentarios TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON financial.pedidos_pagamento_anexos      TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON financial.pedidos_pagamento_historico   TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';

--- a/frontend/src/app/api/financeiro/pedidos-pagamento/[id]/anexos/route.ts
+++ b/frontend/src/app/api/financeiro/pedidos-pagamento/[id]/anexos/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminClient } from '@/lib/supabase-admin';
+import { authenticateUser, authErrorResponse, permissionErrorResponse } from '@/middleware/auth';
+import { fin, podeAprovar } from '@/lib/financeiro/pedidos-pagamento';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+// Aceita imagem (foto da nota/cupom) E PDF (boleto/nota fiscal) — diferente do
+// upload de checklist que só aceita imagem.
+const ALLOWED_TYPES = [
+  'image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'application/pdf',
+];
+const BUCKET = 'uploads';
+const FOLDER = 'pagamentos/anexos';
+
+// POST — upload de anexo (multipart/form-data, campo "file")
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await authenticateUser(request);
+  if (!user) return authErrorResponse('Usuário não autenticado');
+  if (!user.ativo) return authErrorResponse('Usuário inativo', 403);
+  const { id } = await params;
+
+  const supabase = await getAdminClient();
+  const { data: pedido } = await fin(supabase)
+    .from('pedidos_pagamento')
+    .select('id, bar_id, solicitante_id')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (!pedido || pedido.bar_id !== user.bar_id) {
+    return NextResponse.json({ success: false, error: 'Pedido não encontrado' }, { status: 404 });
+  }
+  if (!podeAprovar(user) && pedido.solicitante_id !== user.auth_id) {
+    return permissionErrorResponse('Sem acesso a este pedido');
+  }
+
+  const formData = await request.formData();
+  const file = formData.get('file') as File | null;
+  if (!file) {
+    return NextResponse.json({ success: false, error: 'Nenhum arquivo enviado' }, { status: 400 });
+  }
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json(
+      { success: false, error: `Tipo não permitido. Aceitos: imagem ou PDF.` },
+      { status: 400 }
+    );
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { success: false, error: `Arquivo muito grande (máx ${MAX_FILE_SIZE / 1024 / 1024}MB)` },
+      { status: 400 }
+    );
+  }
+
+  const safeName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_');
+  const unique = `${Date.now()}_${Math.random().toString(36).slice(2, 10)}_${safeName}`;
+  const fullPath = `${FOLDER}/${user.bar_id}/${id}/${unique}`;
+
+  const { error: upErr } = await supabase.storage
+    .from(BUCKET)
+    .upload(fullPath, file, { cacheControl: '3600', upsert: false, contentType: file.type });
+
+  if (upErr) {
+    console.error('[PEDIDOS-PAG][ANEXO] upload', upErr);
+    return NextResponse.json({ success: false, error: 'Falha no upload' }, { status: 500 });
+  }
+
+  const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(fullPath);
+
+  const { data: anexo, error: dbErr } = await fin(supabase)
+    .from('pedidos_pagamento_anexos')
+    .insert({
+      pedido_id: id,
+      bar_id: pedido.bar_id,
+      nome_original: file.name,
+      tipo_arquivo: file.type,
+      tamanho_bytes: file.size,
+      caminho_storage: fullPath,
+      url_publica: urlData.publicUrl,
+      uploadado_por: user.auth_id,
+    })
+    .select()
+    .single();
+
+  if (dbErr) {
+    await supabase.storage.from(BUCKET).remove([fullPath]).catch(() => {});
+    console.error('[PEDIDOS-PAG][ANEXO] db', dbErr);
+    return NextResponse.json({ success: false, error: 'Falha ao salvar anexo' }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, anexo });
+}
+
+// DELETE — remove anexo (?anexo_id=)
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await authenticateUser(request);
+  if (!user) return authErrorResponse('Usuário não autenticado');
+  const { id } = await params;
+  const anexoId = new URL(request.url).searchParams.get('anexo_id');
+  if (!anexoId) {
+    return NextResponse.json({ success: false, error: 'anexo_id é obrigatório' }, { status: 400 });
+  }
+
+  const supabase = await getAdminClient();
+  const { data: anexo } = await fin(supabase)
+    .from('pedidos_pagamento_anexos')
+    .select('*')
+    .eq('id', anexoId)
+    .eq('pedido_id', id)
+    .maybeSingle();
+
+  if (!anexo || anexo.bar_id !== user.bar_id) {
+    return NextResponse.json({ success: false, error: 'Anexo não encontrado' }, { status: 404 });
+  }
+  // Só quem subiu ou o financeiro remove.
+  if (anexo.uploadado_por !== user.auth_id && !podeAprovar(user)) {
+    return permissionErrorResponse('Sem permissão para remover este anexo');
+  }
+
+  await supabase.storage.from(BUCKET).remove([anexo.caminho_storage]).catch(() => {});
+  const { error } = await fin(supabase).from('pedidos_pagamento_anexos').delete().eq('id', anexoId);
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/frontend/src/app/api/financeiro/pedidos-pagamento/[id]/aprovar/route.ts
+++ b/frontend/src/app/api/financeiro/pedidos-pagamento/[id]/aprovar/route.ts
@@ -1,0 +1,203 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminClient } from '@/lib/supabase-admin';
+import { authenticateUser, authErrorResponse, permissionErrorResponse } from '@/middleware/auth';
+import {
+  fin,
+  podeAprovar,
+  registrarHistorico,
+  comentarioSistema,
+  formatBRL,
+  STATUS_APROVAVEL,
+  type PedidoPagamento,
+  type PedidoStatus,
+} from '@/lib/financeiro/pedidos-pagamento';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST — Aprovar pedido. Idempotente:
+ *  - se ainda não criou no Conta Azul, cria a conta a pagar;
+ *  - se ainda não disparou no Inter, agenda o PIX pro vencimento.
+ * Retry após erro_ca/erro_inter reusa o que já deu certo.
+ *
+ * O financeiro completa o vínculo CA no corpo da aprovação:
+ *   categoria_id, conta_financeira_id, contaazul_pessoa_id, inter_credencial_id
+ *   (+ opcionais centro_custo_id/nome, categoria_nome).
+ */
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await authenticateUser(request);
+  if (!user) return authErrorResponse('Usuário não autenticado');
+  if (!podeAprovar(user)) return permissionErrorResponse('Apenas o financeiro pode aprovar pedidos');
+  const { id } = await params;
+
+  let body: any = {};
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const supabase = await getAdminClient();
+  const { data: pedido } = (await fin(supabase)
+    .from('pedidos_pagamento')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle()) as { data: PedidoPagamento | null };
+
+  if (!pedido || pedido.bar_id !== user.bar_id) {
+    return NextResponse.json({ success: false, error: 'Pedido não encontrado' }, { status: 404 });
+  }
+  if (!STATUS_APROVAVEL.includes(pedido.status as PedidoStatus)) {
+    return NextResponse.json(
+      { success: false, error: `Pedido não pode ser aprovado (status atual: ${pedido.status})` },
+      { status: 409 }
+    );
+  }
+
+  // Mescla os campos de vínculo CA enviados na aprovação.
+  const vinculo: Record<string, unknown> = {};
+  for (const c of [
+    'categoria_id', 'categoria_nome', 'centro_custo_id', 'centro_custo_nome',
+    'contaazul_pessoa_id', 'conta_financeira_id', 'inter_credencial_id',
+  ]) {
+    if (c in body && body[c] != null && body[c] !== '') vinculo[c] = body[c];
+  }
+  const p = { ...pedido, ...vinculo } as PedidoPagamento;
+
+  // Validação do que o CA/Inter exigem.
+  const faltando: string[] = [];
+  if (!p.categoria_id) faltando.push('categoria');
+  if (!p.conta_financeira_id) faltando.push('conta financeira pagadora');
+  if (!p.contaazul_pessoa_id) faltando.push('contato/fornecedor no Conta Azul');
+  if (!p.inter_credencial_id) faltando.push('credencial Inter');
+  if (!p.chave_pix) faltando.push('chave PIX');
+  if (faltando.length) {
+    return NextResponse.json(
+      { success: false, error: `Complete antes de aprovar: ${faltando.join(', ')}.` },
+      { status: 400 }
+    );
+  }
+
+  // Persiste o vínculo + carimbo de aprovação (status provisório enquanto processa).
+  if (Object.keys(vinculo).length) {
+    await fin(supabase).from('pedidos_pagamento').update(vinculo).eq('id', id);
+    for (const [campo, valor] of Object.entries(vinculo)) {
+      await registrarHistorico(supabase, {
+        pedido_id: id, bar_id: pedido.bar_id, autor: user, campo,
+        valor_anterior: (pedido as any)[campo], valor_novo: valor,
+      });
+    }
+  }
+
+  const origin = new URL(request.url).origin;
+  const competencia = p.data_competencia || p.data_vencimento;
+
+  // ---------- Etapa 1: Conta a pagar no Conta Azul (pula se já criada) ----------
+  let contaazulLancamentoId = p.contaazul_lancamento_id || null;
+  if (!contaazulLancamentoId) {
+    try {
+      const r = await fetch(`${origin}/api/financeiro/contaazul/lancamentos`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          bar_id: pedido.bar_id,
+          data_competencia: competencia,
+          data_vencimento: p.data_vencimento,
+          valor: p.valor,
+          descricao: p.descricao,
+          categoria_id: p.categoria_id,
+          centro_custo_id: p.centro_custo_id || undefined,
+          conta_financeira_id: p.conta_financeira_id,
+          pessoa_id: p.contaazul_pessoa_id,
+          cpf_cnpj: p.cpf_cnpj || undefined,
+          nome_beneficiario: p.beneficiario_nome || undefined,
+        }),
+      });
+      const d = await r.json();
+      if (!r.ok || !d.success) {
+        const msg = d?.error || `Conta Azul HTTP ${r.status}`;
+        await marcarErro(supabase, id, pedido.bar_id, 'erro_ca', msg, user);
+        return NextResponse.json({ success: false, etapa: 'ca', error: msg }, { status: 400 });
+      }
+      contaazulLancamentoId = d.contaazul_id;
+      await fin(supabase).from('pedidos_pagamento').update({ contaazul_lancamento_id: contaazulLancamentoId }).eq('id', id);
+    } catch (e: any) {
+      const msg = e?.message || 'Falha de rede ao criar no Conta Azul';
+      await marcarErro(supabase, id, pedido.bar_id, 'erro_ca', msg, user);
+      return NextResponse.json({ success: false, etapa: 'ca', error: msg }, { status: 500 });
+    }
+  }
+
+  // ---------- Etapa 2: Agendar PIX no Inter (pula se já disparado) ----------
+  let interCodigo = p.inter_codigo_solicitacao || null;
+  if (!interCodigo) {
+    try {
+      const r = await fetch(`${origin}/api/financeiro/inter/pix`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          valor: p.valor,
+          descricao: p.descricao,
+          destinatario: p.beneficiario_nome || p.solicitante_nome || 'Beneficiário',
+          chave: p.chave_pix,
+          data_pagamento: p.data_vencimento,
+          bar_id: pedido.bar_id,
+          inter_credencial_id: Number(p.inter_credencial_id),
+          agendamento_id: id,
+        }),
+      });
+      const d = await r.json();
+      if (!r.ok || !d.success) {
+        const msg = d?.error || `Inter HTTP ${r.status}`;
+        await marcarErro(supabase, id, pedido.bar_id, 'erro_inter', msg, user);
+        return NextResponse.json({ success: false, etapa: 'inter', error: msg }, { status: 400 });
+      }
+      interCodigo = d.data?.codigoSolicitacao || '';
+    } catch (e: any) {
+      const msg = e?.message || 'Falha de rede ao enviar PIX';
+      await marcarErro(supabase, id, pedido.bar_id, 'erro_inter', msg, user);
+      return NextResponse.json({ success: false, etapa: 'inter', error: msg }, { status: 500 });
+    }
+  }
+
+  // ---------- Sucesso: agendado (sócio dá o OK final no app do Inter) ----------
+  const { data: atualizado } = await fin(supabase)
+    .from('pedidos_pagamento')
+    .update({
+      status: 'agendado',
+      inter_codigo_solicitacao: interCodigo,
+      erro_mensagem: null,
+      aprovado_por_id: user.auth_id,
+      aprovado_por_nome: user.nome,
+      aprovado_em: new Date().toISOString(),
+      atualizado_por: user.auth_id,
+    })
+    .eq('id', id)
+    .select()
+    .single();
+
+  await registrarHistorico(supabase, {
+    pedido_id: id, bar_id: pedido.bar_id, autor: user, campo: 'status',
+    valor_anterior: pedido.status, valor_novo: 'agendado',
+  });
+  await comentarioSistema(supabase, {
+    pedido_id: id, bar_id: pedido.bar_id,
+    mensagem: `Aprovado por ${user.nome}. Conta a pagar criada no Conta Azul e PIX de ${formatBRL(p.valor)} agendado no Inter para ${p.data_vencimento}. Falta o OK final do sócio no app do Inter.`,
+  });
+
+  return NextResponse.json({ success: true, pedido: atualizado });
+}
+
+async function marcarErro(
+  supabase: any, id: string, bar_id: number,
+  status: 'erro_ca' | 'erro_inter', mensagem: string, user: any
+) {
+  await fin(supabase)
+    .from('pedidos_pagamento')
+    .update({ status, erro_mensagem: mensagem, atualizado_por: user.auth_id })
+    .eq('id', id);
+  await comentarioSistema(supabase, {
+    pedido_id: id, bar_id,
+    mensagem: `Falha na ${status === 'erro_ca' ? 'criação no Conta Azul' : 'emissão do PIX no Inter'}: ${mensagem}`,
+  });
+}

--- a/frontend/src/app/api/financeiro/pedidos-pagamento/[id]/cancelar/route.ts
+++ b/frontend/src/app/api/financeiro/pedidos-pagamento/[id]/cancelar/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminClient } from '@/lib/supabase-admin';
+import { authenticateUser, authErrorResponse, permissionErrorResponse } from '@/middleware/auth';
+import {
+  fin, podeAprovar, registrarHistorico, comentarioSistema,
+  STATUS_EDITAVEL_SOLICITANTE, type PedidoStatus,
+} from '@/lib/financeiro/pedidos-pagamento';
+
+export const dynamic = 'force-dynamic';
+
+// POST — solicitante (ou financeiro) cancela o pedido enquanto ainda pendente
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await authenticateUser(request);
+  if (!user) return authErrorResponse('Usuário não autenticado');
+  const { id } = await params;
+
+  const supabase = await getAdminClient();
+  const { data: pedido } = await fin(supabase)
+    .from('pedidos_pagamento')
+    .select('id, bar_id, status, solicitante_id')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (!pedido || pedido.bar_id !== user.bar_id) {
+    return NextResponse.json({ success: false, error: 'Pedido não encontrado' }, { status: 404 });
+  }
+
+  const ehDono = pedido.solicitante_id === user.auth_id;
+  if (!ehDono && !podeAprovar(user)) {
+    return permissionErrorResponse('Sem permissão para cancelar este pedido');
+  }
+  if (!STATUS_EDITAVEL_SOLICITANTE.includes(pedido.status as PedidoStatus)) {
+    return NextResponse.json(
+      { success: false, error: `Pedido não pode mais ser cancelado (status: ${pedido.status})` },
+      { status: 409 }
+    );
+  }
+
+  const { data, error } = await fin(supabase)
+    .from('pedidos_pagamento')
+    .update({ status: 'cancelado', atualizado_por: user.auth_id })
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+
+  await registrarHistorico(supabase, {
+    pedido_id: id, bar_id: pedido.bar_id, autor: user, campo: 'status',
+    valor_anterior: pedido.status, valor_novo: 'cancelado',
+  });
+  await comentarioSistema(supabase, {
+    pedido_id: id, bar_id: pedido.bar_id, mensagem: `Cancelado por ${user.nome}.`,
+  });
+
+  return NextResponse.json({ success: true, pedido: data });
+}

--- a/frontend/src/app/api/financeiro/pedidos-pagamento/[id]/comentarios/route.ts
+++ b/frontend/src/app/api/financeiro/pedidos-pagamento/[id]/comentarios/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminClient } from '@/lib/supabase-admin';
+import { authenticateUser, authErrorResponse, permissionErrorResponse } from '@/middleware/auth';
+import { fin, podeAprovar } from '@/lib/financeiro/pedidos-pagamento';
+
+export const dynamic = 'force-dynamic';
+
+// POST — adiciona comentário na thread (solicitante ou financeiro)
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await authenticateUser(request);
+  if (!user) return authErrorResponse('Usuário não autenticado');
+  const { id } = await params;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: 'JSON inválido' }, { status: 400 });
+  }
+
+  const mensagem = String(body.mensagem || '').trim();
+  if (!mensagem) {
+    return NextResponse.json({ success: false, error: 'mensagem vazia' }, { status: 400 });
+  }
+
+  const supabase = await getAdminClient();
+  const { data: pedido } = await fin(supabase)
+    .from('pedidos_pagamento')
+    .select('id, bar_id, solicitante_id')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (!pedido || pedido.bar_id !== user.bar_id) {
+    return NextResponse.json({ success: false, error: 'Pedido não encontrado' }, { status: 404 });
+  }
+  if (!podeAprovar(user) && pedido.solicitante_id !== user.auth_id) {
+    return permissionErrorResponse('Sem acesso a este pedido');
+  }
+
+  const { data, error } = await fin(supabase)
+    .from('pedidos_pagamento_comentarios')
+    .insert({
+      pedido_id: id,
+      bar_id: pedido.bar_id,
+      autor_id: user.auth_id,
+      autor_nome: user.nome,
+      mensagem,
+      tipo: 'comentario',
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error('[PEDIDOS-PAG][COMENT]', error);
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, comentario: data });
+}

--- a/frontend/src/app/api/financeiro/pedidos-pagamento/[id]/rejeitar/route.ts
+++ b/frontend/src/app/api/financeiro/pedidos-pagamento/[id]/rejeitar/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminClient } from '@/lib/supabase-admin';
+import { authenticateUser, authErrorResponse, permissionErrorResponse } from '@/middleware/auth';
+import { fin, podeAprovar, registrarHistorico, comentarioSistema } from '@/lib/financeiro/pedidos-pagamento';
+
+export const dynamic = 'force-dynamic';
+
+// POST — financeiro rejeita o pedido (motivo obrigatório)
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await authenticateUser(request);
+  if (!user) return authErrorResponse('Usuário não autenticado');
+  if (!podeAprovar(user)) return permissionErrorResponse('Apenas o financeiro pode rejeitar pedidos');
+  const { id } = await params;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: 'JSON inválido' }, { status: 400 });
+  }
+  const motivo = String(body.motivo || '').trim();
+  if (!motivo) {
+    return NextResponse.json({ success: false, error: 'motivo da rejeição é obrigatório' }, { status: 400 });
+  }
+
+  const supabase = await getAdminClient();
+  const { data: pedido } = await fin(supabase)
+    .from('pedidos_pagamento')
+    .select('id, bar_id, status')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (!pedido || pedido.bar_id !== user.bar_id) {
+    return NextResponse.json({ success: false, error: 'Pedido não encontrado' }, { status: 404 });
+  }
+  // Não rejeita o que já foi pra frente (agendado/pago).
+  if (['agendado', 'pago', 'rejeitado', 'cancelado'].includes(pedido.status)) {
+    return NextResponse.json(
+      { success: false, error: `Pedido não pode ser rejeitado (status: ${pedido.status})` },
+      { status: 409 }
+    );
+  }
+
+  const { data, error } = await fin(supabase)
+    .from('pedidos_pagamento')
+    .update({
+      status: 'rejeitado',
+      motivo_rejeicao: motivo,
+      rejeitado_por_id: user.auth_id,
+      rejeitado_por_nome: user.nome,
+      rejeitado_em: new Date().toISOString(),
+      atualizado_por: user.auth_id,
+    })
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+
+  await registrarHistorico(supabase, {
+    pedido_id: id, bar_id: pedido.bar_id, autor: user, campo: 'status',
+    valor_anterior: pedido.status, valor_novo: 'rejeitado',
+  });
+  await comentarioSistema(supabase, {
+    pedido_id: id, bar_id: pedido.bar_id,
+    mensagem: `Rejeitado por ${user.nome}. Motivo: ${motivo}`,
+  });
+
+  return NextResponse.json({ success: true, pedido: data });
+}

--- a/frontend/src/app/api/financeiro/pedidos-pagamento/[id]/route.ts
+++ b/frontend/src/app/api/financeiro/pedidos-pagamento/[id]/route.ts
@@ -1,0 +1,151 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminClient } from '@/lib/supabase-admin';
+import { authenticateUser, authErrorResponse, permissionErrorResponse } from '@/middleware/auth';
+import {
+  fin,
+  podeAprovar,
+  registrarHistorico,
+  STATUS_EDITAVEL_SOLICITANTE,
+  type PedidoPagamento,
+  type PedidoStatus,
+} from '@/lib/financeiro/pedidos-pagamento';
+
+export const dynamic = 'force-dynamic';
+
+async function carregarPedido(supabase: any, id: string): Promise<PedidoPagamento | null> {
+  const { data } = await fin(supabase)
+    .from('pedidos_pagamento')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+  return data || null;
+}
+
+// Campos que o financeiro pode editar; o solicitante só os "de pedido".
+const CAMPOS_SOLICITANTE = [
+  'descricao', 'valor', 'data_competencia', 'data_vencimento',
+  'beneficiario_nome', 'chave_pix', 'cpf_cnpj', 'observacao', 'tipo',
+];
+const CAMPOS_FINANCEIRO = [
+  ...CAMPOS_SOLICITANTE,
+  'categoria_id', 'categoria_nome', 'centro_custo_id', 'centro_custo_nome',
+  'contaazul_pessoa_id', 'conta_financeira_id', 'inter_credencial_id',
+];
+
+// =====================================================
+// GET — detalhe + comentários + anexos + histórico
+// =====================================================
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await authenticateUser(request);
+  if (!user) return authErrorResponse('Usuário não autenticado');
+  const { id } = await params;
+
+  const supabase = await getAdminClient();
+  const pedido = await carregarPedido(supabase, id);
+  if (!pedido || pedido.bar_id !== user.bar_id) {
+    return NextResponse.json({ success: false, error: 'Pedido não encontrado' }, { status: 404 });
+  }
+
+  // Solicitante só vê o próprio; financeiro vê todos do bar.
+  if (!podeAprovar(user) && pedido.solicitante_id !== user.auth_id) {
+    return permissionErrorResponse('Sem acesso a este pedido');
+  }
+
+  const [comentarios, anexos, historico] = await Promise.all([
+    fin(supabase).from('pedidos_pagamento_comentarios').select('*').eq('pedido_id', id).order('created_at', { ascending: true }),
+    fin(supabase).from('pedidos_pagamento_anexos').select('*').eq('pedido_id', id).order('created_at', { ascending: true }),
+    fin(supabase).from('pedidos_pagamento_historico').select('*').eq('pedido_id', id).order('created_at', { ascending: false }),
+  ]);
+
+  return NextResponse.json({
+    success: true,
+    pedido,
+    comentarios: comentarios.data || [],
+    anexos: anexos.data || [],
+    historico: historico.data || [],
+    pode_aprovar: podeAprovar(user),
+  });
+}
+
+// =====================================================
+// PUT — edita campos (solicitante enquanto pendente; financeiro sempre)
+//   grava cada mudança no histórico
+// =====================================================
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await authenticateUser(request);
+  if (!user) return authErrorResponse('Usuário não autenticado');
+  const { id } = await params;
+
+  const supabase = await getAdminClient();
+  const pedido = await carregarPedido(supabase, id);
+  if (!pedido || pedido.bar_id !== user.bar_id) {
+    return NextResponse.json({ success: false, error: 'Pedido não encontrado' }, { status: 404 });
+  }
+
+  const ehFinanceiro = podeAprovar(user);
+  const ehDono = pedido.solicitante_id === user.auth_id;
+  if (!ehFinanceiro && !ehDono) {
+    return permissionErrorResponse('Sem permissão para editar este pedido');
+  }
+  // Solicitante só edita enquanto o pedido está pendente/rascunho.
+  if (!ehFinanceiro && !STATUS_EDITAVEL_SOLICITANTE.includes(pedido.status as PedidoStatus)) {
+    return permissionErrorResponse('Pedido já está em processamento e não pode mais ser editado por você');
+  }
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: 'JSON inválido' }, { status: 400 });
+  }
+
+  const camposPermitidos = ehFinanceiro ? CAMPOS_FINANCEIRO : CAMPOS_SOLICITANTE;
+  const updates: Record<string, unknown> = {};
+  for (const campo of camposPermitidos) {
+    if (campo in body && body[campo] !== (pedido as any)[campo]) {
+      updates[campo] = body[campo];
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ success: true, pedido, alterado: false });
+  }
+
+  // Validação leve de valor
+  if ('valor' in updates) {
+    const v = Number(updates.valor);
+    if (!Number.isFinite(v) || v <= 0) {
+      return NextResponse.json({ success: false, error: 'valor inválido' }, { status: 400 });
+    }
+    updates.valor = Math.round(v * 100) / 100;
+  }
+
+  updates.atualizado_por = user.auth_id;
+
+  const { data, error } = await fin(supabase)
+    .from('pedidos_pagamento')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('[PEDIDOS-PAG][PATCH]', error);
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+
+  // Histórico por campo alterado (exceto metadado atualizado_por)
+  for (const [campo, valorNovo] of Object.entries(updates)) {
+    if (campo === 'atualizado_por') continue;
+    await registrarHistorico(supabase, {
+      pedido_id: id,
+      bar_id: pedido.bar_id,
+      autor: user,
+      campo,
+      valor_anterior: (pedido as any)[campo],
+      valor_novo: valorNovo,
+    });
+  }
+
+  return NextResponse.json({ success: true, pedido: data, alterado: true });
+}

--- a/frontend/src/app/api/financeiro/pedidos-pagamento/route.ts
+++ b/frontend/src/app/api/financeiro/pedidos-pagamento/route.ts
@@ -1,0 +1,158 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminClient } from '@/lib/supabase-admin';
+import { authenticateUser, authErrorResponse } from '@/middleware/auth';
+import {
+  fin,
+  podeAprovar,
+  comentarioSistema,
+  formatBRL,
+  TIPOS_VALIDOS,
+  type PedidoTipo,
+} from '@/lib/financeiro/pedidos-pagamento';
+
+export const dynamic = 'force-dynamic';
+
+// =====================================================
+// GET — lista de pedidos do bar
+//   ?status= filtro · ?tipo= filtro · ?escopo=meus|todos
+//   - escopo=meus: só os do próprio solicitante
+//   - escopo=todos: todos do bar (default p/ quem pode aprovar)
+// =====================================================
+export async function GET(request: NextRequest) {
+  const user = await authenticateUser(request);
+  if (!user) return authErrorResponse('Usuário não autenticado');
+  if (!user.bar_id) {
+    return NextResponse.json({ success: false, error: 'Nenhum bar selecionado' }, { status: 400 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const status = searchParams.get('status');
+  const tipo = searchParams.get('tipo');
+  const escopoParam = searchParams.get('escopo');
+  const limit = Math.min(parseInt(searchParams.get('limit') || '100'), 500);
+
+  // Quem não pode aprovar só enxerga os próprios pedidos, mesmo pedindo "todos".
+  const escopo = podeAprovar(user) && escopoParam !== 'meus' ? 'todos' : 'meus';
+
+  const supabase = await getAdminClient();
+  let query = fin(supabase)
+    .from('pedidos_pagamento')
+    .select('*')
+    .eq('bar_id', user.bar_id)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (status) query = query.eq('status', status);
+  if (tipo) query = query.eq('tipo', tipo);
+  if (escopo === 'meus') query = query.eq('solicitante_id', user.auth_id);
+
+  const { data, error } = await query;
+  if (error) {
+    console.error('[PEDIDOS-PAG][GET]', error);
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    success: true,
+    pedidos: data || [],
+    escopo,
+    pode_aprovar: podeAprovar(user),
+  });
+}
+
+// =====================================================
+// POST — cria um novo pedido (qualquer funcionário logado)
+// =====================================================
+export async function POST(request: NextRequest) {
+  const user = await authenticateUser(request);
+  if (!user) return authErrorResponse('Usuário não autenticado');
+  if (!user.ativo) return authErrorResponse('Usuário inativo', 403);
+  if (!user.bar_id) {
+    return NextResponse.json({ success: false, error: 'Nenhum bar selecionado' }, { status: 400 });
+  }
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: 'JSON inválido' }, { status: 400 });
+  }
+
+  const tipo = String(body.tipo || '') as PedidoTipo;
+  if (!TIPOS_VALIDOS.includes(tipo)) {
+    return NextResponse.json(
+      { success: false, error: `tipo inválido (use: ${TIPOS_VALIDOS.join(', ')})` },
+      { status: 400 }
+    );
+  }
+
+  const valor = Number(body.valor);
+  if (!Number.isFinite(valor) || valor <= 0) {
+    return NextResponse.json({ success: false, error: 'valor inválido' }, { status: 400 });
+  }
+
+  const descricao = String(body.descricao || '').trim();
+  if (!descricao) {
+    return NextResponse.json({ success: false, error: 'descrição é obrigatória' }, { status: 400 });
+  }
+
+  const data_vencimento = body.data_vencimento;
+  if (!data_vencimento || !/^\d{4}-\d{2}-\d{2}$/.test(String(data_vencimento))) {
+    return NextResponse.json(
+      { success: false, error: 'data_vencimento (AAAA-MM-DD) é obrigatória' },
+      { status: 400 }
+    );
+  }
+
+  // Reembolso e adiantamento normalmente caem na chave do próprio funcionário.
+  const chave_pix = body.chave_pix ? String(body.chave_pix).trim() : null;
+  if ((tipo === 'reembolso' || tipo === 'fornecedor') && !chave_pix) {
+    return NextResponse.json(
+      { success: false, error: 'chave PIX é obrigatória para este tipo' },
+      { status: 400 }
+    );
+  }
+
+  const supabase = await getAdminClient();
+  const novo = {
+    bar_id: user.bar_id,
+    tipo,
+    status: 'aguardando_aprovacao',
+    solicitante_id: user.auth_id,
+    solicitante_nome: user.nome,
+    descricao,
+    valor: Math.round(valor * 100) / 100,
+    data_competencia: body.data_competencia || null,
+    data_vencimento,
+    beneficiario_nome: body.beneficiario_nome || null,
+    chave_pix,
+    cpf_cnpj: body.cpf_cnpj || null,
+    observacao: body.observacao || null,
+    // Pré-sugestões opcionais (financeiro confirma na aprovação)
+    categoria_id: body.categoria_id || null,
+    categoria_nome: body.categoria_nome || null,
+    centro_custo_id: body.centro_custo_id || null,
+    centro_custo_nome: body.centro_custo_nome || null,
+    criado_por: user.auth_id,
+    atualizado_por: user.auth_id,
+  };
+
+  const { data, error } = await fin(supabase)
+    .from('pedidos_pagamento')
+    .insert(novo)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('[PEDIDOS-PAG][POST]', error);
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+
+  await comentarioSistema(supabase, {
+    pedido_id: data.id,
+    bar_id: user.bar_id,
+    mensagem: `Pedido criado por ${user.nome} — ${formatBRL(valor)} (${tipo}).`,
+  });
+
+  return NextResponse.json({ success: true, pedido: data });
+}

--- a/frontend/src/app/ferramentas/pedidos-pagamento/components/NovoPedidoDialog.tsx
+++ b/frontend/src/app/ferramentas/pedidos-pagamento/components/NovoPedidoDialog.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/toast';
+import { api } from '@/lib/api-client';
+import { Loader2, Paperclip } from 'lucide-react';
+import { TIPO_LABEL, type PedidoTipo } from '../types';
+
+const TIPOS: PedidoTipo[] = ['reembolso', 'fornecedor', 'avulso', 'adiantamento'];
+
+const parseValor = (v: string): number => {
+  const s = v.replace(/[R$\s]/g, '').replace(/\./g, '').replace(',', '.');
+  const n = parseFloat(s);
+  return Number.isFinite(n) ? n : 0;
+};
+
+export function NovoPedidoDialog({
+  open, onOpenChange, onCriado,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onCriado: () => void;
+}) {
+  const { showToast } = useToast();
+  const [salvando, setSalvando] = useState(false);
+  const [arquivo, setArquivo] = useState<File | null>(null);
+
+  const [tipo, setTipo] = useState<PedidoTipo>('reembolso');
+  const [descricao, setDescricao] = useState('');
+  const [valor, setValor] = useState('');
+  const [vencimento, setVencimento] = useState('');
+  const [competencia, setCompetencia] = useState('');
+  const [chavePix, setChavePix] = useState('');
+  const [beneficiario, setBeneficiario] = useState('');
+  const [observacao, setObservacao] = useState('');
+
+  const pixObrigatorio = tipo === 'reembolso' || tipo === 'fornecedor';
+
+  const reset = () => {
+    setTipo('reembolso'); setDescricao(''); setValor(''); setVencimento('');
+    setCompetencia(''); setChavePix(''); setBeneficiario(''); setObservacao('');
+    setArquivo(null);
+  };
+
+  const submit = async () => {
+    const valorNum = parseValor(valor);
+    if (!descricao.trim()) return showToast({ type: 'error', title: 'Descrição é obrigatória' });
+    if (valorNum <= 0) return showToast({ type: 'error', title: 'Valor inválido' });
+    if (!vencimento) return showToast({ type: 'error', title: 'Informe o vencimento' });
+    if (pixObrigatorio && !chavePix.trim()) return showToast({ type: 'error', title: 'Chave PIX é obrigatória' });
+
+    setSalvando(true);
+    try {
+      const res = await api.post('/api/financeiro/pedidos-pagamento', {
+        tipo,
+        descricao: descricao.trim(),
+        valor: valorNum,
+        data_vencimento: vencimento,
+        data_competencia: competencia || null,
+        chave_pix: chavePix.trim() || null,
+        beneficiario_nome: beneficiario.trim() || null,
+        observacao: observacao.trim() || null,
+      });
+
+      // Anexo (opcional) — sobe depois que o pedido existe
+      if (arquivo && res?.pedido?.id) {
+        const fd = new FormData();
+        fd.append('file', arquivo);
+        const selectedBarId = localStorage.getItem('sgb_selected_bar_id');
+        await fetch(`/api/financeiro/pedidos-pagamento/${res.pedido.id}/anexos`, {
+          method: 'POST',
+          headers: selectedBarId ? { 'x-selected-bar-id': selectedBarId } : {},
+          body: fd,
+        });
+      }
+
+      showToast({ type: 'success', title: 'Pedido enviado', message: 'O financeiro vai analisar.' });
+      reset();
+      onOpenChange(false);
+      onCriado();
+    } catch (e: any) {
+      showToast({ type: 'error', title: 'Erro ao enviar', message: e?.message });
+    } finally {
+      setSalvando(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!salvando) onOpenChange(v); }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Novo pedido de pagamento</DialogTitle>
+          <DialogDescription>Preencha os dados. O financeiro completa categoria/conta na aprovação.</DialogDescription>
+        </DialogHeader>
+
+        <div className="px-6 overflow-y-auto space-y-4">
+          <div>
+            <Label className="mb-1.5 block">Tipo</Label>
+            <div className="grid grid-cols-2 gap-2">
+              {TIPOS.map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setTipo(t)}
+                  className={`rounded-md border px-3 py-2 text-sm transition ${
+                    tipo === t
+                      ? 'border-blue-500 bg-blue-500/10 text-blue-600 font-medium'
+                      : 'border-[hsl(var(--border))] text-muted-foreground hover:bg-muted/40'
+                  }`}
+                >
+                  {TIPO_LABEL[t]}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <Label htmlFor="desc" className="mb-1.5 block">Descrição</Label>
+            <Input id="desc" value={descricao} onChange={(e) => setDescricao(e.target.value)}
+              placeholder="Ex: Reembolso compra de insumos / Pagamento fornecedor X" />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label htmlFor="valor" className="mb-1.5 block">Valor (R$)</Label>
+              <Input id="valor" value={valor} onChange={(e) => setValor(e.target.value)} placeholder="0,00" inputMode="decimal" />
+            </div>
+            <div>
+              <Label htmlFor="venc" className="mb-1.5 block">Vencimento</Label>
+              <Input id="venc" type="date" value={vencimento} onChange={(e) => setVencimento(e.target.value)} />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label htmlFor="pix" className="mb-1.5 block">
+                Chave PIX {pixObrigatorio && <span className="text-red-500">*</span>}
+              </Label>
+              <Input id="pix" value={chavePix} onChange={(e) => setChavePix(e.target.value)}
+                placeholder="CPF, CNPJ, e-mail, telefone ou aleatória" />
+            </div>
+            <div>
+              <Label htmlFor="comp" className="mb-1.5 block">Competência <span className="text-muted-foreground text-xs">(opcional)</span></Label>
+              <Input id="comp" type="date" value={competencia} onChange={(e) => setCompetencia(e.target.value)} />
+            </div>
+          </div>
+
+          <div>
+            <Label htmlFor="benef" className="mb-1.5 block">Beneficiário <span className="text-muted-foreground text-xs">(quem recebe)</span></Label>
+            <Input id="benef" value={beneficiario} onChange={(e) => setBeneficiario(e.target.value)} placeholder="Nome do fornecedor ou funcionário" />
+          </div>
+
+          <div>
+            <Label htmlFor="obs" className="mb-1.5 block">Observação <span className="text-muted-foreground text-xs">(opcional)</span></Label>
+            <Textarea id="obs" value={observacao} onChange={(e) => setObservacao(e.target.value)} rows={2} />
+          </div>
+
+          <div>
+            <Label className="mb-1.5 block">
+              Anexo (nota/cupom/boleto){tipo === 'reembolso' && <span className="text-muted-foreground text-xs"> — recomendado</span>}
+            </Label>
+            <label className="flex items-center gap-2 cursor-pointer rounded-md border border-dashed border-[hsl(var(--border))] px-3 py-2 text-sm text-muted-foreground hover:bg-muted/40">
+              <Paperclip className="w-4 h-4" />
+              {arquivo ? arquivo.name : 'Imagem ou PDF (máx 10MB)'}
+              <input type="file" accept="image/*,application/pdf" className="hidden"
+                onChange={(e) => setArquivo(e.target.files?.[0] || null)} />
+            </label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={salvando}>Cancelar</Button>
+          <Button onClick={submit} disabled={salvando}>
+            {salvando ? <><Loader2 className="w-4 h-4 mr-2 animate-spin" />Enviando...</> : 'Enviar pedido'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/ferramentas/pedidos-pagamento/components/PedidoDetailDialog.tsx
+++ b/frontend/src/app/ferramentas/pedidos-pagamento/components/PedidoDetailDialog.tsx
@@ -1,0 +1,452 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { SearchableSelect } from '@/components/ui/searchable-select';
+import { useToast } from '@/components/ui/toast';
+import { api } from '@/lib/api-client';
+import {
+  Loader2, Send, Check, X, Paperclip, Trash2, FileText, History, Save,
+} from 'lucide-react';
+import {
+  TIPO_LABEL, STATUS_LABEL, STATUS_COLOR, formatBRL,
+  type Pedido, type Comentario, type Anexo, type HistoricoItem,
+} from '../types';
+
+interface Opcao { value: string; label: string; searchHint?: string }
+
+export function PedidoDetailDialog({
+  pedidoId, barId, onClose, onChange,
+}: {
+  pedidoId: string | null;
+  barId: number;
+  onClose: () => void;
+  onChange: () => void;
+}) {
+  const { showToast } = useToast();
+  const [loading, setLoading] = useState(false);
+  const [pedido, setPedido] = useState<Pedido | null>(null);
+  const [comentarios, setComentarios] = useState<Comentario[]>([]);
+  const [anexos, setAnexos] = useState<Anexo[]>([]);
+  const [historico, setHistorico] = useState<HistoricoItem[]>([]);
+  const [podeAprovar, setPodeAprovar] = useState(false);
+
+  // Edição inline dos campos do pedido
+  const [edit, setEdit] = useState<Partial<Pedido>>({});
+  const [salvandoEdit, setSalvandoEdit] = useState(false);
+
+  // Opções do painel de aprovação
+  const [categorias, setCategorias] = useState<Opcao[]>([]);
+  const [centros, setCentros] = useState<Opcao[]>([]);
+  const [contas, setContas] = useState<Opcao[]>([]);
+  const [fornecedores, setFornecedores] = useState<Opcao[]>([]);
+  const [interCreds, setInterCreds] = useState<Opcao[]>([]);
+  const [aprov, setAprov] = useState({
+    categoria_id: '', centro_custo_id: '', contaazul_pessoa_id: '',
+    conta_financeira_id: '', inter_credencial_id: '',
+  });
+  const [aprovando, setAprovando] = useState(false);
+
+  // Rejeição / comentário / cadastro fornecedor
+  const [motivo, setMotivo] = useState('');
+  const [rejeitando, setRejeitando] = useState(false);
+  const [novoComentario, setNovoComentario] = useState('');
+  const [enviandoComentario, setEnviandoComentario] = useState(false);
+  const [showHist, setShowHist] = useState(false);
+  const [novoFornNome, setNovoFornNome] = useState('');
+  const [novoFornDoc, setNovoFornDoc] = useState('');
+  const [cadastrando, setCadastrando] = useState(false);
+
+  const editavel = pedido && (podeAprovar || ['rascunho', 'aguardando_aprovacao'].includes(pedido.status));
+  const aprovavel = pedido && ['aguardando_aprovacao', 'erro_ca', 'erro_inter'].includes(pedido.status);
+
+  const carregar = useCallback(async () => {
+    if (!pedidoId) return;
+    setLoading(true);
+    try {
+      const res = await api.get(`/api/financeiro/pedidos-pagamento/${pedidoId}`);
+      setPedido(res.pedido);
+      setComentarios(res.comentarios || []);
+      setAnexos(res.anexos || []);
+      setHistorico(res.historico || []);
+      setPodeAprovar(!!res.pode_aprovar);
+      setEdit({});
+      setAprov({
+        categoria_id: res.pedido?.categoria_id || '',
+        centro_custo_id: res.pedido?.centro_custo_id || '',
+        contaazul_pessoa_id: res.pedido?.contaazul_pessoa_id || '',
+        conta_financeira_id: res.pedido?.conta_financeira_id || '',
+        inter_credencial_id: res.pedido?.inter_credencial_id ? String(res.pedido.inter_credencial_id) : '',
+      });
+      setNovoFornNome(res.pedido?.beneficiario_nome || '');
+      setNovoFornDoc(res.pedido?.cpf_cnpj || '');
+    } catch (e: any) {
+      showToast({ type: 'error', title: 'Erro ao carregar pedido', message: e?.message });
+    } finally {
+      setLoading(false);
+    }
+  }, [pedidoId, showToast]);
+
+  useEffect(() => { if (pedidoId) carregar(); }, [pedidoId, carregar]);
+
+  // Carrega opções do CA/Inter só quando o financeiro vai aprovar
+  const carregarOpcoes = useCallback(async () => {
+    if (!podeAprovar || !aprovavel) return;
+    try {
+      const [cat, cc, ct, fo, it] = await Promise.all([
+        fetch(`/api/financeiro/contaazul/categorias?bar_id=${barId}`).then(r => r.json()),
+        fetch(`/api/financeiro/contaazul/centros-custo?bar_id=${barId}`).then(r => r.json()),
+        fetch(`/api/financeiro/contaazul/contas-financeiras?bar_id=${barId}`).then(r => r.json()),
+        fetch(`/api/financeiro/contaazul/stakeholders?bar_id=${barId}&perfil=FORNECEDOR`).then(r => r.json()),
+        fetch(`/api/financeiro/inter/credenciais?bar_id=${barId}`).then(r => r.json()),
+      ]);
+      setCategorias((cat.categorias || []).map((c: any) => ({ value: c.contaazul_id, label: c.categoria_nome })));
+      setCentros(((cc.centros_custo || cc.centrosCusto) || []).map((c: any) => ({ value: c.contaazul_id, label: c.nome })));
+      setContas((ct.contas_financeiras || [])
+        .filter((c: any) => c.ativo !== false)
+        .map((c: any) => ({ value: String(c.contaazul_id), label: c.banco ? `${c.nome} (${c.banco})` : c.nome })));
+      setFornecedores((fo.pessoas || []).map((p: any) => ({
+        value: p.contaazul_id, label: p.nome, searchHint: p.documento || '',
+      })));
+      setInterCreds((it.credenciais || []).map((c: any) => ({
+        value: String(c.id), label: c.cnpj ? `${c.nome} (${c.cnpj})` : c.nome,
+      })));
+    } catch {
+      showToast({ type: 'error', title: 'Erro ao carregar opções do Conta Azul/Inter' });
+    }
+  }, [podeAprovar, aprovavel, barId, showToast]);
+
+  useEffect(() => { carregarOpcoes(); }, [carregarOpcoes]);
+
+  const salvarEdicao = async () => {
+    if (!pedido || Object.keys(edit).length === 0) return;
+    setSalvandoEdit(true);
+    try {
+      const payload: any = { ...edit };
+      if ('valor' in payload) payload.valor = Number(String(payload.valor).replace(',', '.'));
+      await api.put(`/api/financeiro/pedidos-pagamento/${pedido.id}`, payload);
+      showToast({ type: 'success', title: 'Alterações salvas' });
+      await carregar();
+      onChange();
+    } catch (e: any) {
+      showToast({ type: 'error', title: 'Erro ao salvar', message: e?.message });
+    } finally {
+      setSalvandoEdit(false);
+    }
+  };
+
+  const cadastrarFornecedor = async () => {
+    if (!novoFornNome.trim()) return showToast({ type: 'error', title: 'Informe o nome do fornecedor' });
+    setCadastrando(true);
+    try {
+      const res = await api.post('/api/financeiro/contaazul/pessoas/cadastrar', {
+        bar_id: barId, nome: novoFornNome.trim(), documento: novoFornDoc.replace(/\D/g, '') || undefined,
+      });
+      const novo = { value: res.contaazul_id, label: res.nome };
+      setFornecedores(prev => [novo, ...prev]);
+      setAprov(a => ({ ...a, contaazul_pessoa_id: res.contaazul_id }));
+      showToast({ type: 'success', title: 'Fornecedor cadastrado no Conta Azul' });
+    } catch (e: any) {
+      showToast({ type: 'error', title: 'Erro ao cadastrar fornecedor', message: e?.message });
+    } finally {
+      setCadastrando(false);
+    }
+  };
+
+  const aprovar = async () => {
+    if (!pedido) return;
+    setAprovando(true);
+    try {
+      await api.post(`/api/financeiro/pedidos-pagamento/${pedido.id}/aprovar`, {
+        categoria_id: aprov.categoria_id || undefined,
+        categoria_nome: categorias.find(c => c.value === aprov.categoria_id)?.label,
+        centro_custo_id: aprov.centro_custo_id || undefined,
+        centro_custo_nome: centros.find(c => c.value === aprov.centro_custo_id)?.label,
+        contaazul_pessoa_id: aprov.contaazul_pessoa_id || undefined,
+        conta_financeira_id: aprov.conta_financeira_id || undefined,
+        inter_credencial_id: aprov.inter_credencial_id ? Number(aprov.inter_credencial_id) : undefined,
+      });
+      showToast({ type: 'success', title: 'Aprovado!', message: 'Conta a pagar criada e PIX agendado no Inter.' });
+      await carregar();
+      onChange();
+    } catch (e: any) {
+      showToast({ type: 'error', title: 'Falha ao aprovar', message: e?.message });
+      await carregar();
+    } finally {
+      setAprovando(false);
+    }
+  };
+
+  const rejeitar = async () => {
+    if (!pedido) return;
+    if (!motivo.trim()) return showToast({ type: 'error', title: 'Informe o motivo da rejeição' });
+    setRejeitando(true);
+    try {
+      await api.post(`/api/financeiro/pedidos-pagamento/${pedido.id}/rejeitar`, { motivo: motivo.trim() });
+      showToast({ type: 'success', title: 'Pedido rejeitado' });
+      setMotivo('');
+      await carregar();
+      onChange();
+    } catch (e: any) {
+      showToast({ type: 'error', title: 'Erro ao rejeitar', message: e?.message });
+    } finally {
+      setRejeitando(false);
+    }
+  };
+
+  const enviarComentario = async () => {
+    if (!pedido || !novoComentario.trim()) return;
+    setEnviandoComentario(true);
+    try {
+      await api.post(`/api/financeiro/pedidos-pagamento/${pedido.id}/comentarios`, { mensagem: novoComentario.trim() });
+      setNovoComentario('');
+      const res = await api.get(`/api/financeiro/pedidos-pagamento/${pedido.id}`);
+      setComentarios(res.comentarios || []);
+    } catch (e: any) {
+      showToast({ type: 'error', title: 'Erro ao comentar', message: e?.message });
+    } finally {
+      setEnviandoComentario(false);
+    }
+  };
+
+  const subirAnexo = async (file: File) => {
+    if (!pedido) return;
+    const fd = new FormData();
+    fd.append('file', file);
+    const selectedBarId = localStorage.getItem('sgb_selected_bar_id');
+    try {
+      const r = await fetch(`/api/financeiro/pedidos-pagamento/${pedido.id}/anexos`, {
+        method: 'POST',
+        headers: selectedBarId ? { 'x-selected-bar-id': selectedBarId } : {},
+        body: fd,
+      });
+      const d = await r.json();
+      if (!r.ok || !d.success) throw new Error(d?.error || 'Falha no upload');
+      setAnexos(prev => [...prev, d.anexo]);
+    } catch (e: any) {
+      showToast({ type: 'error', title: 'Erro no anexo', message: e?.message });
+    }
+  };
+
+  const fld = (k: keyof Pedido) => (edit[k] ?? pedido?.[k] ?? '') as string | number;
+  const setFld = (k: keyof Pedido, v: any) => setEdit(prev => ({ ...prev, [k]: v }));
+
+  return (
+    <Dialog open={!!pedidoId} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 pr-8">
+            {pedido ? (
+              <>
+                <span>{TIPO_LABEL[pedido.tipo]}</span>
+                <Badge className={STATUS_COLOR[pedido.status]}>{STATUS_LABEL[pedido.status]}</Badge>
+                <span className="ml-auto text-base font-bold">{formatBRL(pedido.valor)}</span>
+              </>
+            ) : 'Carregando...'}
+          </DialogTitle>
+        </DialogHeader>
+
+        {loading || !pedido ? (
+          <div className="py-16 text-center"><Loader2 className="w-8 h-8 animate-spin mx-auto text-muted-foreground" /></div>
+        ) : (
+          <div className="px-6 pb-6 overflow-y-auto space-y-5 text-sm">
+            {/* Solicitante */}
+            <p className="text-xs text-muted-foreground">
+              Solicitado por <strong>{pedido.solicitante_nome || '—'}</strong> em {new Date(pedido.created_at).toLocaleString('pt-BR')}
+            </p>
+
+            {pedido.status === 'rejeitado' && pedido.motivo_rejeicao && (
+              <div className="rounded-md bg-red-500/10 text-red-600 p-3">
+                <strong>Rejeitado{pedido.rejeitado_por_nome ? ` por ${pedido.rejeitado_por_nome}` : ''}:</strong> {pedido.motivo_rejeicao}
+              </div>
+            )}
+            {pedido.erro_mensagem && (pedido.status === 'erro_ca' || pedido.status === 'erro_inter') && (
+              <div className="rounded-md bg-red-500/10 text-red-600 p-3"><strong>Erro:</strong> {pedido.erro_mensagem}</div>
+            )}
+            {pedido.status === 'agendado' && (
+              <div className="rounded-md bg-indigo-500/10 text-indigo-600 p-3 text-xs">
+                Conta criada no Conta Azul e PIX agendado no Inter. Falta o OK final do sócio no app do Inter.
+              </div>
+            )}
+
+            {/* Campos do pedido (editáveis) */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="col-span-2">
+                <Label className="mb-1 block text-xs">Descrição</Label>
+                <Input value={fld('descricao')} disabled={!editavel} onChange={(e) => setFld('descricao', e.target.value)} />
+              </div>
+              <div>
+                <Label className="mb-1 block text-xs">Valor (R$)</Label>
+                <Input value={String(fld('valor'))} disabled={!editavel} onChange={(e) => setFld('valor', e.target.value)} />
+              </div>
+              <div>
+                <Label className="mb-1 block text-xs">Vencimento</Label>
+                <Input type="date" value={fld('data_vencimento')} disabled={!editavel} onChange={(e) => setFld('data_vencimento', e.target.value)} />
+              </div>
+              <div>
+                <Label className="mb-1 block text-xs">Competência</Label>
+                <Input type="date" value={fld('data_competencia')} disabled={!editavel} onChange={(e) => setFld('data_competencia', e.target.value)} />
+              </div>
+              <div>
+                <Label className="mb-1 block text-xs">Chave PIX</Label>
+                <Input value={fld('chave_pix')} disabled={!editavel} onChange={(e) => setFld('chave_pix', e.target.value)} />
+              </div>
+              <div>
+                <Label className="mb-1 block text-xs">Beneficiário</Label>
+                <Input value={fld('beneficiario_nome')} disabled={!editavel} onChange={(e) => setFld('beneficiario_nome', e.target.value)} />
+              </div>
+              <div>
+                <Label className="mb-1 block text-xs">CPF/CNPJ</Label>
+                <Input value={fld('cpf_cnpj')} disabled={!editavel} onChange={(e) => setFld('cpf_cnpj', e.target.value)} />
+              </div>
+            </div>
+            {editavel && Object.keys(edit).length > 0 && (
+              <Button size="sm" variant="outline" onClick={salvarEdicao} disabled={salvandoEdit}>
+                {salvandoEdit ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Save className="w-4 h-4 mr-2" />}
+                Salvar alterações
+              </Button>
+            )}
+
+            {/* Anexos */}
+            <div>
+              <Label className="mb-1.5 block text-xs">Anexos ({anexos.length})</Label>
+              <div className="space-y-1.5">
+                {anexos.map((a) => (
+                  <div key={a.id} className="flex items-center gap-2 text-xs">
+                    <FileText className="w-3.5 h-3.5 text-muted-foreground" />
+                    <a href={a.url_publica || '#'} target="_blank" rel="noreferrer" className="text-blue-600 hover:underline truncate flex-1">
+                      {a.nome_original || 'arquivo'}
+                    </a>
+                  </div>
+                ))}
+                {anexos.length === 0 && <p className="text-xs text-muted-foreground">Nenhum anexo.</p>}
+              </div>
+              <label className="mt-2 inline-flex items-center gap-1.5 cursor-pointer text-xs text-blue-600 hover:underline">
+                <Paperclip className="w-3.5 h-3.5" /> Anexar arquivo
+                <input type="file" accept="image/*,application/pdf" className="hidden"
+                  onChange={(e) => { const f = e.target.files?.[0]; if (f) subirAnexo(f); }} />
+              </label>
+            </div>
+
+            {/* Painel de aprovação (financeiro) */}
+            {podeAprovar && aprovavel && (
+              <div className="rounded-lg border border-blue-500/30 bg-blue-500/5 p-4 space-y-3">
+                <p className="font-medium text-sm">Aprovar — completar dados do Conta Azul / Inter</p>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <Label className="mb-1 block text-xs">Categoria *</Label>
+                    <SearchableSelect value={aprov.categoria_id} onValueChange={(v) => setAprov(a => ({ ...a, categoria_id: v || '' }))}
+                      placeholder="Categoria" searchPlaceholder="Filtrar..." emptyMessage="Nenhuma" options={categorias} />
+                  </div>
+                  <div>
+                    <Label className="mb-1 block text-xs">Centro de custo</Label>
+                    <SearchableSelect value={aprov.centro_custo_id} onValueChange={(v) => setAprov(a => ({ ...a, centro_custo_id: v || '' }))}
+                      placeholder="Opcional" searchPlaceholder="Filtrar..." emptyMessage="Nenhum" options={centros} />
+                  </div>
+                  <div>
+                    <Label className="mb-1 block text-xs">Conta pagadora *</Label>
+                    <SearchableSelect value={aprov.conta_financeira_id} onValueChange={(v) => setAprov(a => ({ ...a, conta_financeira_id: v || '' }))}
+                      placeholder="Conta no CA" searchPlaceholder="Filtrar..." emptyMessage="Nenhuma" options={contas} />
+                  </div>
+                  <div>
+                    <Label className="mb-1 block text-xs">Credencial Inter *</Label>
+                    <SearchableSelect value={aprov.inter_credencial_id} onValueChange={(v) => setAprov(a => ({ ...a, inter_credencial_id: v || '' }))}
+                      placeholder="De onde sai o PIX" searchPlaceholder="Filtrar..." emptyMessage="Nenhuma" options={interCreds} />
+                  </div>
+                  <div className="col-span-2">
+                    <Label className="mb-1 block text-xs">Contato / Fornecedor no CA *</Label>
+                    <SearchableSelect value={aprov.contaazul_pessoa_id} onValueChange={(v) => setAprov(a => ({ ...a, contaazul_pessoa_id: v || '' }))}
+                      placeholder="Selecione o contato" searchPlaceholder="Buscar fornecedor..." emptyMessage="Não encontrado — cadastre abaixo" options={fornecedores} />
+                  </div>
+                </div>
+
+                {/* Cadastro rápido de fornecedor/contato */}
+                {!aprov.contaazul_pessoa_id && (
+                  <div className="rounded-md border border-dashed border-[hsl(var(--border))] p-2.5 space-y-2">
+                    <p className="text-xs text-muted-foreground">Não achou o contato? Cadastre no Conta Azul:</p>
+                    <div className="flex gap-2">
+                      <Input className="h-8 text-xs" placeholder="Nome" value={novoFornNome} onChange={(e) => setNovoFornNome(e.target.value)} />
+                      <Input className="h-8 text-xs" placeholder="CPF/CNPJ (opcional)" value={novoFornDoc} onChange={(e) => setNovoFornDoc(e.target.value)} />
+                      <Button size="sm" variant="outline" className="h-8 shrink-0" onClick={cadastrarFornecedor} disabled={cadastrando}>
+                        {cadastrando ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : 'Cadastrar'}
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex gap-2 pt-1">
+                  <Button onClick={aprovar} disabled={aprovando} className="flex-1">
+                    {aprovando ? <><Loader2 className="w-4 h-4 mr-2 animate-spin" />Processando...</> : <><Check className="w-4 h-4 mr-2" />Aprovar e pagar</>}
+                  </Button>
+                </div>
+                <p className="text-[11px] text-muted-foreground">Cria a conta a pagar no Conta Azul e agenda o PIX no Inter. O sócio dá o OK final no app do Inter.</p>
+
+                {/* Rejeição */}
+                <div className="pt-2 border-t border-[hsl(var(--border))]">
+                  <Label className="mb-1 block text-xs">Rejeitar (motivo)</Label>
+                  <div className="flex gap-2">
+                    <Input className="h-8 text-xs" placeholder="Motivo da rejeição" value={motivo} onChange={(e) => setMotivo(e.target.value)} />
+                    <Button size="sm" variant="destructive" className="h-8 shrink-0" onClick={rejeitar} disabled={rejeitando}>
+                      {rejeitando ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <><X className="w-3.5 h-3.5 mr-1" />Rejeitar</>}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Comentários */}
+            <div>
+              <Label className="mb-1.5 block text-xs">Comentários</Label>
+              <div className="space-y-2 max-h-48 overflow-y-auto pr-1">
+                {comentarios.map((c) => (
+                  <div key={c.id} className={`rounded-md p-2 text-xs ${c.tipo === 'sistema' ? 'bg-muted/40 text-muted-foreground italic' : 'bg-muted/60'}`}>
+                    <div className="flex justify-between gap-2">
+                      <strong>{c.autor_nome || 'Sistema'}</strong>
+                      <span className="text-[10px] text-muted-foreground">{new Date(c.created_at).toLocaleString('pt-BR')}</span>
+                    </div>
+                    <p className="mt-0.5 whitespace-pre-wrap">{c.mensagem}</p>
+                  </div>
+                ))}
+                {comentarios.length === 0 && <p className="text-xs text-muted-foreground">Sem comentários.</p>}
+              </div>
+              <div className="flex gap-2 mt-2">
+                <Input className="h-9 text-sm" placeholder="Escrever comentário..." value={novoComentario}
+                  onChange={(e) => setNovoComentario(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') enviarComentario(); }} />
+                <Button size="sm" className="h-9 shrink-0" onClick={enviarComentario} disabled={enviandoComentario || !novoComentario.trim()}>
+                  {enviandoComentario ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
+                </Button>
+              </div>
+            </div>
+
+            {/* Histórico */}
+            <div>
+              <button className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground" onClick={() => setShowHist(s => !s)}>
+                <History className="w-3.5 h-3.5" /> Histórico de alterações ({historico.length})
+              </button>
+              {showHist && (
+                <div className="mt-2 space-y-1 text-[11px] text-muted-foreground">
+                  {historico.map((h) => (
+                    <div key={h.id}>
+                      <span className="text-foreground">{h.autor_nome || 'Sistema'}</span> alterou <strong>{h.campo}</strong>
+                      {h.valor_anterior != null && <> de “{h.valor_anterior}”</>} para “{h.valor_novo}”
+                      <span className="ml-1">· {new Date(h.created_at).toLocaleString('pt-BR')}</span>
+                    </div>
+                  ))}
+                  {historico.length === 0 && <p>Sem alterações registradas.</p>}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/ferramentas/pedidos-pagamento/page.tsx
+++ b/frontend/src/app/ferramentas/pedidos-pagamento/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { usePageTitle } from '@/contexts/PageTitleContext';
+import { useBar } from '@/contexts/BarContext';
+import { ProtectedRoute } from '@/components/ProtectedRoute';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useToast } from '@/components/ui/toast';
+import { api } from '@/lib/api-client';
+import { Plus, Loader2, AlertCircle, Receipt } from 'lucide-react';
+import {
+  TIPO_LABEL, STATUS_LABEL, STATUS_COLOR, formatBRL, type Pedido,
+} from './types';
+import { NovoPedidoDialog } from './components/NovoPedidoDialog';
+import { PedidoDetailDialog } from './components/PedidoDetailDialog';
+
+type TabKey = 'aguardando' | 'andamento' | 'concluidos' | 'recusados' | 'todos';
+
+const TAB_STATUS: Record<TabKey, (s: string) => boolean> = {
+  aguardando: (s) => s === 'aguardando_aprovacao' || s === 'erro_ca' || s === 'erro_inter',
+  andamento: (s) => s === 'aprovado' || s === 'agendado',
+  concluidos: (s) => s === 'pago',
+  recusados: (s) => s === 'rejeitado' || s === 'cancelado',
+  todos: () => true,
+};
+
+export default function PedidosPagamentoPage() {
+  const { setPageTitle } = usePageTitle();
+  const { selectedBar } = useBar();
+  const { showToast } = useToast();
+  const barId = selectedBar?.id ?? null;
+
+  const [pedidos, setPedidos] = useState<Pedido[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [podeAprovar, setPodeAprovar] = useState(false);
+  const [tab, setTab] = useState<TabKey>('aguardando');
+  const [soMeus, setSoMeus] = useState(false);
+  const [novoOpen, setNovoOpen] = useState(false);
+  const [detalheId, setDetalheId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPageTitle('💸 Pedidos de Pagamento');
+    return () => setPageTitle('');
+  }, [setPageTitle]);
+
+  const carregar = useCallback(async () => {
+    if (!barId) return;
+    setLoading(true);
+    try {
+      const res = await api.get(`/api/financeiro/pedidos-pagamento?escopo=${soMeus ? 'meus' : 'todos'}`);
+      setPedidos(res.pedidos || []);
+      setPodeAprovar(!!res.pode_aprovar);
+    } catch (e: any) {
+      showToast({ type: 'error', title: 'Erro ao carregar', message: e?.message });
+    } finally {
+      setLoading(false);
+    }
+  }, [barId, soMeus, showToast]);
+
+  useEffect(() => { carregar(); }, [carregar]);
+
+  const filtrados = useMemo(() => pedidos.filter(p => TAB_STATUS[tab](p.status)), [pedidos, tab]);
+  const countAguardando = useMemo(() => pedidos.filter(p => TAB_STATUS.aguardando(p.status)).length, [pedidos]);
+
+  return (
+    <ProtectedRoute>
+      <div className="min-h-screen bg-background">
+        <div className="container mx-auto px-3 py-5 max-w-5xl">
+          {/* Header */}
+          <div className="flex items-center justify-between gap-3 mb-4">
+            <div>
+              <h1 className="text-xl font-bold flex items-center gap-2"><Receipt className="w-5 h-5" /> Pedidos de Pagamento</h1>
+              <p className="text-sm text-muted-foreground">
+                {podeAprovar
+                  ? 'Revise, comente e aprove. Aprovar cria a conta no Conta Azul e agenda o PIX no Inter.'
+                  : 'Abra um pedido de pagamento. O financeiro analisa e aprova.'}
+              </p>
+            </div>
+            <Button onClick={() => setNovoOpen(true)}><Plus className="w-4 h-4 mr-2" />Novo pedido</Button>
+          </div>
+
+          {!barId && (
+            <Card className="border-red-500/40">
+              <CardContent className="py-10 text-center">
+                <AlertCircle className="w-10 h-10 text-red-600 mx-auto mb-2" />
+                <p className="font-semibold">Nenhum bar selecionado</p>
+                <p className="text-sm text-muted-foreground">Selecione um bar no menu superior.</p>
+              </CardContent>
+            </Card>
+          )}
+
+          {barId && (
+            <>
+              <div className="flex items-center justify-between gap-2 mb-3 flex-wrap">
+                <Tabs value={tab} onValueChange={(v) => setTab(v as TabKey)}>
+                  <TabsList>
+                    <TabsTrigger value="aguardando">
+                      Aguardando {countAguardando > 0 && <Badge variant="secondary" className="ml-1.5">{countAguardando}</Badge>}
+                    </TabsTrigger>
+                    <TabsTrigger value="andamento">Em andamento</TabsTrigger>
+                    <TabsTrigger value="concluidos">Pagos</TabsTrigger>
+                    <TabsTrigger value="recusados">Recusados</TabsTrigger>
+                    <TabsTrigger value="todos">Todos</TabsTrigger>
+                  </TabsList>
+                </Tabs>
+                {podeAprovar && (
+                  <Button variant={soMeus ? 'default' : 'ghost'} size="sm" onClick={() => setSoMeus(s => !s)}>
+                    {soMeus ? 'Mostrando: meus' : 'Mostrando: todos'}
+                  </Button>
+                )}
+              </div>
+
+              {loading ? (
+                <div className="py-16 text-center"><Loader2 className="w-8 h-8 animate-spin mx-auto text-muted-foreground" /></div>
+              ) : filtrados.length === 0 ? (
+                <Card>
+                  <CardContent className="py-12 text-center text-muted-foreground">
+                    <Receipt className="w-10 h-10 mx-auto mb-2 opacity-40" />
+                    Nenhum pedido nesta aba.
+                  </CardContent>
+                </Card>
+              ) : (
+                <div className="space-y-2">
+                  {filtrados.map((p) => (
+                    <button
+                      key={p.id}
+                      onClick={() => setDetalheId(p.id)}
+                      className="w-full text-left rounded-lg border border-[hsl(var(--border))] bg-card hover:bg-muted/40 transition p-3 flex items-center gap-3"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium truncate">{p.descricao}</span>
+                          <Badge variant="outline" className="text-[10px] shrink-0">{TIPO_LABEL[p.tipo]}</Badge>
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-0.5 truncate">
+                          {p.solicitante_nome || '—'} · vence {p.data_vencimento}
+                          {p.beneficiario_nome ? ` · ${p.beneficiario_nome}` : ''}
+                        </div>
+                      </div>
+                      <div className="text-right shrink-0">
+                        <div className="font-semibold">{formatBRL(p.valor)}</div>
+                        <Badge className={`${STATUS_COLOR[p.status]} text-[10px] mt-0.5`}>{STATUS_LABEL[p.status]}</Badge>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <NovoPedidoDialog open={novoOpen} onOpenChange={setNovoOpen} onCriado={carregar} />
+        {barId && (
+          <PedidoDetailDialog
+            pedidoId={detalheId}
+            barId={barId}
+            onClose={() => setDetalheId(null)}
+            onChange={carregar}
+          />
+        )}
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/app/ferramentas/pedidos-pagamento/types.ts
+++ b/frontend/src/app/ferramentas/pedidos-pagamento/types.ts
@@ -1,0 +1,110 @@
+export type PedidoTipo = 'reembolso' | 'fornecedor' | 'avulso' | 'adiantamento';
+
+export type PedidoStatus =
+  | 'rascunho'
+  | 'aguardando_aprovacao'
+  | 'aprovado'
+  | 'agendado'
+  | 'pago'
+  | 'erro_ca'
+  | 'erro_inter'
+  | 'rejeitado'
+  | 'cancelado';
+
+export interface Pedido {
+  id: string;
+  numero?: string | null;
+  bar_id: number;
+  tipo: PedidoTipo;
+  status: PedidoStatus;
+  solicitante_id?: string | null;
+  solicitante_nome?: string | null;
+  descricao: string;
+  valor: number;
+  data_competencia?: string | null;
+  data_vencimento: string;
+  beneficiario_nome?: string | null;
+  chave_pix?: string | null;
+  tipo_chave?: string | null;
+  cpf_cnpj?: string | null;
+  observacao?: string | null;
+  categoria_id?: string | null;
+  categoria_nome?: string | null;
+  centro_custo_id?: string | null;
+  centro_custo_nome?: string | null;
+  contaazul_pessoa_id?: string | null;
+  conta_financeira_id?: string | null;
+  inter_credencial_id?: number | null;
+  contaazul_lancamento_id?: string | null;
+  inter_codigo_solicitacao?: string | null;
+  erro_mensagem?: string | null;
+  aprovado_por_nome?: string | null;
+  aprovado_em?: string | null;
+  rejeitado_por_nome?: string | null;
+  motivo_rejeicao?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Comentario {
+  id: string;
+  pedido_id: string;
+  autor_id?: string | null;
+  autor_nome?: string | null;
+  mensagem: string;
+  tipo: 'comentario' | 'sistema';
+  created_at: string;
+}
+
+export interface Anexo {
+  id: string;
+  pedido_id: string;
+  nome_original?: string | null;
+  tipo_arquivo?: string | null;
+  tamanho_bytes?: number | null;
+  url_publica?: string | null;
+  created_at: string;
+}
+
+export interface HistoricoItem {
+  id: string;
+  campo?: string | null;
+  valor_anterior?: string | null;
+  valor_novo?: string | null;
+  autor_nome?: string | null;
+  created_at: string;
+}
+
+export const TIPO_LABEL: Record<PedidoTipo, string> = {
+  reembolso: 'Reembolso',
+  fornecedor: 'Fornecedor',
+  avulso: 'Avulso',
+  adiantamento: 'Adiantamento/Vale',
+};
+
+export const STATUS_LABEL: Record<PedidoStatus, string> = {
+  rascunho: 'Rascunho',
+  aguardando_aprovacao: 'Aguardando aprovação',
+  aprovado: 'Aprovado',
+  agendado: 'Agendado',
+  pago: 'Pago',
+  erro_ca: 'Erro Conta Azul',
+  erro_inter: 'Erro Inter',
+  rejeitado: 'Rejeitado',
+  cancelado: 'Cancelado',
+};
+
+export const STATUS_COLOR: Record<PedidoStatus, string> = {
+  rascunho: 'bg-gray-500/15 text-gray-600',
+  aguardando_aprovacao: 'bg-amber-500/15 text-amber-600',
+  aprovado: 'bg-blue-500/15 text-blue-600',
+  agendado: 'bg-indigo-500/15 text-indigo-600',
+  pago: 'bg-green-500/15 text-green-600',
+  erro_ca: 'bg-red-500/15 text-red-600',
+  erro_inter: 'bg-red-500/15 text-red-600',
+  rejeitado: 'bg-red-500/15 text-red-600',
+  cancelado: 'bg-gray-500/15 text-gray-500',
+};
+
+export const formatBRL = (v: number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v || 0);

--- a/frontend/src/components/layouts/ModernSidebarOptimized.tsx
+++ b/frontend/src/components/layouts/ModernSidebarOptimized.tsx
@@ -176,6 +176,7 @@ const defaultSidebarItems: SidebarItem[] = [
     subItems: [
       { icon: Zap, label: 'Insights Estratégicos', href: '/ferramentas/insights', permission: 'gestao' },
       { icon: Calendar, label: 'Agendamento', href: '/ferramentas/agendamento', permission: 'financeiro_agendamento' },
+      { icon: Receipt, label: 'Pedidos de Pagamento', href: '/ferramentas/pedidos-pagamento', permission: 'home' },
       { icon: Tag, label: 'Classificação de Consumos', href: '/ferramentas/consumos-classificacao', permission: 'gestao' },
     ],
   },

--- a/frontend/src/lib/financeiro/pedidos-pagamento.ts
+++ b/frontend/src/lib/financeiro/pedidos-pagamento.ts
@@ -1,0 +1,135 @@
+/**
+ * Helpers compartilhados do módulo "Pedidos de Pagamento".
+ *
+ * Tabelas vivem no schema `financial` (já exposto no PostgREST, igual pix_enviados).
+ * Acesso sempre via service-role + .schema('financial').
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { AuthenticatedUser } from '@/middleware/auth';
+import { userHasModule } from '@/lib/permissions/resolver';
+
+export type PedidoTipo = 'reembolso' | 'fornecedor' | 'avulso' | 'adiantamento';
+
+export type PedidoStatus =
+  | 'rascunho'
+  | 'aguardando_aprovacao'
+  | 'aprovado'
+  | 'agendado'
+  | 'pago'
+  | 'erro_ca'
+  | 'erro_inter'
+  | 'rejeitado'
+  | 'cancelado';
+
+export const TIPOS_VALIDOS: PedidoTipo[] = ['reembolso', 'fornecedor', 'avulso', 'adiantamento'];
+
+/** Status em que o solicitante ainda pode editar/cancelar o próprio pedido. */
+export const STATUS_EDITAVEL_SOLICITANTE: PedidoStatus[] = ['rascunho', 'aguardando_aprovacao'];
+
+/** Status que permitem (re)processar a aprovação (novo ou retry após falha parcial). */
+export const STATUS_APROVAVEL: PedidoStatus[] = ['aguardando_aprovacao', 'erro_ca', 'erro_inter'];
+
+export interface PedidoPagamento {
+  id: string;
+  numero?: string | null;
+  bar_id: number;
+  tipo: PedidoTipo;
+  status: PedidoStatus;
+  solicitante_id?: string | null;
+  solicitante_nome?: string | null;
+  descricao: string;
+  valor: number;
+  data_competencia?: string | null;
+  data_vencimento: string;
+  beneficiario_nome?: string | null;
+  chave_pix?: string | null;
+  tipo_chave?: string | null;
+  cpf_cnpj?: string | null;
+  observacao?: string | null;
+  categoria_id?: string | null;
+  categoria_nome?: string | null;
+  centro_custo_id?: string | null;
+  centro_custo_nome?: string | null;
+  contaazul_pessoa_id?: string | null;
+  conta_financeira_id?: string | null;
+  inter_credencial_id?: number | null;
+  contaazul_lancamento_id?: string | null;
+  inter_codigo_solicitacao?: string | null;
+  erro_mensagem?: string | null;
+  aprovado_por_id?: string | null;
+  aprovado_por_nome?: string | null;
+  aprovado_em?: string | null;
+  rejeitado_por_id?: string | null;
+  rejeitado_por_nome?: string | null;
+  rejeitado_em?: string | null;
+  motivo_rejeicao?: string | null;
+  pago_em?: string | null;
+  criado_por?: string | null;
+  atualizado_por?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Cliente apontado pro schema financial. */
+export function fin(supabase: SupabaseClient) {
+  return supabase.schema('financial' as any) as any;
+}
+
+/**
+ * Pode aprovar/rejeitar/editar pedidos de outras pessoas?
+ * Financeiro/admin por role, ou quem tem o módulo financeiro/agendamento.
+ * Segue o resolver único (sem .includes cru em modulos_permitidos).
+ */
+export function podeAprovar(user: AuthenticatedUser): boolean {
+  if (user.role === 'admin' || user.role === 'financeiro') return true;
+  return userHasModule(user.modulos_permitidos, 'ferramentas_agendamento');
+}
+
+/** Registra uma linha de auditoria de mudança de campo/status. */
+export async function registrarHistorico(
+  supabase: SupabaseClient,
+  params: {
+    pedido_id: string;
+    bar_id: number;
+    autor: AuthenticatedUser;
+    campo: string;
+    valor_anterior?: unknown;
+    valor_novo?: unknown;
+  }
+): Promise<void> {
+  const toText = (v: unknown) =>
+    v === null || v === undefined ? null : typeof v === 'string' ? v : JSON.stringify(v);
+  await fin(supabase)
+    .from('pedidos_pagamento_historico')
+    .insert({
+      pedido_id: params.pedido_id,
+      bar_id: params.bar_id,
+      autor_id: params.autor.auth_id,
+      autor_nome: params.autor.nome,
+      campo: params.campo,
+      valor_anterior: toText(params.valor_anterior),
+      valor_novo: toText(params.valor_novo),
+    });
+}
+
+/** Comentário automático do sistema (transições importantes na thread). */
+export async function comentarioSistema(
+  supabase: SupabaseClient,
+  params: { pedido_id: string; bar_id: number; mensagem: string }
+): Promise<void> {
+  await fin(supabase)
+    .from('pedidos_pagamento_comentarios')
+    .insert({
+      pedido_id: params.pedido_id,
+      bar_id: params.bar_id,
+      autor_id: null,
+      autor_nome: 'Sistema',
+      mensagem: params.mensagem,
+      tipo: 'sistema',
+    });
+}
+
+/** Formata valor numérico em BRL pra mensagens. */
+export function formatBRL(valor: number): string {
+  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(valor || 0);
+}

--- a/frontend/src/lib/menu-config.ts
+++ b/frontend/src/lib/menu-config.ts
@@ -52,6 +52,7 @@ export const MENU_LATERAL_STRUCTURE: MenuSectionConfig[] = [
     subItems: [
       { label: 'CRM', href: '/ferramentas/crm' },
       { label: 'Agendamento', href: '/ferramentas/agendamento' },
+      { label: 'Pedidos de Pagamento', href: '/ferramentas/pedidos-pagamento' },
       { label: 'NPS Funcionários', href: '/ferramentas/nps' },
       { label: 'CMV Semanal', href: '/ferramentas/cmv-semanal' },
       { label: 'CMA - Alimentação', href: '/ferramentas/cma-semanal' },


### PR DESCRIPTION
## O que é

Substitui o grupo de WhatsApp "Pagamentos" por um módulo no Zykor: qualquer funcionário abre um **pedido de pagamento** (reembolso, fornecedor, avulso, adiantamento) com valor, PIX, competência, vencimento e anexo (imagem/PDF). O financeiro (David) revisa, comenta, ajusta e aprova; ao **aprovar**, o sistema cria a conta a pagar no **Conta Azul** e agenda o **PIX no Inter** (o sócio dá o OK final no app do Inter).

É uma camada de pedido + aprovação **na frente do motor CA+Inter que já existe** (agendamento-v2). Reusa os endpoints `contaazul/lancamentos` e `inter/pix` via self-fetch, **sem refatorá-los** (sem regressão no agendamento).

## O que entra

- **DB** (`database/migrations/2026-06-01-pedidos-pagamento.sql`, já aplicada): 4 tabelas em `financial` (pedido + comentários + anexos + histórico), índices por `bar_id`/status, trigger `updated_at`, grants + `NOTIFY pgrst`.
- **API** `/api/financeiro/pedidos-pagamento`: listar/criar, detalhe/editar (PUT, com histórico), comentários, anexos (aceita PDF), **aprovar** (idempotente), rejeitar, cancelar.
- **Front** `/ferramentas/pedidos-pagamento`: lista por abas, dialog de novo pedido por tipo, dialog de detalhe com edição inline, painel de aprovação (categoria/centro/conta/Inter + cadastro rápido de fornecedor no CA), rejeição, thread de comentários e histórico.
- **Menu**: item em Ferramentas (sidebar + menu-config), visível a qualquer funcionário logado.

## Regras respeitadas

- Multi-tenant: tudo filtrado por `bar_id`.
- Aprovação restrita ao financeiro no servidor (resolver único `userHasModule`, sem `.includes` cru).
- Credenciais bancárias continuam via envelope encryption (não tocado).

## Validação

- `type-check` e `lint` limpos.
- Round-trip da camada de dados testado (insert → trigger → cascade delete).
- API responde 401 sem auth; página renderiza 200.

## Atenção ao testar

O **"Aprovar" dispara CA + PIX reais**. Testar com valor mínimo.

## Fase 2 (futuro)

Notificação Discord ao financeiro em pedido novo, `pago` automático via webhook Inter, número sequencial (PD-2026-xxxx), extração das libs CA/Inter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)