### PR TITLE
perf(build): usa Turbopack no next build (compile 43s->10s)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,9 +5,9 @@
     "private": true,
     "scripts": {
         "dev": "next dev --port 3001",
-        "build": "next build",
+        "build": "next build --turbopack",
         "build:analyze": "NEXT_PUBLIC_ANALYZE_BUNDLE=true next build",
-        "build:production": "NODE_ENV=production next build && next-sitemap",
+        "build:production": "NODE_ENV=production next build --turbopack && next-sitemap",
         "start": "next start",
         "start:production": "NODE_ENV=production next start -p 3000",
         "type-check": "tsc --noEmit",


### PR DESCRIPTION
## O que
Troca `next build` por `next build --turbopack` no script de build.

## Por quê
O build da Vercel (Enhanced 8-core, já no topo) gastava **43s** só no compile do webpack. Build local com Turbopack: **10,2s** (~4x), limpo, mesmas paginas, so os warnings de <img> ja existentes.

## Impacto esperado
- Compile: 43s -> ~10s
- next build: ~125s -> ~90s
- Deploy total: ~3 min -> ~2 min

## Notas
- Lint + typecheck seguem no build (gate preservado).
- build:analyze mantido no webpack (bundle analyzer exige webpack).
- Proximo lever (separado): mover lint+typecheck pra CI tira mais ~52s.

Generated with Claude Code